### PR TITLE
Ensure forgery protection callback runs first

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,5 @@
 class ApplicationController < ActionController::Base
   include Controllers::Base
 
-  protect_from_forgery with: :exception
+  protect_from_forgery with: :exception, prepend: true
 end


### PR DESCRIPTION
Address the TODO in [bullet_train-base/app/controllers/sessions/controller_base.rb](https://github.com/bullet-train-co/bullet_train-base/blob/88573750c8e519aff0a4a2bacf07c2dd12e611cd/app/controllers/concerns/sessions/controller_base.rb)

Joint PR
- https://github.com/bullet-train-co/bullet_train-base/pull/96

## Details
We were including `protect_from_forgery` in our application, but we were still getting this error without the workaround in `bullet_train-base`:
```
ActionController::InvalidAuthenticityToken (Can't verify CSRF token authenticity.)
```

## Fixes for others that didn't work for me
I sifted through devise's issues and the general consensus was that it wasn't an issue with devise. However, they had some different fixes. Unfortunately, they didn't work for me:
- `> rails dev:cache`
- Revert to rack `2.2.2`
- Remove `config.session_store :cache_store` in `development.rb`

## The fix
I eventually came across [a comment](https://github.com/heartcombo/devise/issues/4085#issuecomment-233001593) that suggested adding `prepend: true` to `protect_from_forgery`. This made the most sense to me because we already had this method implemented (which means we shouldn't have been getting a security-related error in this case), and since we're splitting a lot of our logic across different packages I'd imagine it would be easy to lose track of where this is fired in the sign in process.

From the [Rails API](https://api.rubyonrails.org/classes/ActionController/RequestForgeryProtection/ClassMethods.html):
> `prepend: true` - By default, the verification of the authentication token will be added at the position of the [protect_from_forgery](https://api.rubyonrails.org/classes/ActionController/RequestForgeryProtection/ClassMethods.html#method-i-protect_from_forgery) call in your application. This means any callbacks added before are run first. This is useful when you want your forgery protection to depend on other callbacks, like authentication methods (Oauth vs Cookie auth).

The comment above also referred to [this section in the Rails upgrade docs](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#protect-from-forgery-now-defaults-to-prepend-false). It was technically in the Rails 4 to 5 upgrade, but I think it makes sense here to use `prepend: true` when signing in.