### PR TITLE
Address devise gem placement issue in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -91,8 +91,6 @@ end
 # BULLET TRAIN GEMS
 # This section is the list of Ruby gems included by default for Bullet Train.
 
-# TODO We have to reference `devise` in the local application Gemfile before `bullet_train`, otherwise our overrides of
-# its views don't take effect. Is there another way around this?
 gem "devise"
 
 # Core packages.

--- a/Gemfile
+++ b/Gemfile
@@ -91,8 +91,6 @@ end
 # BULLET TRAIN GEMS
 # This section is the list of Ruby gems included by default for Bullet Train.
 
-gem "devise"
-
 # Core packages.
 gem "bullet_train"
 gem "bullet_train-super_scaffolding"
@@ -107,6 +105,8 @@ gem "bullet_train-integrations-stripe"
 gem "bullet_train-sortable"
 gem "bullet_train-scope_questions"
 gem "bullet_train-obfuscates_id"
+
+gem "devise"
 
 group :development do
   # Open any sent emails in your browser instead of having to setup an SMTP trap.

--- a/config/initializers/theme.rb
+++ b/config/initializers/theme.rb
@@ -1,1 +1,2 @@
 BulletTrain::Themes::Light.color = :blue
+BulletTrain::Themes::Light.original_devise_path = `bundle show devise`.chomp

--- a/test/system/account_test.rb
+++ b/test/system/account_test.rb
@@ -56,7 +56,7 @@ class AccountTest < ApplicationSystemTestCase
       click_on "Next" if two_factor_authentication_enabled?
       fill_in "Your Password", with: another_example_password
       click_on "Sign In"
-      assert page.has_content?("Invalid Email Address or Password.")
+      assert page.has_content?("Invalid Email Address or password.")
     end
   end
 end

--- a/test/system/authentication_test.rb
+++ b/test/system/authentication_test.rb
@@ -71,7 +71,7 @@ class AuthenticationSystemTest < ApplicationSystemTestCase
       fill_in "Your Password", with: "notpassword1234"
       check "Remember me"
       click_on "Sign In"
-      assert page.has_content?("Invalid Email Address or Password.")
+      assert page.has_content?("Invalid Email Address or password.")
 
       # try signing in with the valid credentials.
       fill_in "Your Email Address", with: "andrew.culver@gmail.com"


### PR DESCRIPTION
Addresses the TODO in the Gemfile concerning the devise gem.

Joint PRs
- https://github.com/bullet-train-co/bullet_train-themes/pull/15
- https://github.com/bullet-train-co/bullet_train-themes-light/pull/46

## Details
The main fix is in a monkey patch if the first joint PR.

I had to adjust the tests because `"Password"` was turning into `"password"` in a couple of flash notices, but I'm not entirely sure why it's happening. I can look into that side more if necessary.