### PR TITLE
Cleaning up Super Scaffolding Partial Tests

### DIFF
--- a/test/bin/setup-super-scaffolding-system-test
+++ b/test/bin/setup-super-scaffolding-system-test
@@ -114,7 +114,7 @@ if [ -z "${CIRCLE_NODE_INDEX}" ] || [ "${CIRCLE_NODE_INDEX}" == "6" ]; then
     phone_field_test:string \
     super_select_test:string \
     multiple_super_select_test:jsonb \
-    text_area_test:text \
+    text_area_test:text
   bin/super-scaffold crud PartialTest Team \
     text_field_test:text_field \
     boolean_test:boolean \

--- a/test/bin/setup-super-scaffolding-system-test
+++ b/test/bin/setup-super-scaffolding-system-test
@@ -115,7 +115,6 @@ if [ -z "${CIRCLE_NODE_INDEX}" ] || [ "${CIRCLE_NODE_INDEX}" == "6" ]; then
     super_select_test:string \
     multiple_super_select_test:jsonb \
     text_area_test:text \
-    file_test:attachment
   bin/super-scaffold crud PartialTest Team \
     text_field_test:text_field \
     boolean_test:boolean \
@@ -129,8 +128,7 @@ if [ -z "${CIRCLE_NODE_INDEX}" ] || [ "${CIRCLE_NODE_INDEX}" == "6" ]; then
     phone_field_test:phone_field \
     super_select_test:super_select \
     multiple_super_select_test:super_select{multiple} \
-    text_area_test:text_area \
-    file_test:file_field --sidebar="ti.ti-layout"
+    text_area_test:text_area --sidebar="ti.ti-layout"
 else
   echo "Skipping \`PartialTest\` on this CI node."
 fi

--- a/test/bin/setup-super-scaffolding-system-test
+++ b/test/bin/setup-super-scaffolding-system-test
@@ -101,41 +101,38 @@ else
 fi
 
 if [ -z "${CIRCLE_NODE_INDEX}" ] || [ "${CIRCLE_NODE_INDEX}" == "6" ]; then
-  bundle exec spring rails g model TestFile team:references foo:attachment
-  bin/super-scaffold crud TestFile Team foo:file_field --sidebar="ti.ti-tag"
-  # TODO Write an actual test for this in `test/system/super_scaffolding_test.rb`.
+  spring rails g model PartialTest team:references \
+    text_field_test:string \
+    boolean_test:boolean \
+    single_button_test:string \
+    multiple_buttons_test:jsonb \
+    date_test:date \
+    date_time_test:datetime \
+    file_test:attachment \
+    option_test:string \
+    password_test:string \
+    phone_field_test:string \
+    super_select_test:string \
+    multiple_super_select_test:jsonb \
+    text_area_test:text \
+    file_test:attachment
+  bin/super-scaffold crud PartialTest Team \
+    text_field_test:text_field \
+    boolean_test:boolean \
+    single_button_test:buttons \
+    multiple_buttons_test:buttons{multiple} \
+    date_test:date_field\
+    date_time_test:date_and_time_field \
+    file_test:file_field \
+    option_test:options \
+    password_test:password_field \
+    phone_field_test:phone_field \
+    super_select_test:super_select \
+    multiple_super_select_test:super_select{multiple} \
+    text_area_test:text_area \
+    file_test:file_field --sidebar="ti.ti-layout"
 else
-  echo "Skipping \`TestFile\` on this CI node."
+  echo "Skipping \`PartialTest\` on this CI node."
 fi
-
-# TODO: Generate these in parallel.
-spring rails g model PartialTest team:references \
-  text_field_test:string \
-  boolean_test:boolean \
-  single_button_test:string \
-  multiple_buttons_test:jsonb \
-  date_test:date \
-  date_time_test:datetime \
-  file_test:attachment \
-  option_test:string \
-  password_test:string \
-  phone_field_test:string \
-  super_select_test:string \
-  multiple_super_select_test:jsonb \
-  text_area_test:text
-bin/super-scaffold crud PartialTest Team \
-  text_field_test:text_field \
-  boolean_test:boolean \
-  single_button_test:buttons \
-  multiple_buttons_test:buttons{multiple} \
-  date_test:date_field\
-  date_time_test:date_and_time_field \
-  file_test:file_field \
-  option_test:options \
-  password_test:password_field \
-  phone_field_test:phone_field \
-  super_select_test:super_select \
-  multiple_super_select_test:super_select{multiple} \
-  text_area_test:text_area --sidebar="ti.ti-layout"
 
 bundle exec spring rake db:schema:load db:migrate db:test:prepare

