### PR TITLE
Read Ruby version correctly when using rvm

### DIFF
--- a/bin/configure
+++ b/bin/configure
@@ -42,7 +42,8 @@ def not_installed?(package)
 end
 
 # Unless the shell's current version of Ruby is the same as what the application requires, we should flag it.
-required_ruby = `cat ./.ruby-version`.strip
+# rbenv produces strings like "3.1.2" while rvm produces ones like "ruby-3.1.2", so we account for that here.
+required_ruby = `cat ./.ruby-version`.strip.gsub(/^ruby-/, "")
 actual_ruby = `ruby -v`.strip
 message = "Bullet Train requires Ruby #{required_ruby} and `ruby -v` returns #{actual_ruby}."
 if actual_ruby.include?(required_ruby)


### PR DESCRIPTION
Context: https://discord.com/channels/836637622432170028/836637623048601633/996487503286644757

## Details
As you can see in the comment, `./.ruby-version` had a value of `ruby-3.1.2`:
```
Bullet Train requires Ruby ruby-3.1.2 and ruby -v returns ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [x86_64-darwin21].
Try proceeding with with Ruby ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [x86_64-darwin21] anyway? [y]
```

rbenv simply writes `3.1.2` so it worked for anyone using rbenv, but rvm was breaking so I edited the code here so it's compatible with rvm as well.

[Here's a Jetbrains post](https://www.jetbrains.com/help/ruby/ruby-version-managers.html#auto_switch) that shows rvm writes Ruby versions like `ruby-3.1.2`.