### PR TITLE
Use GitHub Active Hash

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -162,7 +162,7 @@ group :production do
   gem "aws-sdk-s3", require: false
 end
 
-gem "active_hash"
+gem "active_hash", path: "../../../ruby/gems/active_hash"
 
 # YOUR GEMS
 # You can add any Ruby gems you need below. By keeping them separate from our gems above, you'll avoid the likelihood

--- a/Gemfile
+++ b/Gemfile
@@ -162,7 +162,10 @@ group :production do
   gem "aws-sdk-s3", require: false
 end
 
-gem "active_hash", path: "../../../ruby/gems/active_hash"
+gem "active_hash", git: "git@github.com:active-hash/active_hash.git"
+
+# YOUR GEMS
+# You can add any Ruby gems you need below. By keeping them separate from our gems above, you'll avoid the likelihood
 
 # YOUR GEMS
 # You can add any Ruby gems you need below. By keeping them separate from our gems above, you'll avoid the likelihood

--- a/Gemfile
+++ b/Gemfile
@@ -162,8 +162,7 @@ group :production do
   gem "aws-sdk-s3", require: false
 end
 
-# TODO Have to specify this dependency here until our changes are in the original package.
-gem "active_hash", github: "bullet-train-co/active_hash"
+gem "active_hash"
 
 # YOUR GEMS
 # You can add any Ruby gems you need below. By keeping them separate from our gems above, you'll avoid the likelihood

--- a/Gemfile
+++ b/Gemfile
@@ -163,7 +163,7 @@ group :production do
 end
 
 # TODO: Eventually just use `gem "active_hash"`
-gem "active_hash", git: "git@github.com:active-hash/active_hash.git"
+gem "active_hash", github: "active-hash/active_hash"
 
 # YOUR GEMS
 # You can add any Ruby gems you need below. By keeping them separate from our gems above, you'll avoid the likelihood

--- a/Gemfile
+++ b/Gemfile
@@ -162,10 +162,8 @@ group :production do
   gem "aws-sdk-s3", require: false
 end
 
+# TODO: Eventually just use `gem "active_hash"`
 gem "active_hash", git: "git@github.com:active-hash/active_hash.git"
-
-# YOUR GEMS
-# You can add any Ruby gems you need below. By keeping them separate from our gems above, you'll avoid the likelihood
 
 # YOUR GEMS
 # You can add any Ruby gems you need below. By keeping them separate from our gems above, you'll avoid the likelihood

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,6 +12,12 @@ GIT
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
 
