### PR TITLE
Silence esbuild warnings

### DIFF
--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -72,4 +72,6 @@ require("esbuild").build({
   plugins: [
     ImportGlobPlugin()
   ],
+  // TODO: Silencing warnings until the charset warning is fixed.
+  logLevel: 'error',
 }).catch(() => process.exit(1));


### PR DESCRIPTION
Addresses [this issue](https://github.com/bullet-train-co/bullet_train-themes-light/issues/7) in the `bullet_train-themes-light` repository.

### Details
This unfortunately is a problem other people are having that hasn't seemingly been solved yet. I'm not entirely sure what's going on here, and I don't think these answers are ideal, but angular-cli for example just decided to silence the warning ([Pull Request here](https://github.com/angular/angular-cli/pull/22098)), and [this issue](https://github.com/vitejs/vite/issues/6333) in vitejs just shows people silencing the warning (and also showing concern for not addressing the root cause).

I guess it's just a matter of wanting to keep the warning present until it gets fixed by a third-party library, or to just silence the warnings like I have proposed here until then. By the way in esbuild, it seems you can't silence specific warnings (check out [Dynamic import(): how to ignore an import that’s passed a variable?](https://github.com/evanw/esbuild/issues/574) and [suppressing specific warnings](https://github.com/evanw/esbuild/issues/395) for reference).

[Docs](https://esbuild.github.io/api/#log-level) for esbuild log levels.