### PR TITLE
Adjust invitations system test

### DIFF
--- a/test/system/fields_test.rb
+++ b/test/system/fields_test.rb
@@ -8,7 +8,7 @@ unless scaffolding_things_disabled?
 
         visit root_path
 
-        click_on "Don't have an account?"
+        invitation_only? ? be_invited_to_sign_up : click_on("Don't have an account?")
         assert page.has_content?("Create Your Account")
         fill_in "Your Email Address", with: "me@acme.com"
         fill_in "Set Password", with: example_password

--- a/test/system/invitations_test.rb
+++ b/test/system/invitations_test.rb
@@ -177,90 +177,92 @@ class InvitationDetailsTest < ApplicationSystemTestCase
 
       assert page.has_content?("Taka Yamaguchi’s Membership on The Testing Team")
 
-      within_team_menu_for(display_details) do
-        click_on "Add New Team"
+      # Users cannot create another team in invitation-only mode.
+      unless invitation_only?
+        within_team_menu_for(display_details) do
+          click_on "Add New Team"
+        end
+
+        assert page.has_content?("Create a New Team")
+        fill_in "Team Name", with: "Another Team"
+        click_on "Create Team"
+
+        assert page.has_content?("Another Team’s Dashboard")
+        within_team_menu_for(display_details) do
+          click_on "Team Members"
+        end
+
+        assert page.has_content?("Another Team Team Members")
+        click_on "Invite a New Team Member"
+
+        assert page.has_content?("New Invitation Details")
+
+        perform_enqueued_jobs do
+          clear_emails
+
+          # this is specifically a different email address than the one they signed up with originally.
+          fill_in "Email Address", with: "hanako@some-company.com"
+          click_on "Create Invitation"
+          assert page.has_content?("Invitation was successfully created.")
+        end
+
+        # sign out.
+        sign_out_for(display_details)
+
+        # we need the id of the membership that's created so we can address it's row in the table specifically.
+        invited_membership = Membership.order(:id).last
+
+        # # click the link in the email.
+        open_email "hanako@some-company.com"
+        current_email.click_link "Join Another Team"
+
+        assert page.has_content?("Create Your Account")
+        click_link "Already have an account?"
+
+        assert page.has_content?("Sign In")
+        fill_in "Your Email Address", with: "hanako.tanaka@gmail.com"
+        click_on "Next" if two_factor_authentication_enabled?
+        fill_in "Your Password", with: example_password
+        click_on "Sign In"
+
+        assert page.has_content?("Join Another Team")
+        assert page.has_content?("Taka Yamaguchi has invited you to join Another Team")
+        assert page.has_content?("This invitation was emailed to hanako@some-company.com")
+        assert page.has_content?("but you're currently signed in as hanako.tanaka@gmail.com")
+        click_on "Join Another Team"
+
+        assert page.has_content?("Welcome to Another Team!")
+
+        within_team_menu_for(display_details) do
+          click_on "Team Members"
+        end
+
+        last_membership = Membership.order(:id).last
+
+        within_current_memberships_table do
+          assert page.has_content?("Hanako Tanaka")
+          within_membership_row(last_membership) do
+            assert page.has_no_content?("Invited")
+            assert page.has_content?("Viewer")
+            click_on "Details"
+          end
+        end
+
+        accept_alert { click_on "Leave This Team" }
+
+        assert page.has_content?("You've successfully removed yourself from Another Team.")
+
+        assert page.has_content?("The Testing Team’s Dashboard")
       end
 
-      if invitation_only?
-        assert page.has_content?("Creating new teams is currently limited")
-
-        # this will take them to the create new team page.
-        be_invited_to_sign_up
-      end
-
-      assert page.has_content?("Create a New Team")
-      fill_in "Team Name", with: "Another Team"
-      click_on "Create Team"
-
-      assert page.has_content?("Another Team’s Dashboard")
-      within_team_menu_for(display_details) do
-        click_on "Team Members"
-      end
-
-      assert page.has_content?("Another Team Team Members")
-      click_on "Invite a New Team Member"
-
-      assert page.has_content?("New Invitation Details")
-
-      perform_enqueued_jobs do
-        clear_emails
-
-        # this is specifically a different email address than the one they signed up with originally.
-        fill_in "Email Address", with: "hanako@some-company.com"
-        click_on "Create Invitation"
-        assert page.has_content?("Invitation was successfully created.")
-      end
-
-      # sign out.
+      # Make sure we're actually signed in as Hanako and on the Team Members page.
       sign_out_for(display_details)
