### PR TITLE
Remove `pry` in theme script

### DIFF
--- a/bin/theme
+++ b/bin/theme
@@ -4,7 +4,6 @@
 
 require "active_support"
 require "fileutils"
-require "pry"
 
 if ARGV.size < 2
   puts "Please make sure you write both the the file type you're looking for along with the theme, in that order."


### PR DESCRIPTION
Context: https://discord.com/channels/836637622432170028/836637623048601633/1008367566894403644

## Details
Most of our scripts are run manually, but `bin/theme` is run whenever we run the commands in `Procfile.dev`.

`./package.json`:
```js
"scripts": {
  "build": "node esbuild.config.js",
  "build:css": "bin/link; yarn light:build; yarn light:build:css; yarn light:build:mailer:css",
  "light:build": "esbuild `bundle exec bin/theme javascript light` --bundle --sourcemap --outdir=app/assets/builds --loader:.png=file --loader:.jpg=file",
  "light:build:css": "NODE_PATH=./node_modules tailwindcss -c `bundle exec bin/theme tailwind-config light` -i `bundle exec bin/theme tailwind-stylesheet light` -o ./app/assets/builds/application.light.css --postcss ./postcss.config.js",
  "light:build:mailer:css": "NODE_PATH=./node_modules tailwindcss -c `bundle exec bin/theme tailwind-mailer-config light` -i `bundle exec bin/theme tailwind-stylesheet light` -o ./app/assets/builds/application.mailer.light.css --postcss ./postcss.mailer.config.js"
}
```

I'm not quite sure what everyone else's production environment is (I haven't seen many other people bring up the same issue in production), but my initial instinct tells me we don't need the requirement unless we're debugging locally, so all I've done is remove the requirement in `bin/theme`.