### PR TITLE
Switch system tests to Cuprite

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,6 +93,7 @@ jobs:
     parallelism: 16
     steps:
       - browser-tools/install-chrome
+      - browser-tools/install-chromedriver
       - checkout
       - restore_cache: *restore_bundler_cache
       - restore_cache: *restore_yarn_cache
@@ -139,6 +140,7 @@ jobs:
     parallelism: 7
     steps:
       - browser-tools/install-chrome
+      - browser-tools/install-chromedriver
       - checkout
 
       # Restore dependency caches
@@ -162,6 +164,47 @@ jobs:
           name: 'Run Super Scaffolding Test'
           command: bundle exec rails test test/system/super_scaffolding_test.rb
 
+  'System Tests with Cuprite':
+    docker:
+      - <<: *ruby_node_browsers_docker_image
+      - <<: *postgres_docker_image
+      - image: circleci/redis
+    executor: ruby/default
+    parallelism: 16
+    steps:
+      - browser-tools/install-chrome
+      - browser-tools/install-chromedriver
+      - checkout
+      - restore_cache: *restore_bundler_cache
+      - restore_cache: *restore_yarn_cache
+
+      # Install dependencies
+      - ruby/bundle-install
+      - run: bin/link
+      - run: yarn install
+      - run: yarn build
+      - run: yarn build:css
+
+      - *wait_for_docker
+
+      - run:
+          name: Run system tests with cuprite as system test driver
+          command: |
+            if test $BT_CORE_CI
+            then
+              echo "Running system tests with Cuprite"
+              sed -i'.orig' 's/# gem "cuprite"/gem "cuprite"/' Gemfile
+              sed -i'.orig' 's/gem "selenium-webdriver"/# gem "selenium-webdriver"/' Gemfile
+              sed -i'.orig' 's/gem "webdrivers"/# gem "webdrivers"/' Gemfile
+              bundle install
+              bundle exec rails test:system
+            else
+              echo "Skipping system tests with Cuprite"
+              exit 0
+            fi
+          environment:
+            RAILS_ENV: test
+
 workflows:
   version: 2
   build:
@@ -170,3 +213,4 @@ workflows:
       - 'Database Schema Check'
       - 'Minitest'
       - 'Minitest for Super Scaffolding'
+      - 'System Tests with Cuprite'

--- a/Gemfile
+++ b/Gemfile
@@ -72,8 +72,6 @@ end
 group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem "capybara", github: "teamcapybara/capybara"
-  gem "selenium-webdriver"
-  gem "webdrivers"
 end
 
 # BULLET TRAIN GEMS
@@ -152,6 +150,16 @@ group :production do
 
   # Use S3 for Active Storage by default.
   gem "aws-sdk-s3", require: false
+
+  # Selenium is the default default Capybara driver for system tests that ships with
+  # Rails. Cuprite is an alternative driver that uses Chrome's native DevTools protocol
+  # and offers improved speed and reliability. You can switch to Cuprite by commenting out
+  # `commenting out `gem "selenium-webdriver"` and `gem webdrivers` and uncommenting
+  # `gem cuprite` and Bullet Train will automatically load the correct configuration.
+  gem "selenium-webdriver"
+  gem "webdrivers"
+
+  # gem "cuprite"
 end
 
 # TODO Have to specify this dependency here until our changes are in the original package.

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -4,12 +4,30 @@ require "support/waiting"
 require "minitest/retry"
 
 Minitest::Retry.use!(retry_count: 3, verbose: true, exceptions_to_retry: [Net::ReadTimeout])
-
 OmniAuth.config.test_mode = true
 
