### PR TITLE
Fixes typo in Stimulus controllers/index

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -19,7 +19,7 @@ application.register('reveal', RevealController)
 
 const controllers = Object.keys(controllersContext).map((filename) => ({
   identifier: identifierForContextKey(filename),
-  controllerConstructor: context[filename] }))
+  controllerConstructor: controllersContext[filename] }))
 
 application.load(controllers)
 


### PR DESCRIPTION
In controllers/index, context is called when it should be controllersContext.

This causes an error when using Stimulus. 