### PR TITLE
Change README example filename in bin/configure

### DIFF
--- a/bin/configure
+++ b/bin/configure
@@ -139,8 +139,8 @@ replace_in_file("./config/locales/en/application.en.yml", "untitled application"
 replace_in_file("./config/locales/en/user_mailer.en.yml", "Untitled Application", human)
 puts ""
 
-puts green "Moving `./README.md.example` to `./README.md`."
-puts `mv ./README.md.example ./README.md`.chomp
+puts green "Moving `./README.example.md` to `./README.md`."
+puts `mv ./README.example.md ./README.md`.chomp
 
 # We can only do this after the README is moved into place.
 replace_in_file("./README.md", "Untitled Application", human)


### PR DESCRIPTION
With clean copy of repository `bin/configure` shows an `mv` error caused by invalid filename. 

```
[...]

Moving `./README.md.example` to `./README.md`.
mv: cannot stat './README.md.example': No such file or directory

[...]
```

Issue is caused by name typo as the file is named `README.example.md`, not `README.md.example`.

resolves #11 