### PR TITLE
Open link in `bin/configure` depending on OS

### DIFF
--- a/bin/configure
+++ b/bin/configure
@@ -86,7 +86,12 @@ if `git remote | grep origin`.strip.length > 0
   puts yellow "Repository already has a \`origin`\ remote."
 else
   ask "Hit <Return> and we'll open a browser to GitHub where you can create a new repository. When you're done, copy the SSH path from the new repository and return here. We'll ask you to paste it to us in the next step."
-  `open https://github.com/new`
+  command = if Gem::Platform.local.os == "linux"
+    "xdg-open"
+  else
+    "open"
+  end
+  `#{command} https://github.com/new`
 
   ssh_path = ask "OK, what was the SSH path? (It should look like `git@github.com:your-account/your-new-repo.git`.)"
   puts green "Setting repository's `origin` remote to `#{ssh_path}`."


### PR DESCRIPTION
Developers running on Linux will get an error when the script tries to open `https://github.com/new` causing the script to stop.

I'm not sure if there's already a gem out there like this, but I just made a small one to take care of this in case we want to use it in the future since I've run into some OS terminal differences in the past:
[Terminal Commands](https://github.com/gazayas/terminal_commands)

All we'd have to do is write the following after adding it to the Gemfile:
```Ruby
require `terminal_commands`

TerminalCommands.open_file_or_link("https://github.com/new")
```
