### PR TITLE
Enable Devise rememberable module

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -155,7 +155,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :rememberable
   # The time the user will be remembered without asking for credentials again.
-  # config.remember_for = 2.weeks
+  config.remember_for = 2.weeks
 
   # Invalidates all the remember me tokens when the user signs out.
   config.expire_all_remember_me_on_sign_out = true


### PR DESCRIPTION
Closes #319.

Joint PR
- https://github.com/bullet-train-co/bullet_train-base/pull/86

## Details
It seems that we just didn't have the rememberable module enabled in the first place, so I updated the new session view over in `bullet_train-base`.