--- a/test/system/super_scaffolding_partial_test.rb
+++ b/test/system/super_scaffolding_partial_test.rb
@@ -56,6 +56,7 @@ class SuperScaffoldingSystemTest < ApplicationSystemTestCase
       find("#partial_test_date_time_test").click
       find(".daterangepicker").click_on("Apply")
       # File partial
+      assert page.has_content?("Upload New Document")
       attach_file("test/support/foo.txt", make_visible: true)
       # Single Option partial
       choose("One")
@@ -78,9 +79,6 @@ class SuperScaffoldingSystemTest < ApplicationSystemTestCase
       find("#partial_test_multiple_super_select_test").find("option[value='two']").select_option
       # Text Area partial
       fill_in "Text Area Test", with: "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
-      # File partial
-      assert page.has_content?("Upload New Document")
-      attach_file("test/support/foo.txt", make_visible: true)
 
       click_on "Create Partial Test"
       assert page.has_content?("Partial Test was successfully created.")
@@ -103,6 +101,7 @@ class SuperScaffoldingSystemTest < ApplicationSystemTestCase
       assert_equal partial_test.date_time_test.class, ActiveSupport::TimeWithZone
       # File
       refute_nil partial_test.file_test
+      refute partial_test.foo.blank?
       assert_equal partial_test.file_test.class, ActiveStorage::Attached::One
       # Single Option
       refute_nil partial_test.option_test
@@ -125,9 +124,8 @@ class SuperScaffoldingSystemTest < ApplicationSystemTestCase
       # Text Area
       refute_nil partial_test.text_area_test
       assert_equal partial_test.text_area_test, "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
-      # File Field
-      refute partial_test.foo.blank?
 
+      # Make sure we can remove a file as well.
       click_on "Edit"
       assert page.has_content?("Remove Current Document")
       find("span", text: "Remove Current Document").click

--- a/test/system/super_scaffolding_partial_test.rb
+++ b/test/system/super_scaffolding_partial_test.rb
@@ -137,9 +137,7 @@ class SuperScaffoldingSystemTest < ApplicationSystemTestCase
 
       # This tests consistently adds a new text file,
       # so we clear out the directory the files are saved to.
-      Dir.glob("tmp/storage/*").each do |dir|
-        FileUtils.rm_rf(dir)
-      end
+      Dir.glob("tmp/storage/*").each { |dir| FileUtils.rm_r(dir) }
     end
   end
 end

--- a/test/system/super_scaffolding_partial_test.rb
+++ b/test/system/super_scaffolding_partial_test.rb
@@ -57,6 +57,12 @@ class SuperScaffoldingSystemTest < ApplicationSystemTestCase
 
       assert page.has_content?("Test File was successfully updated.")
       assert TestFile.first.foo.blank?
+
+      # This tests consistently adds a new text file,
+      # so we clear out the directory the files are saved to.
+      Dir.glob("tmp/storage/*").each do |dir|
+        FileUtils.rm_rf(dir)
+      end
     end
   end
 

--- a/test/system/super_scaffolding_partial_test.rb
+++ b/test/system/super_scaffolding_partial_test.rb
@@ -130,9 +130,10 @@ class SuperScaffoldingSystemTest < ApplicationSystemTestCase
       assert page.has_content?("Remove Current Document")
       find("span", text: "Remove Current Document").click
       click_on "Update Partial Test"
-
       assert page.has_content?("Partial Test was successfully updated.")
-      assert partial_test.file_test.blank?
+
+      # We make another call to the database here since the record's state has been updated.
+      assert PartialTest.first.file_test.blank?
 
       # This tests consistently adds a new text file,
       # so we clear out the directory the files are saved to.

--- a/test/system/super_scaffolding_partial_test.rb
+++ b/test/system/super_scaffolding_partial_test.rb
@@ -23,47 +23,11 @@ class SuperScaffoldingSystemTest < ApplicationSystemTestCase
 
   # force autoload.
   [
-    "TestFile",
     "PartialTest"
   ].each do |class_name|
     class_name.constantize
   rescue
     nil