+# Configure Capybara with either cuprite or selenium based on what gems are installed
+if Bundler.locked_gems.dependencies.has_key? "cuprite"
+  require "capybara/cuprite"
+  require "support/ferrum_console_logger"
+
+  Capybara.register_driver(:bt_cuprite) do |app|
+    Capybara::Cuprite::Driver.new(
+      app,
+      logger: FerrumConsoleLogger.new,
+      window_size: [1400, 1400],
+      process_timeout: 10,
+      inspector: true,
+      headless: !ENV["HEADLESS"].in?(%w[n 0 no false]) && !ENV["MAGIC_TEST"].in?(%w[y 1 yes true]),
+    )
+  end
+  Capybara.default_driver = Capybara.javascript_driver = :bt_cuprite
+else # Selenium
+  Capybara.javascript_driver = ENV["MAGIC_TEST"].present? ? :selenium_chrome : :selenium_chrome_headless
+  Capybara.default_driver = ENV["MAGIC_TEST"].present? ? :selenium_chrome : :selenium_chrome_headless
+end
+
 Capybara.default_max_wait_time = ENV.fetch("CAPYBARA_DEFAULT_MAX_WAIT_TIME", ENV["MAGIC_TEST"].present? ? 5 : 15)
-Capybara.javascript_driver = ENV["MAGIC_TEST"].present? ? :selenium_chrome : :selenium_chrome_headless
-Capybara.default_driver = ENV["MAGIC_TEST"].present? ? :selenium_chrome : :selenium_chrome_headless
 
 Capybara.register_server :puma do |app, port, host|
   require "rack/handler/puma"
@@ -22,7 +40,16 @@ Capybara.server_port = 3001
 Capybara.app_host = "http://localhost:3001"
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
-  driven_by :selenium, using: :chrome, screen_size: [1400, 1400]
+  def self.use_cuprite?
+    Bundler.locked_gems.dependencies.has_key? "cuprite"
+  end
+  delegate :use_cuprite?, to: :class
+
+  if use_cuprite?
+    driven_by :bt_cuprite
+  else
+    driven_by :selenium, using: :chrome, screen_size: [1400, 1400]
+  end
   include ActiveJob::TestHelper
   include MagicTest::Support
   include Capybara::DSL
@@ -69,7 +96,11 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   end
 
   def resize_for(display_details)
-    page.driver.browser.manage.window.resize_to(*calculate_resolution(display_details))
+    if use_cuprite?
+      page.driver.resize(*calculate_resolution(display_details))
+    else
+      page.driver.browser.manage.window.resize_to(*calculate_resolution(display_details))
+    end
   end
 
   def within_team_menu_for(display_details)
@@ -137,6 +168,21 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   end
 
   def select2_select(label, string)
