### PR TITLE
Update comment concerning failing Cuprite test

### DIFF
--- a/test/system/animations_test.rb
+++ b/test/system/animations_test.rb
@@ -8,7 +8,8 @@ class AnimationsTest < ApplicationSystemTestCase
   end
 
   test "mobile menu works properly" do
-    # TODO This test fails on Cuprite?
+    # TODO: Unfortunately we have to skip this test when using Cuprite because
+    # the `obscured?` method below has not been implemented in the driver yet.
     skip unless Capybara.current_driver.to_s.include?("selenium")
 
     display_details = {resolution: [750, 1334], mobile: true, high_dpi: true}


### PR DESCRIPTION
Addresses the TODO in `test/system/animations_test.rb`

# TL;DR
Cuprite doesn't currently support `obscured?`

## Details
The method that was giving us a problem was `obscured?` from this line:
```ruby
assert_not els[:open_button].obscured?, "open_button should not initially be obscured on iteration #{i}"
```

Since Capybara can use different drivers, it initially calls this general method from [Capybara::Node::Element](https://github.com/teamcapybara/capybara/blob/b8705059b142930e97fcbd8f34b9409755570c44/lib/capybara/node/element.rb#L316):
```ruby
def obscured?
  synchronize { base.obscured? }
end
```

Prying here and checking out `base`, we get the following results.

## When using Selenium
```
> base
#=> #<Capybara::Selenium::ChromeNode tag="button" path="/HTML/BODY[1]/DIV[2]/DIV[1]/DIV[3]/MAIN[1]/DIV[1]/BUTTON[1]">

> base.class
#=> Capybara::Selenium::ChromeNode

> base.class.instance_method(:obscured?).source_location
#=> ["/home/gazayas/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/capybara-b8705059b142/lib/capybara/selenium/node.rb", 205]
```

## When using Cuprite
```
> base
#=> #<Capybara::Cuprite::Node @node=#<Ferrum::Node @target_id="0E492DB1691FA636DDF86C0E9E1DBB84" @node_id=16 @description={"nodeId"=>0, "backendNodeId"=>28, "nodeType"=>1, "nodeName"=>"BUTTON", "localName"=>"button", "nodeValue"=>"", "childNodeCount"=>2, "attributes"=>["class", "lg:hidden h-12 w-12 ml-1 flex-none inline-flex items-center justify-center rounded-md text-gray-500 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500", "id", "mobile-menu-open", "data-action", "mobile-menu#open"]}>>

> base.class
#=> Capybara::Cuprite::Node

> base.class.instance_method(:obscured?).source_location
#=> ["/home/gazayas/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/capybara-b8705059b142/lib/capybara/driver/node.rb", 92]
```

## Cuprite doesn't support `obscured?`
Looking at the source locations from the results above, `Capybara::Selenium::Node` has `obscured?` as one of its methods ([source](https://github.com/teamcapybara/capybara/blob/a5b5a04d81e1138d6904e33ac176227d04aacce9/lib/capybara/selenium/node.rb#L205))
```ruby
def obscured?(x: nil, y: nil)
  res = driver.evaluate_script(OBSCURED_OR_OFFSET_SCRIPT, self, x, y)
  return true if res == true

  driver.frame_obscured_at?(x: res['x'], y: res['y'])
end
```

However, the Cuprite node above just takes us to the `Capybara::Driver::Node` class and [raises an error](https://github.com/teamcapybara/capybara/blob/b8705059b142930e97fcbd8f34b9409755570c44/lib/capybara/driver/node.rb#L92)
```ruby
def obscured?
  raise NotImplementedError
end
```

## Related issues
It looks like we'll just have to skip this test until Cuprite supports the method. For example, here's a comment from [this issue](https://github.com/teamcapybara/capybara/issues/2478) when a user tried to use the `drag_to` method with Cuprite:
> The error is in cuprite, sounds like it hasn't implemented all the base driver methods, nothing Capybara can do about that

[Here is another issue](https://github.com/rubycdp/cuprite/issues/39) where there is talk about adding support for the `set_proxy` method because it hadn't been implemented yet.