### PR TITLE
Use correct colorize method

### DIFF
--- a/bin/configure
+++ b/bin/configure
@@ -153,7 +153,7 @@ end
 puts "Running `bundle install`.".green
 stream "bundle install"
 
-puts green "Running `yarn install`."
+puts "Running `yarn install`.".green
 stream "yarn install"
 
 # This should be available now.


### PR DESCRIPTION
Fixes #223.

### Details
We merged #183 recently, but I missed the method on line 156... 🙇‍♂️️

### Move dependency to `bullet_train-base` gemspec?
In Issue #222, developers who don't already have colorize on their machine will get a `cannot load colorize` error. I mentioned putting `colorize` in a gemspec in PR #183, specifically for `bullet_train-base`. Since we run `bundle install` later in `bin/configure`, it would make sense to have it as a run-time dependency that's already downloaded before the developer runs `bin/configure`. So we can either...
1. Remove `colorize` from `Gemfile` here and move it to the `bullet_train-base` gemspec
2. Revert to the manual methods we had in the first place.

If option 1 seems reasonable, I'll make a PR in `bullet_train-base`.

Tagging @esmale for reporting.