### PR TITLE
Only setup `PartialTest` on one node in parallel tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,7 +137,7 @@ jobs:
       - <<: *postgres_docker_image
       - image: cimg/redis:6.2.6
     executor: ruby/default
-    parallelism: 7
+    parallelism: 8
     steps:
       - browser-tools/install-chrome
       - browser-tools/install-chromedriver

--- a/test/bin/setup-super-scaffolding-system-test
+++ b/test/bin/setup-super-scaffolding-system-test
@@ -108,34 +108,37 @@ else
   echo "Skipping \`TestFile\` on this CI node."
 fi
 
-# TODO: Generate these in parallel.
-spring rails g model PartialTest team:references \
-  text_field_test:string \
-  boolean_test:boolean \
-  single_button_test:string \
-  multiple_buttons_test:jsonb \
-  date_test:date \
-  date_time_test:datetime \
-  file_test:attachment \
-  option_test:string \
-  password_test:string \
-  phone_field_test:string \
-  super_select_test:string \
-  multiple_super_select_test:jsonb \
-  text_area_test:text
-bin/super-scaffold crud PartialTest Team \
-  text_field_test:text_field \
-  boolean_test:boolean \
-  single_button_test:buttons \
-  multiple_buttons_test:buttons{multiple} \
-  date_test:date_field\
-  date_time_test:date_and_time_field \
-  file_test:file_field \
-  option_test:options \
-  password_test:password_field \
-  phone_field_test:phone_field \
-  super_select_test:super_select \
-  multiple_super_select_test:super_select{multiple} \
-  text_area_test:text_area --sidebar="ti.ti-layout"
+if [ -z "${CIRCLE_NODE_INDEX}" ] || [ "${CIRCLE_NODE_INDEX}" == "7" ]; then
+  spring rails g model PartialTest team:references \
+    text_field_test:string \
+    boolean_test:boolean \
+    single_button_test:string \
+    multiple_buttons_test:jsonb \
+    date_test:date \
+    date_time_test:datetime \
+    file_test:attachment \
+    option_test:string \
+    password_test:string \
+    phone_field_test:string \
+    super_select_test:string \
+    multiple_super_select_test:jsonb \
+    text_area_test:text
+  bin/super-scaffold crud PartialTest Team \
+    text_field_test:text_field \
+    boolean_test:boolean \
+    single_button_test:buttons \
+    multiple_buttons_test:buttons{multiple} \
+    date_test:date_field\
+    date_time_test:date_and_time_field \
+    file_test:file_field \
+    option_test:options \
+    password_test:password_field \
+    phone_field_test:phone_field \
+    super_select_test:super_select \
+    multiple_super_select_test:super_select{multiple} \
+    text_area_test:text_area --sidebar="ti.ti-layout"
+else
+  echo "Skipping \`PartialTest\` on this CI node."
+fi
 
 bundle exec spring rake db:schema:load db:migrate db:test:prepare


### PR DESCRIPTION
Addresses the TODO in `test/bin/setup-super-scaffolding-system-test`.

If we want to keep parallelism to 7, I can shift things around and see how we can fit it into the space we have.