### PR TITLE
Test selecting time-zone during signup

### DIFF
--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -187,10 +187,12 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
     field = find("label", text: /\A#{label}\z/)
     field.click
     "#{string}\n".chars.each do |digit|
-      within(field.find(:xpath, "..")) do
-        find(".select2-search__field").send_keys(digit)
-      end
+      active_element.send_keys(digit)
     end
+  end
+  
+  def active_element
+    page.driver.browser.switch_to.active_element
   end
 
   # https://stackoverflow.com/a/50794401/2414273

--- a/test/system/authentication_test.rb
+++ b/test/system/authentication_test.rb
@@ -36,6 +36,9 @@ class AuthenticationSystemTest < ApplicationSystemTestCase
       fill_in "First Name", with: "Testy"
       fill_in "Last Name", with: "McTesterson"
       fill_in "Your Team Name", with: "The Testing Team"
+      
+      select2_select "Your Time Zone", "Tokyo"
+      
       click_on "Next"
 
       # sign out.


### PR DESCRIPTION
The process of selecting a time-zone during sign up is cumbersome because [too many clicks are needed to use type-ahead search for `super_select` field that allow a single selection](https://github.com/bullet-train-co/bullet_train-fields/issues/35).

Also, the existing `select2_select` helper only works with `super_select` fields that allow multiple selections.

This PR:

* Makes the `select2_select` helper work with `super_select` fields that allow only a single selection. It simulates typing into the un-opened field and continues to type with the super_select dropdown opened and the input field in focus.
* Adds a step to `authentication_test` to select the Time Zone during sign up.

Co-dependent PRs (required for the test to pass):
* https://github.com/bullet-train-co/bullet_train-themes/pull/21
* https://github.com/bullet-train-co/bullet_train-fields/pull/36
