### PR TITLE
Fix the `NoMethodError` caused by `current_email.click_link` 

### DIFF
--- a/test/system/webhooks_system_test.rb
+++ b/test/system/webhooks_system_test.rb
@@ -1,12 +1,10 @@
 require "application_system_test_case"
-require "sidekiq/testing"
 
 class WebhooksSystemTest < ApplicationSystemTestCase
   def setup
     super
     @user = create :onboarded_user, first_name: "Andrew", last_name: "Culver"
     @another_user = create :onboarded_user, first_name: "John", last_name: "Smith"
-    switch_adapter_to_sidekiq
   end
 
   unless scaffolding_things_disabled?
@@ -57,7 +55,7 @@ class WebhooksSystemTest < ApplicationSystemTestCase
           fill_in "Text Field Value", with: "Some Other Thing"
           click_on "Create Tangible Thing"
           assert page.has_content? "Tangible Thing was successfully created"
-          Sidekiq::Testing.inline! { Webhooks::Outgoing::Delivery.order(:id).last.deliver }
+          Webhooks::Outgoing::Delivery.order(:id).last.deliver
         end
 
         assert_difference "Webhooks::Outgoing::Delivery.count", 1, "an outbound webhook should be issued" do
@@ -75,7 +73,7 @@ class WebhooksSystemTest < ApplicationSystemTestCase
           fill_in "Text Field Value", with: "One Last Updated Thing"
           click_on "Update Tangible Thing"
           assert page.has_content? "Tangible Thing was successfully updated"
-          Sidekiq::Testing.inline! { Webhooks::Outgoing::Delivery.order(:id).last.deliver }
+          Webhooks::Outgoing::Delivery.order(:id).last.deliver
         end
 
         click_on "Back"
@@ -86,7 +84,7 @@ class WebhooksSystemTest < ApplicationSystemTestCase
           end
           page.driver.browser.switch_to.alert.accept
           assert page.has_content?("Tangible Thing was successfully destroyed.")
-          Sidekiq::Testing.inline! { Webhooks::Outgoing::Delivery.order(:id).last.deliver }
+          Webhooks::Outgoing::Delivery.order(:id).last.deliver
         end
 
         sign_out_for(display_details)
@@ -146,7 +144,7 @@ class WebhooksSystemTest < ApplicationSystemTestCase
             page.driver.browser.switch_to.alert.accept
             assert page.has_content?("Tangible Thing was successfully destroyed.")
           end
-          Sidekiq::Testing.inline! { Webhooks::Outgoing::Delivery.order(:id).last.deliver }
+          Webhooks::Outgoing::Delivery.order(:id).last.deliver
         end
       end
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,6 +11,9 @@ require "knapsack_pro"
 knapsack_pro_adapter = KnapsackPro::Adapters::MinitestAdapter.bind
 knapsack_pro_adapter.set_test_helper_path(__FILE__)
 
+require "sidekiq/testing"
+Sidekiq::Testing.inline!
+
 ActiveSupport::TestCase.class_eval do
   # Run tests in parallel with specified workers
   # parallelize(workers: :number_of_processors)
@@ -18,13 +21,4 @@ ActiveSupport::TestCase.class_eval do
   fixtures :all
 
   # Add more helper methods to be used by all tests here...
-end
-
-# TODO: The test adapter gets overwritten when a test class inherits SystemTestCase,
-# so this is hack to get inline sidekiq jobs running.
-# https://github.com/rails/rails/issues/37270
-# https://edgeapi.rubyonrails.org/classes/ActionDispatch/SystemTestCase.html
-def switch_adapter_to_sidekiq
-  (ActiveJob::Base.descendants << ActiveJob::Base).each { |a| a.disable_test_adapter }
-  ActiveJob::Base.queue_adapter = :sidekiq
 end


### PR DESCRIPTION
・Fixes the `NoMethodError` caused by `current_email.click_link` 

### Details
This inherently had to do with a Rails issue which I talked about [here](https://github.com/bullet-train-co/bullet-train/pull/441) a while back. I also mention the problem with `current_email` [here](https://github.com/bullet-train-co/bullet-train-tailwind-css/issues/562).

I wrestled with this for a while and ultimately came up with this solution. I’m not sure if Rails has simply made an update to fix the issue (there’s nothing mentioned in the issue itself about an official fix), but using `Sidekiq::inline!` in `test/test_helper.rb` consistently made the Invitation system test pass.

This caused the webhooks system test to fail though. It was the only system test that used the fix proposed in the Rails issue which we implemented in the test helper, but this system test also passed consistently for me after making the new additions here, so I think we should be good for the time being.
