### PR TITLE
Prepare for using `yalc link` instead of using `yarn link` for local npm packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,8 @@
 /yarn-error.log
 yarn-debug.log*
 .yarn-integrity
+.yalc
+yalc.lock
 
 # 🚅 this is bullet train's list of files to ignore.
 # please add yours at the end of the file.


### PR DESCRIPTION
- gitignore `.yalc` and `yalc.lock`
- everything else is handled by `bin/develop`. See https://github.com/bullet-train-co/bullet_train-base/pull/37