-  end
-
-  if defined?(TestFile)
-
-    test "developers can Super Scaffold a file partial and perfrom crud actions on the record" do
-      display_details = @@test_devices[:macbook_pro_15_inch]
-      resize_for(display_details)
-
-      login_as(@jane, scope: :user)
-      visit account_team_path(@jane.current_team)
-
-      assert page.has_content?("Test Files")
-      click_on "Add New Test File"
-
-      assert page.has_content?("Upload New Document")
-      attach_file("test/support/foo.txt", make_visible: true)
-      click_on "Create Test File"
-
-      assert page.has_content?("Test File was successfully created.")
-      refute TestFile.first.foo.blank?
-
-      click_on "Edit"
-      assert page.has_content?("Remove Current Document")
-      find("span", text: "Remove Current Document").click
-      click_on "Update Test File"
-
-      assert page.has_content?("Test File was successfully updated.")
-      assert TestFile.first.foo.blank?
-
-      # This tests consistently adds a new text file,
-      # so we clear out the directory the files are saved to.
-      Dir.glob("tmp/storage/*").each do |dir|
-        FileUtils.rm_rf(dir)
-      end
-    end
   end
 
   if defined?(PartialTest)
@@ -114,6 +78,9 @@ class SuperScaffoldingSystemTest < ApplicationSystemTestCase
       find("#partial_test_multiple_super_select_test").find("option[value='two']").select_option
       # Text Area partial
       fill_in "Text Area Test", with: "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
+      # File partial
+      assert page.has_content?("Upload New Document")
+      attach_file("test/support/foo.txt", make_visible: true)
 
       click_on "Create Partial Test"
       assert page.has_content?("Partial Test was successfully created.")
@@ -158,6 +125,22 @@ class SuperScaffoldingSystemTest < ApplicationSystemTestCase
       # Text Area
       refute_nil partial_test.text_area_test
       assert_equal partial_test.text_area_test, "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
+      # File Field
+      refute partial_test.foo.blank?
+
+      click_on "Edit"
+      assert page.has_content?("Remove Current Document")
+      find("span", text: "Remove Current Document").click
+      click_on "Update Partial Test"
+
+      assert page.has_content?("Partial Test was successfully updated.")
+      assert partial_test.foo.blank?
+
+      # This tests consistently adds a new text file,
+      # so we clear out the directory the files are saved to.
+      Dir.glob("tmp/storage/*").each do |dir|
+        FileUtils.rm_rf(dir)
+      end
     end
   end
 end

--- a/test/system/super_scaffolding_partial_test.rb
+++ b/test/system/super_scaffolding_partial_test.rb
@@ -101,7 +101,7 @@ class SuperScaffoldingSystemTest < ApplicationSystemTestCase
       assert_equal partial_test.date_time_test.class, ActiveSupport::TimeWithZone
       # File
       refute_nil partial_test.file_test
-      refute partial_test.foo.blank?
+      refute partial_test.file_test.blank?
       assert_equal partial_test.file_test.class, ActiveStorage::Attached::One
       # Single Option
       refute_nil partial_test.option_test
@@ -132,7 +132,7 @@ class SuperScaffoldingSystemTest < ApplicationSystemTestCase
       click_on "Update Partial Test"
 
       assert page.has_content?("Partial Test was successfully updated.")
-      assert partial_test.foo.blank?
+      assert partial_test.file_test.blank?
 
       # This tests consistently adds a new text file,
       # so we clear out the directory the files are saved to.


### PR DESCRIPTION
At first I set out to simply clean up the test files that were being generated in `tmp/storage` whenever running the Super Scaffolding `TestFile` test, but it turned out there was some more cleanup to get taken care of, so here are the different things I addressed.

## Changes
1. Remove the `foo.txt` file that’s generated whenever we run `super_scaffolding_system_test.rb`
2. Move all the necessary logic to `PartialTest` and delete `TestFile` (I wrote `TestFile` before `PartialTest` was merged in, so these were separated before)
3. Make sure `PartialTest` runs in parallel

I made sure PartialTest ran in parallel in #338, but I figured there would be conflicts so I just decided to take care of it here.
