### PR TITLE
Limit access to internal connections only in Render Redis instance

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -7,10 +7,7 @@ databases:
 services:
   - type: redis
     name: redis
-    # TODO Do we actually want this? Let's check with support@render.com.
-    ipAllowList:
-      - source: 0.0.0.0
-        description: everywhere
+    ipAllowList: []
     plan: starter
     maxmemoryPolicy: noeviction
   - type: web


### PR DESCRIPTION
・Address the TODO in `render.yaml`

[Here are the docs](https://render.com/docs/blueprint-spec#access-control) that specifically talk about this.
Since setting this to `everywhere` could potentially be a security issue, setting this value to `[]` allows only internal connections to access the Redis instance.
