### PR TITLE
Set name in `config/application.rb` via initial setup

### DIFF
--- a/bin/configure
+++ b/bin/configure
@@ -123,6 +123,7 @@ kebab_case = variable.tr("_", "-")
 puts ""
 puts green "Replacing instances of \"Untitled Application\" with \"#{human}\" throughout the codebase."
 replace_in_file("./.circleci/config.yml", "untitled_application", variable)
+replace_in_file("./config/application.rb", "untitled_application", variable)
 replace_in_file("./config/database.yml", "untitled_application", variable)
 replace_in_file("./config/database.yml", "UNTITLED_APPLICATION", environment_variable)
 replace_in_file("./config/cable.yml", "untitled_application", variable)

--- a/bin/configure
+++ b/bin/configure
@@ -119,11 +119,12 @@ variable = ActiveSupport::Inflector.parameterize(human, separator: '_')
 environment_variable = ActiveSupport::Inflector.parameterize(human, separator: '_').upcase
 class_name = variable.classify
 kebab_case = variable.tr("_", "-")
+connected_name = variable.gsub("_", "") # i.e. `bullettrain` as opposed to `bullet_train`
 
 puts ""
 puts green "Replacing instances of \"Untitled Application\" with \"#{human}\" throughout the codebase."
 replace_in_file("./.circleci/config.yml", "untitled_application", variable)
-replace_in_file("./config/application.rb", "untitled_application", variable)
+replace_in_file("./config/application.rb", "untitled_application", connected_name)
 replace_in_file("./config/database.yml", "untitled_application", variable)
 replace_in_file("./config/database.yml", "UNTITLED_APPLICATION", environment_variable)
 replace_in_file("./config/cable.yml", "untitled_application", variable)

--- a/config/application.rb
+++ b/config/application.rb
@@ -25,7 +25,7 @@ module UntitledApplication
     config.i18n.default_locale = config.i18n.available_locales.first
 
     # This actually doesn't appear to work.
-    # TODO We should update `bullettrain` here during `bin/set-name` and then make the at-mentions stuff configurable.
-    config.action_view.sanitized_allowed_protocols = ["http", "bullettrain"]
+    # TODO We should make the at-mentions stuff configurable.
+    config.action_view.sanitized_allowed_protocols = ["http", "untitled_application"]
   end
 end


### PR DESCRIPTION
・Addresses the TODO in `config/application.rb`

### Details
I went with the naming convention already used in `bin/configure` and changed `bullettrain` to `untitled_application`.

As a side note, I have also addressed `sanitized_allowed_protocols` [here](https://github.com/bullet-train-co/bullet-train-tailwind-css/pull/580) in the second part of the details.