### PR TITLE
Use web app capable meta tag for iOS

### DIFF
--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -12,6 +12,8 @@
 <meta content="<%= t('application.description') %>" name="description" />
 <meta content="width=device-width, initial-scale=1" name="viewport" />
 
+<meta name="apple-mobile-web-app-capable" content="yes" />
+
 <%= csrf_meta_tags %>
 
 <meta name="turbo-cache-control" content="no-cache">


### PR DESCRIPTION
This doesn't solve #381 completely, but I think it's a step in the right direction.

I don't think this is necessarily a problem with `_box.html.erb` or Chrome, but with iOS. For example, in this video the website still has the scrolling issue even in Safari, but when adding the page to the home screen and scrolling from there (also after adding the meta tag in this PR), there is no bounce/double scroll issue:

https://user-images.githubusercontent.com/10546292/190663041-4991406a-f427-4ea6-8d0f-047acd4d7a44.mov

I'm convinced that it's because we're not minimizing the address bar when we scroll down the page. I'm finding a lot of different suggestions online for minimizing the address bar when scrolling down, but no luck so far.

Here's a comparison with Tailwind's website:

https://user-images.githubusercontent.com/10546292/190663742-06ac394c-aa53-4af8-a4fd-441875f0dfe3.mov
