### PR TITLE
Build mailer css in a separate file with css variables replaced

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -2,4 +2,5 @@ web: bin/rails server -p 3000
 worker: bundle exec sidekiq -t 25
 js: yarn build --watch
 light-js: yarn light:build --watch
-light-css: yarn light:build:css --watch
+light-css: bundle exec rake bt:link && yarn light:build:css --watch
+light-mailer-css: bundle exec rake bt:link && yarn light:build:mailer:css --watch

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -2,5 +2,5 @@ web: bin/rails server -p 3000
 worker: bundle exec sidekiq -t 25
 js: yarn build --watch
 light-js: yarn light:build --watch
-light-css: bundle exec rake bt:link && yarn light:build:css --watch
-light-mailer-css: bundle exec rake bt:link && yarn light:build:mailer:css --watch
+light-css: yarn light:build:css --watch
+light-mailer-css: yarn light:build:mailer:css --watch

--- a/bin/theme
+++ b/bin/theme
@@ -12,6 +12,7 @@ if ARGV.size < 2
   puts ""
   puts "File type options:"
   puts "\t\"tailwind-config\""
+  puts "\t\"tailwind-mailer-config\""
   puts "\t\"tailwind-stylesheet\""
   puts "\t\"javascript\""
 end
@@ -20,25 +21,32 @@ file_type = ARGV.shift
 theme = ARGV.shift
 gem_path = `bundle show bullet_train-themes-#{theme} 2> /dev/null`.chomp
 
-file_path = case file_type
+file_path, fallback_file_path = case file_type
 when "tailwind-config"
-  "/tailwind.#{theme}.config.js"
+  ["/tailwind.#{theme}.config.js", nil]
+when "tailwind-mailer-config"
+  ["/tailwind.mailer.#{theme}.config.js", "/tailwind.#{theme}.config.js"]
 when "tailwind-stylesheet"
-  "/app/assets/stylesheets/#{theme}.tailwind.css"
+  ["/app/assets/stylesheets/#{theme}.tailwind.css", nil]
 when "javascript"
-  "/app/javascript/application.#{theme}.js"
+  ["/app/javascript/application.#{theme}.js", nil]
 else
   raise "Sorry, we couldn't recognize the file you're looking for: \"#{file_type}\""
 end
 
-candidate_paths = [Dir.pwd, gem_path].select(&:present?)
+@candidate_paths = [Dir.pwd, gem_path].select(&:present?)
 
-candidate_paths.each do |candidate_path|
-  full_file_path = candidate_path + file_path
-  if File.exist?(full_file_path)
-    puts full_file_path
-    exit
+def find_file(file_path)
+  @candidate_paths.each do |candidate_path|
+    full_file_path = candidate_path + file_path
+    if File.exist?(full_file_path)
+      puts full_file_path
+      exit
+    end
   end
 end
 
-raise "Sorry, we couldn't find `#{file_path}` in any of the following paths: #{candidate_paths.join(", ")}"
+find_file(file_path)
+find_file(fallback_file_path) if fallback_file_path
+
+raise "Sorry, we couldn't find `#{file_path}` in any of the following paths: #{@candidate_paths.join(", ")}"

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "jquery": "^3.5.1",
     "jstz": "^2.1.1",
     "postcss": "^8.4.14",
+    "postcss-css-variables": "^0.18.0",
     "postcss-extend-rule": "^4.0.0",
     "postcss-import": "^14.1.0",
     "postcss-nested": "^5.0.6",
@@ -33,6 +34,7 @@
     "build": "node esbuild.config.js",
     "build:css": "bin/link; yarn light:build; yarn light:build:css",
     "light:build": "esbuild `bundle exec bin/theme javascript light` --bundle --sourcemap --outdir=app/assets/builds --loader:.png=file --loader:.jpg=file",
