### PR TITLE
Delete unneeded ability

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -13,9 +13,6 @@ class Ability
       permit user, through: :memberships, parent: :team
       permit user, through: :scaffolding_absolutely_abstract_creative_concepts_collaborators, parent: :creative_concept
 
-      # TODO is this even used?
-      can :dashboard, User, user_id: user.id
-
       # INDIVIDUAL USER PERMISSIONS.
       can :manage, User, id: user.id
       can :destroy, Membership, user_id: user.id


### PR DESCRIPTION
Looking through our current Bullet Train packages, I don't see `@user_ability.can?(:dashboard, @user)` or anything like it show up anywhere, so I think we're safe to delete this one.

There weren't any tests in `test/models/ability_test.rb` either, so we don't need to adjust our tests.

The only place I figured MIGHT get affected is `config/initializers/rails_admin.rb` in `bullet_train-platform`, but it doesn't seem like it's being used so I think we're ok.
