### PR TITLE
Remove extra yarn install check

### DIFF
--- a/bin/configure
+++ b/bin/configure
@@ -167,13 +167,6 @@ end
 puts green "Running `bundle install`."
 stream "bundle install"
 
-if `yarn -v 2> /dev/null`.strip.length > 0
-  puts green "Yarn is installed."
-else
-  puts red "Yarn is not installed. Try `brew install yarn`."
-  exit
-end
-
 puts green "Running `yarn install`."
 stream "yarn install"
 


### PR DESCRIPTION
We check if yarn is installed with this block earlier on line 121:
```ruby
if `yarn -v 2> /dev/null`.length > 0
  puts green "Yarn is installed."
else
  puts red "You don't have Yarn installed. We can't proceed without it. Try `brew install yarn` or see the installation instructions at https://yarnpkg.com/getting-started/install ."
  exit
end
```