-
-      # we need the id of the membership that's created so we can address it's row in the table specifically.
-      invited_membership = Membership.order(:id).last
-
-      # # click the link in the email.
-      open_email "hanako@some-company.com"
-      current_email.click_link "Join Another Team"
-
-      assert page.has_content?("Create Your Account")
-      click_link "Already have an account?"
-
-      assert page.has_content?("Sign In")
+      visit root_url
       fill_in "Your Email Address", with: "hanako.tanaka@gmail.com"
       click_on "Next" if two_factor_authentication_enabled?
       fill_in "Your Password", with: example_password
       click_on "Sign In"
-
-      assert page.has_content?("Join Another Team")
-      assert page.has_content?("Taka Yamaguchi has invited you to join Another Team")
-      assert page.has_content?("This invitation was emailed to hanako@some-company.com")
-      assert page.has_content?("but you're currently signed in as hanako.tanaka@gmail.com")
-      click_on "Join Another Team"
-
-      assert page.has_content?("Welcome to Another Team!")
-
-      within_team_menu_for(display_details) do
-        click_on "Team Members"
-      end
-
-      last_membership = Membership.order(:id).last
-
-      within_current_memberships_table do
-        assert page.has_content?("Hanako Tanaka")
-        within_membership_row(last_membership) do
-          assert page.has_no_content?("Invited")
-          assert page.has_content?("Viewer")
-          click_on "Details"
-        end
-      end
-
-      accept_alert { click_on "Leave This Team" }
-
-      assert page.has_content?("You've successfully removed yourself from Another Team.")
-
-      assert page.has_content?("The Testing Team’s Dashboard")
-      within_team_menu_for(display_details) do
-        click_on "Team Members"
-      end
+      click_on "Team Members"
 
       assert page.has_content?("The Testing Team Team Members")
       within_current_memberships_table do

--- a/test/system/reactivity_system_test.rb
+++ b/test/system/reactivity_system_test.rb
@@ -8,7 +8,7 @@ unless scaffolding_things_disabled?
 
         visit root_path
 
-        click_on "Don't have an account?"
+        invitation_only? ? be_invited_to_sign_up : click_on("Don't have an account?")
         assert page.has_content?("Create Your Account")
         fill_in "Your Email Address", with: "me@acme.com"
         fill_in "Set Password", with: example_password

--- a/test/system/tangible_thing_test.rb
+++ b/test/system/tangible_thing_test.rb
@@ -8,7 +8,7 @@ unless scaffolding_things_disabled?
 
         visit root_path
 
-        click_on "Don't have an account?"
+        invitation_only? ? be_invited_to_sign_up : click_on("Don't have an account?")
         assert page.has_content?("Create Your Account")
         fill_in "Your Email Address", with: "me@acme.com"
         fill_in "Set Password", with: example_password


### PR DESCRIPTION
Closes #300.

`"Don't have an account?"` shouldn't be present on the sign in page in invitation-only mode, but we didn't have a hook in the tests to check this. This PR takes care of the three test files which just include a one-liner, along with the invitations system test.

## Invitations System Test

This file took a little more work than the other three files. There are a lot of diffs, but most of it is because I wrapped the test logic in an `unless invitation_only?` block. That way the test skips adding a new team, since we can't add a new team in invitation-only mode, if my understanding is correct.

I also removed this block:
```ruby
if invitation_only?
  assert page.has_content?("Creating new teams is currently limited")

  # this will take them to the create new team page.
  be_invited_to_sign_up
end
```

The test was failing before we got here because `Add New Team` wasn't present on the page.

I think someone else brought it up in the past, but it's due to the following code: 
### [app/views/account/shared/_menu_item.html.erb](https://github.com/bullet-train-co/bullet_train/blob/ed9c8d593c9362dba72e830ebc8fa2eaf86b488d/app/views/account/shared/_menu.html.erb#L46)

```erb
<% elsif show_sign_up_options? %>

  <%= render 'account/shared/menu/item', url: main_app.new_account_team_path, label: t('menus.main.labels.add_new_team') do |p| %>
    <% p.content_for :icon do %>
      <i class="ti ti-plus"></i>
    <% end %>
  <% end %>

<% end %>
```

### [app/helpers/invitation_only_helper.rb](https://github.com/bullet-train-co/bullet_train-base/blob/60b64715beb28c4008d521d83dda14224253c7ed/app/helpers/invitation_only_helper.rb#L6)
```ruby
def show_sign_up_options?
  return true unless invitation_only?
  invited?
end
```

I don't want to simply delete the `"Creating new teams is currently limited"` assertion, but I wonder if we should have it if there's no `Add New Team` button for the user to click on. I'm sure we can work it in somehow if it's necessary though.

Either way, these fixes will make our current tests pass.