### PR TITLE
Use Knapsack for Cuprite tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,13 +197,15 @@ jobs:
               sed -i'.orig' 's/gem "selenium-webdriver"/# gem "selenium-webdriver"/' Gemfile
               sed -i'.orig' 's/gem "webdrivers"/# gem "webdrivers"/' Gemfile
               bundle install
-              bundle exec rails test:system
+              bundle exec rails "knapsack_pro:queue:minitest[--verbose]"
             else
               echo "Skipping system tests with Cuprite"
               exit 0
             fi
           environment:
             RAILS_ENV: test
+            KNAPSACK_PRO_CI_NODE_TOTAL: 16
+            KNAPSACK_PRO_TEST_FILE_PATTERN: "test/system/**{,/*/**}/*_test.rb"
 
 workflows:
   version: 2


### PR DESCRIPTION
This PR adds Knapsack to the Cuprite system test run to improve speed.