### PR TITLE
WIP: Add missing @hotwired/stimulus, @hotwired/stimulus-webpack-helpers

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -1,5 +1,5 @@
-import { Application } from "stimulus"
-import { identifierForContextKey } from "stimulus/webpack-helpers"
+import { Application } from "@hotwired/stimulus"
+import { identifierForContextKey } from "@hotwired/stimulus-webpack-helpers"
 import { controllerDefinitions as bulletTrainControllers } from "@bullet-train/bullet-train"
 import { controllerDefinitions as bulletTrainFieldControllers } from "@bullet-train/fields"
 import RevealController from 'stimulus-reveal'

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "@bullet-train/fields": "^1.0.15",
     "@esbuild-plugins/node-globals-polyfill": "^0.1.1",
     "@fullhuman/postcss-purgecss": "4.1.3",
+    "@hotwired/stimulus": "^3.0.1",
+    "@hotwired/stimulus-webpack-helpers": "^1.0.1",
     "@hotwired/turbo-rails": "^7.1.3",
     "@icon/themify-icons": "^1.0.1-alpha.3",
     "@rails/actioncable": "^7.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -48,7 +48,7 @@
   dependencies:
     purgecss "^4.1.3"
 
-"@hotwired/stimulus-webpack-helpers@^1.0.0":
+"@hotwired/stimulus-webpack-helpers@^1.0.0", "@hotwired/stimulus-webpack-helpers@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@hotwired/stimulus-webpack-helpers/-/stimulus-webpack-helpers-1.0.1.tgz#4cd74487adeca576c9865ac2b9fe5cb20cef16dd"
   integrity sha512-wa/zupVG0eWxRYJjC1IiPBdt3Lruv0RqGN+/DTMmUWUyMAEB27KXmVY6a8YpUVTM7QwVuaLNGW4EqDgrS2upXQ==


### PR DESCRIPTION
Closes #149

Remaining issue:

If we update the starter repo to use `@hotwired/stimulus*`, but reference older versions of the npm packages that use the older `stimulus:^2.0`, we'll get this error in the browser console and tests won't pass.

<img width="877" alt="CleanShot 2022-05-13 at 17 42 57@2x" src="https://user-images.githubusercontent.com/104179/168393278-4f74e02c-6a09-43be-9bd3-fed3e5068401.png">

