### PR TITLE
Remove `Timecop` dependecy

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -119,9 +119,6 @@ group :development do
 end
 
 group :test do
-  # Make it easier to test things related to time.
-  gem "timecop"
-
   # Helps smooth over flakiness in system tests.
   gem "minitest-retry"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -567,7 +567,6 @@ GEM
     strscan (3.0.1)
     thor (1.2.1)
     thread-local (1.1.0)
-    timecop (0.9.5)
     timeout (0.2.0)
     turbo-rails (1.0.1)
       actionpack (>= 6.0.0)
@@ -648,7 +647,6 @@ DEPENDENCIES
   sprockets-rails
   standard
   stimulus-rails
-  timecop
   turbo-rails
   tzinfo-data
   web-console

--- a/test/system/dates_helper_test.rb
+++ b/test/system/dates_helper_test.rb
@@ -36,18 +36,16 @@ class DatesHelperTest < ApplicationSystemTestCase
       assert page.has_text? "Today at #{time.strftime("%l:%M %p").strip}"
 
       # Assert yesterday's date is displayed correctly.
-      Timecop.travel(time + 1.day)
+      travel_to time + 1.day
       visit current_url # Refresh the page
       assert page.has_text? "Yesterday at #{(time).strftime("%l:%M %p").strip}"
 
       # Assert the month and day is shown for anything before then.
-      Timecop.travel(time + 2.days)
+      travel_to time + 2.days
       visit current_url
       assert page.has_text? "#{time.strftime("%B %-d").strip} at #{time.strftime("%l:%M %p").strip}"
 
       # TODO: Write test for a user with a different time zone
-
-      Timecop.return
     end
   end
 end


### PR DESCRIPTION
Rails ships with [TimeHelpers](https://api.rubyonrails.org/classes/ActiveSupport/Testing/TimeHelpers.html),
so I'm not sure that additional dependecy is necessary.

This commit removes `timecop` gem and uses rails time helpers for time
traveling.