### PR TITLE
Added missing loader for woff2.

### DIFF
--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -64,6 +64,7 @@ require("esbuild").build({
     ".jpg": "file",
     ".svg": "file",
     ".woff": "file",
+    ".woff2": "file",
     ".ttf": "file",
     ".eot": "file",
   },


### PR DESCRIPTION
This is needed after installing FontAwesome Pro. Otherwise the esbuild fails.

See the following screenshot for the encountered error:
![image](https://user-images.githubusercontent.com/6199/163700692-8e2a7b55-0024-41dd-b9dc-6dbc416cc32d.png)
