### PR TITLE
Update CircleCI image for system tests with Cuprite

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,7 +168,7 @@ jobs:
     docker:
       - <<: *ruby_node_browsers_docker_image
       - <<: *postgres_docker_image
-      - image: circleci/redis
+      - image: cimg/redis:6.2.6
     executor: ruby/default
     parallelism: 16
     steps:


### PR DESCRIPTION
I was about to close #176 when I noticed we hadn't updated the CircleCI image for the system tests with Cuprite. Besides that, we should have all of the images updated here on the starter repo.