+    if use_cuprite?
+      select2_select_cuprite(label, string)
+    else
+      select2_select_selenium(label, string)
+    end
+  end
+
+  private def select2_select_cuprite(label, string)
+    string = string.join("\n") if string.is_a?(Array)
+    field = find("label", text: /\A#{label}\z/)
+    field.click
+    page.driver.browser.keyboard.type(string, :Enter)
+  end
+
+  private def select2_select_selenium(label, string)
     string = string.join("\n") if string.is_a?(Array)
     field = find("label", text: /\A#{label}\z/)
     field.click
@@ -148,7 +194,31 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   end
 
   # https://stackoverflow.com/a/50794401/2414273
-  def assert_no_js_errors
+
+  def assert_no_js_errors &block
+    if use_cuprite?
+      assert_no_js_errors_cuprite(&block)
+    else
+      assert_no_js_errors_selenium(&block)
+    end
+  end
+
+  private def assert_no_js_errors_cuprite &block
+    last_timestamp = page.driver.browser.logger.logs
+      .map(&:timestamp)
+      .last || 0
+
+    yield
+
+    errors = page.driver.browser.logger.logs
+
+    errors = errors.reject { |e| e.timestamp.blank? || e.timestamp < last_timestamp } if last_timestamp > 0
+    errors = errors.filter { |e| e.level == "error" }
+
+    assert errors.length.zero?, "Expected no js errors, but these errors where found: #{errors.map(&:message).join(", ")}"
+  end
+
+  private def assert_no_js_errors_selenium &block
     last_timestamp = page.driver.browser.logs.get(:browser)
       .map(&:timestamp)
       .last || 0
@@ -207,23 +277,23 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
     display_details[:resolution].map { |pixel_count| pixel_count / (display_details[:high_dpi] ? 2 : 1) }
   end
 
-  # We monkey patch #execute when headless browser system tests
-  # are finicky and need to sleep to reflect changes.
-  module ::Selenium::WebDriver::Remote
-    class Bridge
-      @@execute_sleep_time = 0
-      alias_method :patched_execute, :execute
-      def execute(*args)
-        sleep @@execute_sleep_time
-        patched_execute(*args)
-      end
-
-      def self.slow_down_execute_time
-        @@execute_sleep_time = 0.1
-      end
-
-      def self.reset_execute_time
+  if !use_cuprite?
+    module ::Selenium::WebDriver::Remote
+      class Bridge
         @@execute_sleep_time = 0
+        alias_method :patched_execute, :execute
+        def execute(*args)
+          sleep @@execute_sleep_time
+          patched_execute(*args)
+        end
+
+        def self.slow_down_execute_time
+          @@execute_sleep_time = 0.1
+        end
+
+        def self.reset_execute_time
+          @@execute_sleep_time = 0
+        end
       end
     end
   end

--- a/test/support/ferrum_console_logger.rb
+++ b/test/support/ferrum_console_logger.rb
@@ -1,0 +1,76 @@
+class FerrumConsoleLogger
+  def initialize
+    @logs = []
+  end
+
+  # Filter out the noise - I believe Runtime.exceptionThrown and Log.entryAdded are the interesting log methods but there might be others you need
+  def puts(log_str)
+    message = Message.new(log_str)
+    if %w[Runtime.exceptionThrown Log.entryAdded Runtime.consoleAPICalled].include?(message.method)
+      # selenium_compatible_log_message = "#{log_body["params"]["entry"]["url"]} - #{log_body["params"]["entry"]["text"]}"
+      # @logs << { message: selenium_compatible_log_message, level: log_body["params"]["entry"]["level"] }
+      @logs << message
+    end
+  end
+
+  def logs(include_unparsed: false)
+    if include_unparsed
+      @logs
+    else
+      @logs.reject { |l| l.parser_error? }
+    end
+  end
+
+  def flush
+    @logs = []
+  end
+
+  class Message
+    attr_reader :body, :body_raw, :parser_error
+
+    def initialize(log_str)
+      _symbol, _time, body_raw = log_str.strip.split(" ", 3)
+      @body = JSON.parse body_raw
+    rescue JSON::ParserError => e
+      @parser_error = e
+      @body_raw = log_str
+    end
+
+    def level
+      if method == "Log.entryAdded"
+        body.dig "params", "entry", "level"
+      else
+        body.dig "params", "type"
+      end
+    end
+
+    def message
+      if method == "Log.entryAdded"
+        body.dig "params", "entry", "text"
+      else
+        args = body.dig "params", "args"
+        args.map { |h| h["value"] }.join(", ")
+      end
+    end
+
+    def timestamp
+      if method == "Log.entryAdded"
+        body.dig "params", "entry", "timestamp"
+      else
+        body.dig "params", "timestamp"
+      end
+    end
+
+    def stacktrace
+      body.dig "params", "stackTrace"
+    end
+
+    def method
+      body["method"]
+    end
+
+    def parser_error?
+      !!parser_error
+    end
+  end
+end

--- a/test/system/fields_test.rb
+++ b/test/system/fields_test.rb
@@ -41,7 +41,7 @@ unless scaffolding_things_disabled?
         assert_no_js_errors do
           disconnect_stimulus_controller_on button
           reconnect_stimulus_controller_on button
-          assert button.find('input[type="radio"]', visible: false)["checked"] == "true"
+          assert button.find('input[type="radio"]', visible: false)["checked"]
           improperly_disconnect_and_reconnect_stimulus_controller_on button # the radio button won't be checked because we're using innerHTML
         end
 

--- a/test/system/invitation_details_test.rb
+++ b/test/system/invitation_details_test.rb
@@ -51,8 +51,9 @@ class InvitationsTest < ApplicationSystemTestCase
       within "tbody[data-model='Membership'] tr[data-id='#{membership.id}']" do
         click_link "Details"
       end
-      click_on "Remove from Team"
-      page.driver.browser.switch_to.alert.accept
+      accept_alert do
+        click_on "Remove from Team"
+      end
       assert page.has_content?("That user has been successfully removed from the team.")
       within "tbody[data-model='Membership'][data-scope='current']" do
         assert page.has_no_content?("john@bullettrain.co")

--- a/test/system/invitations_test.rb
+++ b/test/system/invitations_test.rb
@@ -100,8 +100,7 @@ class InvitationDetailsTest < ApplicationSystemTestCase
       # TODO we should first test that a canceled invitation can't be claimed.
       assert page.has_content?("Invitation Details")
 
-      click_on "Remove from Team"
-      page.driver.browser.switch_to.alert.accept
+      accept_alert { click_on "Remove from Team" }
       assert page.has_content?("That user has been successfully removed from the team.")
 
       # click the link in the email.
@@ -131,8 +130,7 @@ class InvitationDetailsTest < ApplicationSystemTestCase
           end
         end
 
-        click_on "Re-Invite to Team"
-        page.driver.browser.switch_to.alert.accept
+        accept_alert { click_on "Re-Invite to Team" }
         assert page.has_content?("The user has been successfully re-invited. They will receive an email to rejoin the team.")
       end
 
@@ -261,8 +259,7 @@ class InvitationDetailsTest < ApplicationSystemTestCase
         end
       end
 
-      click_on "Leave This Team"
-      page.driver.browser.switch_to.alert.accept
+      accept_alert { click_on "Leave This Team" }
 
       assert page.has_content?("You've successfully removed yourself from Another Team.")
 
@@ -281,8 +278,7 @@ class InvitationDetailsTest < ApplicationSystemTestCase
       end
 
       assert page.has_content?("Hanako Tanaka’s Membership on The Testing Team")
-      click_on "Demote from Admin"
-      page.driver.browser.switch_to.alert.accept
+      accept_alert { click_on "Demote from Admin" }
 
       assert page.has_content?("The Testing Team Team Members")
       within_current_memberships_table do
@@ -300,8 +296,7 @@ class InvitationDetailsTest < ApplicationSystemTestCase
       assert page.has_no_content?("Promote to Admin")
       assert page.has_no_content?("Demote from Admin")
 
-      click_on "Leave This Team"
-      page.driver.browser.switch_to.alert.accept
+      accept_alert { click_on "Leave This Team" }
 
       # if this is happening, it shouldn't be.
       assert page.has_no_content?("You are not authorized to access this page.")

--- a/test/system/membership_test.rb
+++ b/test/system/membership_test.rb
@@ -73,8 +73,9 @@ class MembershipSystemTest < ApplicationSystemTestCase
       assert page.has_content?("SPECIAL PRIVILEGES")
       assert page.has_content?("Team Administrator")
 
-      click_on "Demote from Admin"
-      page.driver.browser.switch_to.alert.accept
+      accept_alert do
+        click_on "Demote from Admin"
+      end
 
       within_current_memberships_table do
         within_membership_row(invited_membership) do
@@ -88,8 +89,7 @@ class MembershipSystemTest < ApplicationSystemTestCase
       assert page.has_no_content?("Team Administrator")
       assert page.has_content?("Viewer")
 
-      click_on "Promote to Admin"
-      page.driver.browser.switch_to.alert.accept
+      accept_alert { click_on "Promote to Admin" }
 
       within_current_memberships_table do
         within_membership_row(invited_membership) do
@@ -114,8 +114,7 @@ class MembershipSystemTest < ApplicationSystemTestCase
       assert page.has_content?("Yuto Nishiyama")
       assert page.has_content?("Viewer")
 
-      click_on "Remove from Team"
-      page.driver.browser.switch_to.alert.accept
+      accept_alert { click_on "Remove from Team" }
 
       within_current_memberships_table do
         assert page.has_no_content?("Yuto Nishiyama")
@@ -131,8 +130,7 @@ class MembershipSystemTest < ApplicationSystemTestCase
       within_former_memberships_table do
         assert page.has_content?("Yuto Nishiyama")
         assert page.has_content?("Viewer")
-        click_on "Re-Invite to Team"
-        page.driver.browser.switch_to.alert.accept
+        accept_alert { click_on "Re-Invite to Team" }
       end
 
       assert page.has_content?("The user has been successfully re-invited. They will receive an email to rejoin the team.")

--- a/test/system/reactivity_system_test.rb
+++ b/test/system/reactivity_system_test.rb
@@ -2,15 +2,6 @@ require "application_system_test_case"
 
 unless scaffolding_things_disabled?
   class ReactivitySystemTest < ApplicationSystemTestCase
-    def setup
-      super
-      ::Selenium::WebDriver::Remote::Bridge.slow_down_execute_time
-    end
-
-    def teardown
-      ::Selenium::WebDriver::Remote::Bridge.reset_execute_time
-    end
-
     @@test_devices.each do |device_name, display_details|
       test "create a new tangible thing on a #{device_name} and update it" do
         resize_for(display_details)
@@ -95,9 +86,7 @@ unless scaffolding_things_disabled?
         # to try and figure this scenario out. So for now, we'll do it like this, from the index page:
 
         click_on "Back"
-        click_on "Delete"
-
-        page.driver.browser.switch_to.alert.accept
+        accept_alert { click_on "Delete" }
 
         assert page.has_content? "Creative Concept was successfully destroyed."
         assert page.has_content? "There are no Creative Concepts for you to see on My Super Team yet."

--- a/test/system/webhooks_system_test.rb
+++ b/test/system/webhooks_system_test.rb
@@ -80,9 +80,8 @@ class WebhooksSystemTest < ApplicationSystemTestCase
 
         assert_difference "Webhooks::Outgoing::Delivery.count", 0, "an outbound webhook should not be issued" do
           within("table tr:first-child[data-id]") do
-            click_on "Delete"
+            accept_alert { click_on "Delete" }
           end
-          page.driver.browser.switch_to.alert.accept
           assert page.has_content?("Tangible Thing was successfully destroyed.")
           Webhooks::Outgoing::Delivery.order(:id).last.deliver
         end
@@ -139,9 +138,8 @@ class WebhooksSystemTest < ApplicationSystemTestCase
         assert_difference "Webhooks::Incoming::BulletTrainWebhook.count", 1, "an inbound webhook should be received" do
           assert_difference "Webhooks::Outgoing::Delivery.count", 1, "an outbound webhook should not be issued" do
             within("table tr:first-child[data-id]") do
-              click_on "Delete"
+              accept_alert { click_on "Delete" }
             end
-            page.driver.browser.switch_to.alert.accept
             assert page.has_content?("Tangible Thing was successfully destroyed.")
           end
           Webhooks::Outgoing::Delivery.order(:id).last.deliver


### PR DESCRIPTION
This PR switches the backend for system tests to use [Cuprite](https://github.com/rubycdp/cuprite) as a more reliable alternative to Selenium.  It is generally drop-in.  There are a few differences in the driver API that required some updates to the test code:

- Accessing browser console logs (for `assert_no_js_errors`) requires a custom logger (based on https://github.com/rubycdp/cuprite/issues/113#issuecomment-753598305)
- Cuprite doesn't support `page.driver.browser.switch_to.alert.accept`, but we can use the generic Capybara `accept_alert` instead
- I updated the code for typing in select2 elements, moving from send_keys to `page.driver.browser.keyboard.type`