### PR TITLE
Use `current_theme` in `Current` class

### DIFF
--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -1,4 +1,5 @@
 # See https://api.rubyonrails.org/classes/ActiveSupport/CurrentAttributes.html for details.
 class Current < ActiveSupport::CurrentAttributes
   include CurrentAttributes::Base
+  include ApplicationHelper
 end


### PR DESCRIPTION
The purpose of this PR is to use the `current_theme` helper method in the `Current` class so we can call `directory_order` from there.

Joint PRs (The main PR is in `bullet_train-themes`)
- https://github.com/bullet-train-co/bullet_train-themes/pull/18
- https://github.com/bullet-train-co/bullet_train-base/pull/103