### PR TITLE
Install foreman in `bin/setup`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,9 +67,6 @@ group :development do
 
   # Speed up commands on slow machines / big apps [https://github.com/rails/spring]
   # gem "spring"
-
-  # TODO Not sure why we need to add this when it's not in the Gemfile of a new Rails application.
-  gem "foreman"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -285,7 +285,6 @@ GEM
     fastimage (2.2.6)
     figaro (1.2.0)
       thor (>= 0.14.0, < 2)
-    foreman (0.87.2)
     globalid (1.0.0)
       activesupport (>= 5.0)
     grape (1.6.2)
@@ -625,7 +624,6 @@ DEPENDENCIES
   debug
   devise
   factory_bot_rails
-  foreman
   honeybadger
   jbuilder
   jsbundling-rails

--- a/bin/setup
+++ b/bin/setup
@@ -37,6 +37,9 @@ FileUtils.chdir APP_ROOT do
     system! "cp config/application.yml.example config/application.yml"
   end
 
+  puts "\n== Installing foreman =="
+  system! "gem install foreman"
+
   puts "\n== Restarting application server =="
   system! "bin/rails restart"
 end


### PR DESCRIPTION
・Addresses TODO in Gemfile

### Details
Rails installs foreman manually when installing esbuild.
There are some commands that are run in the main Rails repo, but since esbuild is optional, the logic for installing foreman was actually in [jsbundling-rails](https://github.com/rails/jsbundling-rails/blob/b6ec0980ff573203ac1031074e57bc59be5acbf5/lib/install/install.rb#L34):
```ruby
if Rails.root.join("Procfile.dev").exist?
  append_to_file "Procfile.dev", "js: yarn build --watch\n"
else
  say "Add default Procfile.dev"
  copy_file "#{__dir__}/Procfile.dev", "Procfile.dev"

  say "Ensure foreman is installed"
  run "gem install foreman"
end
```

Bullet Train already ships with `Procfile.dev` configured with everything we need, so I just added the installation command in `bin/setup`, since it's basically the same thing `js-bundling` is doing.