### PR TITLE
Re-enable overmind

### DIFF
--- a/bin/dev
+++ b/bin/dev
@@ -4,7 +4,6 @@ bin/link
 
 if [ -x "$(command -v overmind)" ]
 then
-  echo "RUNNING OVERMIND"
   overmind start -f Procfile.dev "$@"
 else
   foreman start -f Procfile.dev "$@"

--- a/bin/dev
+++ b/bin/dev
@@ -2,12 +2,12 @@
 
 bin/link
 
-# TODO Enable this again when https://github.com/DarthSim/overmind/issues/132 is fixed.
-# if [ -x "$(command -v overmind)" ]
-# then
-#   overmind start -f Procfile.dev "$@"
-# else
-#   foreman start -f Procfile.dev "$@"
-# fi
+if [ -x "$(command -v overmind)" ]
+then
+  echo "RUNNING OVERMIND"
+  overmind start -f Procfile.dev "$@"
+else
+  foreman start -f Procfile.dev "$@"
+fi
 
 bundle exec foreman start -f Procfile.dev "$@"


### PR DESCRIPTION
I'm curious if this is an M1 issue or if it has actually been fixed, because I updated tmux to 3.3a on my mac (not M1) with brew and it's working for me. Thought I'd open this PR in case it started working for anyone else too.

<img width="1440" alt="tmux 3 3a" src="https://user-images.githubusercontent.com/10546292/185053734-7660e220-02ff-4a6d-9e8c-ce5df2c3d8ea.png">

