### PR TITLE
Use the free version of Rails Autoscale

### DIFF
--- a/app.json
+++ b/app.json
@@ -25,7 +25,7 @@
     "hdrive:starter-s3",
     "cloudinary:starter",
     "scheduler:standard",
-    "rails-autoscale:bronze-std",
+    "rails-autoscale:free",
     "honeybadger:free",
     "sentry:f1",
     "realemail:free"


### PR DESCRIPTION
When deploying to Heroku for the first time, there's no need to start with a paid Rails Autoscale plan. The free plan supports 20 autoscale events per month at any scale, and will prompt if there is a need to upgrade.