### PR TITLE
Require "active_support/inflector" instead of all of Rails

### DIFF
--- a/bin/configure
+++ b/bin/configure
@@ -161,7 +161,7 @@ stream "yarn install"
 
 human = ask "What is the name of your new application in title case? (e.g. \"Some Great Application\")"
 
-require "rails"
+require "active_support/inflector"
 
 variable = ActiveSupport::Inflector.parameterize(human.gsub("-", " "), separator: '_')
 environment_variable = ActiveSupport::Inflector.parameterize(human.gsub("-", " "), separator: '_').upcase


### PR DESCRIPTION
Requiring all of Rails caused issues on my machine because of conflicting gem versions. It's also unnecessary. Requiring `active_support/inflector` is enough to get us going.

```
/Users/carl/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/rubygems/specification.rb:2236:in `raise_if_conflicts': Unable to activate railties-7.0.3.1, because activesupport-7.0.4 conflicts with activesupport (= 7.0.3.1) (Gem::ConflictError)
	from /Users/carl/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/rubygems/specification.rb:1367:in `activate'
	from /Users/carl/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/rubygems.rb:211:in `rescue in try_activate'
	from /Users/carl/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/rubygems.rb:204:in `try_activate'
	from <internal:/Users/carl/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:153:in `rescue in require'
	from <internal:/Users/carl/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:149:in `require'
	from /Users/carl/code/bt_monolith/bin/configure:165:in `<main>'
/Users/carl/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/rubygems/specification.rb:2236:in `raise_if_conflicts': Unable to activate railties-7.0.3.1, because activesupport-7.0.4 conflicts with activesupport (= 7.0.3.1) (Gem::ConflictError)
	from /Users/carl/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/rubygems/specification.rb:1367:in `activate'
	from /Users/carl/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/rubygems.rb:205:in `try_activate'
	from <internal:/Users/carl/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:153:in `rescue in require'
	from <internal:/Users/carl/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:149:in `require'
	from /Users/carl/code/bt_monolith/bin/configure:165:in `<main>'
<internal:/Users/carl/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:148:in `require': cannot load such file -- rails (LoadError)
	from <internal:/Users/carl/.asdf/installs/ruby/3.1.2/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:148:in `require'
	from /Users/carl/code/bt_monolith/bin/configure:165:in `<main>'
```