### PR TITLE
Update cloudinary widget

### DIFF
--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -17,7 +17,7 @@
 <meta name="turbo-cache-control" content="no-cache">
 
 <% if cloudinary_enabled? %>
-<script src="//widget.cloudinary.com/v2.0/global/all.js" type="text/javascript"></script>
+<script src="https://upload-widget.cloudinary.com/2.1.15/global/all.js" type="text/javascript"></script>
 <% end %>
 
 <meta name="intl_tel_input_utils_path" content="<%= asset_path("intl-tel-input-utils.js") %>">


### PR DESCRIPTION
Closes #219.

# Before
![Screenshot from 2022-06-21 20-04-30](https://user-images.githubusercontent.com/10546292/174786246-f502690c-caf6-4aaf-a545-5b5af390f0cb.png)

# After
![Screenshot from 2022-06-21 20-05-43](https://user-images.githubusercontent.com/10546292/174786264-7462d604-6fd7-463d-851a-054e281eabc0.png)

# Bug
However, when actually trying to save the resource after uploading the image, I get the following error (I named the model `Pic`):
```
ActiveSupport::MessageVerifier::InvalidSignature in Account::PicsController#create
```
Maybe I'm not creating the model correctly, but if this is legitimately a bug I can look into this too and open a separate PR.

Thanks for reporting, @malachaifrazier!