-    "light:build:css": "NODE_PATH=./node_modules tailwindcss -c `bundle exec bin/theme tailwind-config light` -i `bundle exec bin/theme tailwind-stylesheet light` -o ./app/assets/builds/application.light.css --postcss ./postcss.config.js"
+    "light:build:css": "NODE_PATH=./node_modules tailwindcss -c `bundle exec bin/theme tailwind-config light` -i `bundle exec bin/theme tailwind-stylesheet light` -o ./app/assets/builds/application.light.css --postcss ./postcss.config.js",
+    "light:build:mailer:css": "NODE_PATH=./node_modules tailwindcss -c `bundle exec bin/theme tailwind-config light` -i `bundle exec bin/theme tailwind-stylesheet light` -o ./app/assets/builds/application.mailer.light.css --postcss ./postcss.mailer.config.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,6 @@
     "build:css": "bin/link; yarn light:build; yarn light:build:css",
     "light:build": "esbuild `bundle exec bin/theme javascript light` --bundle --sourcemap --outdir=app/assets/builds --loader:.png=file --loader:.jpg=file",
     "light:build:css": "NODE_PATH=./node_modules tailwindcss -c `bundle exec bin/theme tailwind-config light` -i `bundle exec bin/theme tailwind-stylesheet light` -o ./app/assets/builds/application.light.css --postcss ./postcss.config.js",
-    "light:build:mailer:css": "NODE_PATH=./node_modules tailwindcss -c `bundle exec bin/theme tailwind-config light` -i `bundle exec bin/theme tailwind-stylesheet light` -o ./app/assets/builds/application.mailer.light.css --postcss ./postcss.mailer.config.js"
-  }
+    "light:build:mailer:css": "NODE_PATH=./node_modules tailwindcss -c `bundle exec bin/theme tailwind-mailer-config light` -i `bundle exec bin/theme tailwind-stylesheet light` -o ./app/assets/builds/application.mailer.light.css --postcss ./postcss.mailer.config.js"
+ }
 }

--- a/postcss.mailer.config.js
+++ b/postcss.mailer.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  plugins: [
+    require('postcss-import'),
+    require('postcss-extend-rule'),
+    require('postcss-nested'),
+    require('tailwindcss'),
+    require('postcss-css-variables'),
+    require('autoprefixer'),
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -490,6 +490,16 @@ escalade@^3.1.1:
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
   integrity sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==
 
+escape-string-regexp@^1.0.3:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
+  integrity sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==
+
+extend@^3.0.1:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
+  integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
+
 fast-glob@^3.2.11:
   version "3.2.11"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.11.tgz#a1172ad95ceb8a16e20caa5c5e56480e5129c1d9"
@@ -771,6 +781,15 @@ pify@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
   integrity sha1-7RQaasBDqEnqWISY59yosVMw6Qw=
+
+postcss-css-variables@^0.18.0:
+  version "0.18.0"
+  resolved "https://registry.yarnpkg.com/postcss-css-variables/-/postcss-css-variables-0.18.0.tgz#d97b6da19e86245eb817006e11117382f997bb93"
+  integrity sha512-lYS802gHbzn1GI+lXvy9MYIYDuGnl1WB4FTKoqMQqJ3Mab09A7a/1wZvGTkCEZJTM8mSbIyb1mJYn8f0aPye0Q==
+  dependencies:
+    balanced-match "^1.0.0"
+    escape-string-regexp "^1.0.3"
+    extend "^3.0.1"
 
 postcss-extend-rule@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Builds a separate `application.mailer.light.css` file with css variables replaced using `postcss-css-variables`, so we can use Tailwind styles as safely as possible in mailer views.

Note, not all Tailwind classes will work, as some will rely on css variables, but not all CSS works in many mail clients anyway, so care should still be taken when designing email HTML - don't just assume all Tailwind styles will behave how you expect.

Also allowed the theme to have an optional separate `tailwind.mailer.#{theme}.config.js` - premailer inlines all styles from media queries, to the light theme's dark styles would always be rendered inline, making all emails dark themed. This seems wrong, so in the light theme in https://github.com/bullet-train-co/bullet_train-themes-light/pull/10 the dark theme is disabled for the mailer styles. This required updating `bin/theme` to allow fallback options.