### PR TITLE
Document specific details about Doorkeeper grant flows

### DIFF
--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -358,7 +358,20 @@ Doorkeeper.configure do
   #   http://tools.ietf.org/html/rfc6819#section-4.4.2
   #   http://tools.ietf.org/html/rfc6819#section-4.4.3
   #
-  # TODO What are the implications of each of these?
+  # Implicit Grant:
+  # The access token is directly returned to the client as a fragment part
+  # of the redirect URI. It is not sent to the redirect URI target.
+  # Because the token is sent from the server to the client via a URI fragment,
+  # an attacker can eavesdrop on the token if the communication or the
+  # endpoint is not secured. See the first link above for countermeasures.
+  #
+  # Password Grant:
+  # Allows a client to request an access token using a user id and password
+  # along with its own credential, and is often used for legacy/migration reasons.
+  # This grant has a higher risk because it maintains the UID/password anti-pattern. 
+  # The user doesn't have control over the authorization process, so clients
+  # aren't limited by scope, and could potentially have the same capabilities
+  # as the user themselves. See the second link above for countermeasures.
   grant_flows %w[authorization_code password implicit client_credentials]
 
   # Allows to customize OAuth grant flows that +each+ application support.

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -368,7 +368,7 @@ Doorkeeper.configure do
   # Password Grant:
   # Allows a client to request an access token using a user id and password
   # along with its own credential, and is often used for legacy/migration reasons.
-  # This grant has a higher risk because it maintains the UID/password anti-pattern. 
+  # This grant has a higher risk because it maintains the UID/password anti-pattern.
   # The user doesn't have control over the authorization process, so clients
   # aren't limited by scope, and could potentially have the same capabilities
   # as the user themselves. See the second link above for countermeasures.


### PR DESCRIPTION
## TL;DR
If there's no specific reason to use the `password` grant flow, we probably shouldn't use it because of the security risks that come along with it.

## Details
If no grant flows are specified, Doorkeeper automatically sets these values to `authorization_code` and `client_credentials`, so these should be the default values.

`implicit` and `password` have pitfalls to look out for, so I read up on the information provided by the links and paraphrased it to make it somewhat shorter.

The password grant seems to be the most high-risk, so if we don't have a need for it we can probably remove it from `grant_flows`, but I'll leave that up to your discretion.