### PR TITLE
Fixes typo in controllers/index from context to controllersContext (#51)

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -19,7 +19,7 @@ application.register('reveal', RevealController)
 
 const controllers = Object.keys(controllersContext).map((filename) => ({
   identifier: identifierForContextKey(filename),
-  controllerConstructor: context[filename] }))
+  controllerConstructor: controllersContext[filename] }))
 
 application.load(controllers)
 


### PR DESCRIPTION
Doing this to force CI run for https://github.com/bullet-train-co/bullet_train/pull/51 . 