+PATH
+  remote: ../../../ruby/gems/active_hash
+  specs:
+    active_hash (3.1.1)
+      activesupport (>= 5.0.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -60,8 +66,6 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
-    active_hash (3.1.0)
-      activesupport (>= 5.0.0)
     activejob (7.0.4)
       activesupport (= 7.0.4)
       globalid (>= 0.3.6)
@@ -553,7 +557,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  active_hash
+  active_hash!
   aws-sdk-s3
   bootsnap
   bullet_train

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,4 @@
 GIT
-  remote: https://github.com/bullet-train-co/active_hash.git
-  revision: a6628bc65e7c099ec9428c2bfe1e292ef01f1ef1
-  specs:
-    active_hash (3.1.0)
-      activesupport (>= 5.0.0)
-
-GIT
   remote: https://github.com/teamcapybara/capybara.git
   revision: b8705059b142930e97fcbd8f34b9409755570c44
   specs:
@@ -67,6 +60,8 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    active_hash (3.1.0)
+      activesupport (>= 5.0.0)
     activejob (7.0.4)
       activesupport (= 7.0.4)
       globalid (>= 0.3.6)
@@ -558,7 +553,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  active_hash!
+  active_hash
   aws-sdk-s3
   bootsnap
   bullet_train

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,11 @@
 GIT
+  remote: git@github.com:active-hash/active_hash.git
+  revision: cbf3d200710ba90df0e98375e232f1288900bfda
+  specs:
+    active_hash (3.1.1)
+      activesupport (>= 5.0.0)
+
+GIT
   remote: https://github.com/teamcapybara/capybara.git
   revision: b8705059b142930e97fcbd8f34b9409755570c44
   specs:
@@ -11,12 +18,6 @@ GIT
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
-
-PATH
-  remote: ../../../ruby/gems/active_hash
-  specs:
-    active_hash (3.1.1)
-      activesupport (>= 5.0.0)
 
 GEM
   remote: https://rubygems.org/


### PR DESCRIPTION
Replace Bullet Train’s `active_hash` with the main GitHub repository.

## Details
Although the gem on rubygems.org still doesn’t work for us, the main branch on GitHub works, so for the time being I decided to just switch to that.

After the next official release we should be able to just call it as is in the Gemfile:
`gem "active_hash"`

## Error log
By the way, this is the error we get when running unit tests when it's just `gem "active_hash"`:

```
/home/gazayas/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/activerecord-7.0.4/lib/active_record/nested_attributes.rb:351:in `block in accepts_nested_attributes_for': No association found for name `current_team'. Has it been defined yet? (ArgumentError)
	from /home/gazayas/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/activerecord-7.0.4/lib/active_record/nested_attributes.rb:339:in `each'
	from /home/gazayas/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/activerecord-7.0.4/lib/active_record/nested_attributes.rb:339:in `accepts_nested_attributes_for'
	from /home/gazayas/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bullet_train-1.1.4/app/models/concerns/users/base.rb:25:in `block in <module:Base>'
	from /home/gazayas/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/activesupport-7.0.4/lib/active_support/concern.rb:136:in `class_eval'
	from /home/gazayas/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/activesupport-7.0.4/lib/active_support/concern.rb:136:in `append_features'
	from /home/gazayas/work/bt/bullet_train/app/models/user.rb:2:in `include'
	from /home/gazayas/work/bt/bullet_train/app/models/user.rb:2:in `<class:User>'
	from /home/gazayas/work/bt/bullet_train/app/models/user.rb:1:in `<main>'
	from /home/gazayas/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bootsnap-1.13.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
	from /home/gazayas/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bootsnap-1.13.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
	from /home/gazayas/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/zeitwerk-2.6.0/lib/zeitwerk/kernel.rb:27:in `require'
	from /home/gazayas/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/activesupport-7.0.4/lib/active_support/inflector/methods.rb:280:in `const_get'
	from /home/gazayas/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/activesupport-7.0.4/lib/active_support/inflector/methods.rb:280:in `constantize'
	from /home/gazayas/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/activesupport-7.0.4/lib/active_support/core_ext/string/inflections.rb:74:in `constantize'
	from /home/gazayas/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/devise-4.8.1/lib/devise.rb:320:in `get'
	from /home/gazayas/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/devise-4.8.1/lib/devise/mapping.rb:83:in `to'
	from /home/gazayas/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/devise-4.8.1/lib/devise/mapping.rb:78:in `modules'
	from /home/gazayas/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/devise-4.8.1/lib/devise/mapping.rb:95:in `routes'
	from /home/gazayas/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/devise-4.8.1/lib/devise/mapping.rb:162:in `default_used_route'
	from /home/gazayas/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/devise-4.8.1/lib/devise/mapping.rb:72:in `initialize'
	from /home/gazayas/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/devise-4.8.1/lib/devise.rb:354:in `new'
	from /home/gazayas/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/devise-4.8.1/lib/devise.rb:354:in `add_mapping'
	from /home/gazayas/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/devise-4.8.1/lib/devise/rails/routes.rb:243:in `block in devise_for'
	from /home/gazayas/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/devise-4.8.1/lib/devise/rails/routes.rb:242:in `each'
	from /home/gazayas/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/devise-4.8.1/lib/devise/rails/routes.rb:242:in `devise_for'
	from /home/gazayas/work/bt/bullet_train/config/routes/devise.rb:1:in `draw'
	from /home/gazayas/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/actionpack-7.0.4/lib/action_dispatch/routing/mapper.rb:1600:in `instance_eval'
	from /home/gazayas/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/actionpack-7.0.4/lib/action_dispatch/routing/mapper.rb:1600:in `draw'
	from /home/gazayas/work/bt/bullet_train/config/routes.rb:4:in `block in <main>'
	from /home/gazayas/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/actionpack-7.0.4/lib/action_dispatch/routing/route_set.rb:428:in `instance_exec'
	from /home/gazayas/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/actionpack-7.0.4/lib/action_dispatch/routing/route_set.rb:428:in `eval_block'
	from /home/gazayas/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/actionpack-7.0.4/lib/action_dispatch/routing/route_set.rb:410:in `draw'
	from /home/gazayas/work/bt/bullet_train/config/routes.rb:1:in `<main>'
	from /home/gazayas/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/railties-7.0.4/lib/rails/application/routes_reloader.rb:50:in `load'
	from /home/gazayas/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/railties-7.0.4/lib/rails/application/routes_reloader.rb:50:in `block in load_paths'
	from /home/gazayas/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/railties-7.0.4/lib/rails/application/routes_reloader.rb:50:in `each'
	from /home/gazayas/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/railties-7.0.4/lib/rails/application/routes_reloader.rb:50:in `load_paths'
	from /home/gazayas/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/railties-7.0.4/lib/rails/application/routes_reloader.rb:24:in `reload!'
	from /home/gazayas/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/railties-7.0.4/lib/rails/application/routes_reloader.rb:38:in `block in updater'
	from /home/gazayas/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/activesupport-7.0.4/lib/active_support/file_update_checker.rb:83:in `execute'
	from /home/gazayas/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/railties-7.0.4/lib/rails/application/routes_reloader.rb:13:in `execute'
	from /home/gazayas/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/railties-7.0.4/lib/rails/application/finisher.rb:158:in `block in <module:Finisher>'
	from /home/gazayas/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/railties-7.0.4/lib/rails/initializable.rb:32:in `instance_exec'
	from /home/gazayas/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/railties-7.0.4/lib/rails/initializable.rb:32:in `run'
	from /home/gazayas/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/railties-7.0.4/lib/rails/initializable.rb:61:in `block in run_initializers'
	from /home/gazayas/.rbenv/versions/3.1.2/lib/ruby/3.1.0/tsort.rb:228:in `block in tsort_each'
	from /home/gazayas/.rbenv/versions/3.1.2/lib/ruby/3.1.0/tsort.rb:350:in `block (2 levels) in each_strongly_connected_component'
	from /home/gazayas/.rbenv/versions/3.1.2/lib/ruby/3.1.0/tsort.rb:431:in `each_strongly_connected_component_from'
	from /home/gazayas/.rbenv/versions/3.1.2/lib/ruby/3.1.0/tsort.rb:349:in `block in each_strongly_connected_component'
	from /home/gazayas/.rbenv/versions/3.1.2/lib/ruby/3.1.0/tsort.rb:347:in `each'
	from /home/gazayas/.rbenv/versions/3.1.2/lib/ruby/3.1.0/tsort.rb:347:in `call'
	from /home/gazayas/.rbenv/versions/3.1.2/lib/ruby/3.1.0/tsort.rb:347:in `each_strongly_connected_component'
	from /home/gazayas/.rbenv/versions/3.1.2/lib/ruby/3.1.0/tsort.rb:226:in `tsort_each'
	from /home/gazayas/.rbenv/versions/3.1.2/lib/ruby/3.1.0/tsort.rb:205:in `tsort_each'
	from /home/gazayas/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/railties-7.0.4/lib/rails/initializable.rb:60:in `run_initializers'
	from /home/gazayas/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/railties-7.0.4/lib/rails/application.rb:372:in `initialize!'
	from /home/gazayas/work/bt/bullet_train/config/environment.rb:5:in `<main>'
	from /home/gazayas/work/bt/bullet_train/test/test_helper.rb:2:in `require_relative'
	from /home/gazayas/work/bt/bullet_train/test/test_helper.rb:2:in `<main>'
	from /home/gazayas/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bootsnap-1.13.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
	from /home/gazayas/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bootsnap-1.13.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
	from /home/gazayas/work/bt/bullet_train/test/channels/application_cable/connection_test.rb:1:in `<main>'
	from /home/gazayas/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bootsnap-1.13.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
	from /home/gazayas/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bootsnap-1.13.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
	from /home/gazayas/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/railties-7.0.4/lib/rails/test_unit/runner.rb:47:in `block in load_tests'
	from /home/gazayas/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/railties-7.0.4/lib/rails/test_unit/runner.rb:47:in `each'
	from /home/gazayas/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/railties-7.0.4/lib/rails/test_unit/runner.rb:47:in `load_tests'
	from /home/gazayas/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/railties-7.0.4/lib/rails/test_unit/runner.rb:40:in `run'
	from /home/gazayas/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/railties-7.0.4/lib/rails/commands/test/test_command.rb:33:in `perform'
	from /home/gazayas/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/thor-1.2.1/lib/thor/command.rb:27:in `run'
	from /home/gazayas/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/thor-1.2.1/lib/thor/invocation.rb:127:in `invoke_command'
	from /home/gazayas/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/thor-1.2.1/lib/thor.rb:392:in `dispatch'
	from /home/gazayas/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/railties-7.0.4/lib/rails/command/base.rb:87:in `perform'
	from /home/gazayas/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/railties-7.0.4/lib/rails/command.rb:48:in `invoke'
	from /home/gazayas/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/railties-7.0.4/lib/rails/commands.rb:18:in `<main>'
	from /home/gazayas/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bootsnap-1.13.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
	from /home/gazayas/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bootsnap-1.13.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
	from bin/rails:4:in `<main>'
```
