### PR TITLE
Update the CircleCI `db/schema.rb` check to output the diff on fail

### DIFF
--- a/.circleci/db_schema_check
+++ b/.circleci/db_schema_check
@@ -7,5 +7,9 @@ echo $GIT_STATUS
 if [[ $GIT_STATUS =~ "nothing to commit, working tree clean" ]]; then
   exit 0
 else
+  echo ""
+  echo "rails db:migrate made a change to your database's schema."
+  echo "Please make sure your database is updated locally before pushing to CircleCI:"
+  git diff db/schema.rb
   exit 1
 fi


### PR DESCRIPTION
This is the fix by itself for outputting `db/schema.rb`'s git diff.