### PR TITLE
removes duplicate jstz entry in application.js

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -25,10 +25,6 @@ import "@bullet-train/bullet-train-sortable"
 
 require("@icon/themify-icons/themify-icons.css")
 
-// For inline use in `app/views/account/onboarding/user_details/edit.html.erb`.
-import jstz from 'jstz';
-global.jstz = require("jstz");
-
 import { trixEditor } from "@bullet-train/fields"
 trixEditor()
 


### PR DESCRIPTION
I was referencing the upstream repo and noticed that `jstz` was imported into `application.js` twice: [here](https://github.com/bullet-train-co/bullet_train/blob/main/app/javascript/application.js#L20) and [here](https://github.com/bullet-train-co/bullet_train/blob/main/app/javascript/application.js#L28-L30). This change just removes the duplicate import & global assignment.