### PR TITLE
Address test deprecations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,7 +71,7 @@ end
 
 group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
-  gem "capybara"
+  gem "capybara", github: "teamcapybara/capybara"
   gem "selenium-webdriver"
   gem "webdrivers"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,6 +13,20 @@ GIT
       doorkeeper (>= 1.4, < 6.0)
       grape (>= 0.10)
 
+GIT
+  remote: https://github.com/teamcapybara/capybara.git
+  revision: d05ae5c595bb60237629f710ae33cb63ed4a7790
+  specs:
+    capybara (3.36.0)
+      addressable
+      matrix
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (>= 1.5, < 3.0)
+      xpath (~> 3.2)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -203,15 +217,6 @@ GEM
       railties (>= 5.2)
       thread-local (>= 1.1.0)
     cancancan (3.3.0)
-    capybara (3.36.0)
-      addressable
-      matrix
-      mini_mime (>= 0.1.3)
-      nokogiri (~> 1.8)
-      rack (>= 1.6.0)
-      rack-test (>= 0.6.3)
-      regexp_parser (>= 1.5, < 3.0)
-      xpath (~> 3.2)
     capybara-email (3.0.2)
       capybara (>= 2.4, < 4.0)
       mail
@@ -619,7 +624,7 @@ DEPENDENCIES
   bullet_train-sortable
   bullet_train-super_scaffolding
   bullet_train-themes-light
-  capybara
+  capybara!
   capybara-email
   cssbundling-rails
   debug

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,9 +24,5 @@ module UntitledApplication
     config.i18n.load_path += Dir[Rails.root.join("config", "locales", "**", "*.{rb,yml}")]
     config.i18n.available_locales = YAML.safe_load(File.read("config/locales/locales.yml"), aliases: true).with_indifferent_access.dig(:locales).keys.map(&:to_sym)
     config.i18n.default_locale = config.i18n.available_locales.first
-
-    # This actually doesn't appear to work.
-    # TODO We should make the at-mentions stuff configurable.
-    config.action_view.sanitized_allowed_protocols = ["http", "untitled_application"]
   end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -73,9 +73,6 @@ Rails.application.configure do
   config.action_mailer.default_url_options = {host: "localhost", port: 3001}
   config.i18n.raise_on_missing_translations = true
 
-  # TODO There are too many deprecation warnings after upgrading to Rails 6.
-  config.active_support.deprecation = :silence
-
   # TODO for some reason this doesn't seem to be doing anything.
   config.active_job.queue_adapter = :inline
 

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -141,13 +141,13 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
 
   # https://stackoverflow.com/a/50794401/2414273
   def assert_no_js_errors
-    last_timestamp = page.driver.browser.manage.logs.get(:browser)
+    last_timestamp = page.driver.browser.logs.get(:browser)
       .map(&:timestamp)
       .last || 0
 
     yield
 
-    errors = page.driver.browser.manage.logs.get(:browser)
+    errors = page.driver.browser.logs.get(:browser)
     errors = errors.reject { |e| e.timestamp > last_timestamp } if last_timestamp > 0
     errors = errors.reject { |e| e.level == "WARNING" }
 


### PR DESCRIPTION
Carry over from [this PR](https://github.com/bullet-train-co/bullet-train-tailwind-css/pull/580) in the tailwind repo.