### PR TITLE
Add setup script to update BASE_URL with current ngrok url

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -3,3 +3,4 @@ worker: bundle exec sidekiq -t 25
 js: THEME="light" yarn build --watch
 light-css: yarn light:build:css --watch
 light-mailer-css: yarn light:build:mailer:css --watch
+ngrok: ngrok http 3000

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -3,4 +3,4 @@ worker: bundle exec sidekiq -t 25
 js: THEME="light" yarn build --watch
 light-css: yarn light:build:css --watch
 light-mailer-css: yarn light:build:mailer:css --watch
-ngrok: ngrok http 3000
+# ngrok: ngrok http 3000

--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ If you're looking contribute to Bullet Train, you should "Fork" this template re
     bin/dev
     ```
 
+    > [!NOTE]
+    > Optional: If you have [ngrok](https://ngrok.com/) installed, uncomment `ngrok: ngrok http 3000` from `Procfile.dev` and run
+    > `bin/set-ngrok-url` to set `BASE_URL` to a publically accessible domain.
+
 8. Visit http://localhost:3000.
 
 ---

--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ If you're looking contribute to Bullet Train, you should "Fork" this template re
     > [!NOTE]
     > Optional: If you have [ngrok](https://ngrok.com/) installed, uncomment `ngrok: ngrok http 3000` from `Procfile.dev` and run
     > `bin/set-ngrok-url` to set `BASE_URL` to a publically accessible domain.
+    > Run `bin/set-ngrok-url` after restarting `ngrok` to update `BASE_URL` to
+    > the current public url.
 
 8. Visit http://localhost:3000.
 

--- a/bin/set-ngrok-url
+++ b/bin/set-ngrok-url
@@ -6,14 +6,19 @@ require "yaml"
 
 begin
   response = JSON.parse(Net::HTTP.get(URI("http://localhost:4040/api/tunnels")))
-  ngrok_url = response.dig("tunnels", 1, "public_url")
+  ngrok_url = response.dig("tunnels", 0, "public_url")
 rescue Errno::ECONNREFUSED
   puts "*******NGROK not running*******".yellow
   return
 end
 
 if ngrok_url
-  config_data = Psych.load_file("config/application.yml")
+  begin
+    config_data = Psych.load_file("config/application.yml")
+  rescue Errno::ENOENT
+    puts "config/application.yml not found".red
+  end
+
   if config_data["BASE_URL"] == ngrok_url
     puts "ngrok url has not changed".green
   else

--- a/bin/set-ngrok-url
+++ b/bin/set-ngrok-url
@@ -1,0 +1,30 @@
+#!/usr/bin/env ruby
+require "colorize"
+require "json"
+require "net/http"
+require "yaml"
+
+begin
+  response = JSON.parse(Net::HTTP.get(URI("http://localhost:4040/api/tunnels")))
+  ngrok_url = response.dig("tunnels", 1, "public_url")
+rescue Errno::ECONNREFUSED
+  puts "*******NGROK not running*******".yellow
+  return
+end
+
+if ngrok_url
+  config_data = Psych.load_file("config/application.yml")
+  if config_data["BASE_URL"] == ngrok_url
+    puts "ngrok url has not changed".green
+  else
+    updated_config_data = config_data.merge("BASE_URL" => ngrok_url)
+    File.open("config/application.yml", "w" ) do |file|
+      if updated_config_data
+        file.write(Psych.dump(updated_config_data).sub("---\n", ""))
+      end
+    end
+    puts "config/application.yml has been updated with new ngrok_url: #{ngrok_url}".green
+  end
+else
+  puts "Something went wrong, can not find ngrok url".red
+end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -92,6 +92,9 @@ Rails.application.configure do
     config.hosts << /.*#{URI.parse(gitpod_workspace_url).host}/
   end
 
+  # whitelist ngrok domains.
+  config.hosts << /[a-z0-9-]+\.ngrok\.io/
+
   config.action_mailer.delivery_method = :letter_opener
   config.active_job.queue_adapter = :sidekiq
 


### PR DESCRIPTION
With the price increase of the ngrok paid plan, I thought it would be nice to add some ways to leverage the free account easier.

Running ngrok in `Procfile.dev` may be too opinionated but wanted to include it for a working example.

new script `bin/set-ngrok-url`

- Checks for running ngrok instance
- Outputs warning message if ngrok not running
- If ngrok is currently running, grab the current public URL
- If the current value of `BASE_URL` is different from the ngrok URL, update `BASE_URL` to current ngrok URL
- Output success message with URL (handy for command + click in the console to open)
- Whitelists ngrok URLs for hosts config

A script seemed the easier to evaluate if something like this would be useful.  I've also done something similar in a rake task to have the ability to check the current environment before executing.