### PR TITLE
Build assets in `bin/configure`

### DIFF
--- a/bin/configure
+++ b/bin/configure
@@ -177,6 +177,9 @@ end
 puts green "Running `yarn install`."
 stream "yarn install"
 
+puts green "Building assets"
+stream "yarn run build && yarn run build:css && yarn run light:build && yarn light:build:css"
+
 # This should be available now.
 require "active_support/inflector"
 

--- a/bin/configure
+++ b/bin/configure
@@ -177,9 +177,6 @@ end
 puts green "Running `yarn install`."
 stream "yarn install"
 
-puts green "Building assets"
-stream "yarn run build && yarn run build:css && yarn run light:build && yarn light:build:css"
-
 # This should be available now.
 require "active_support/inflector"
 

--- a/bin/setup
+++ b/bin/setup
@@ -39,6 +39,9 @@ FileUtils.chdir APP_ROOT do
   system("yarn check") || system!("yarn install")
   system!("bin/link")
 
+  puts "== Building assets =="
+  system!("yarn run build && yarn run build:css && yarn run light:build && yarn light:build:css")
+
   # puts "\n== Copying sample files =="
   # unless File.exist?("config/database.yml")
   #   FileUtils.cp "config/database.yml.sample", "config/database.yml"


### PR DESCRIPTION
When initially making a Bullet Train application, developers run the following commands:
`bin/configure`
`bin/setup`

However, unit tests will fail if they haven't run `bin/dev` yet because the assets haven't been compiled yet.

This step compiles the assets in the configure step so developers don't get confused in case they try to run tests before ever starting the server, assuming that things are broken.