### PR TITLE
Update mustermann to remove `ruby2_keywords` warning

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -372,7 +372,7 @@ GEM
       minitest (>= 5.0)
     msgpack (1.5.3)
     multi_xml (0.6.0)
-    mustermann (2.0.0)
+    mustermann (2.0.1)
       ruby2_keywords (~> 0.0.1)
     mustermann-grape (1.0.2)
       mustermann (>= 1.0.0)


### PR DESCRIPTION
Closes #306.

We could probably just wait for depfu to update the changes, but either way this will take care of the warning.