### PR TITLE
Add window.Stimulus for help debugging, even in production

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -9,10 +9,11 @@ import consumer from '../channels/consumer'
 
 const application = Application.start()
 
-// https://stimulus.hotwired.dev/handbook/installing#debugging
-// Use `window.Stimulus.debug = true` in the console to log actions and lifecycle hooks
-// on subsequent user interactions and Turbo page views.
-// Use `window.Stimulus.router.modulesByIdentifier` for a list of loaded controllers.
+// In the browser console:
+// * Type `window.Stimulus.debug = true` to log actions and lifecycle hooks
+//   on subsequent user interactions and Turbo page views.
+// * Type `window.Stimulus.router.modulesByIdentifier` for a list of loaded controllers.
+// See https://stimulus.hotwired.dev/handbook/installing#debugging
 window.Stimulus = application
 
 // Load all the controllers within this directory and all subdirectories.

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -9,6 +9,12 @@ import consumer from '../channels/consumer'
 
 const application = Application.start()
 
+// https://stimulus.hotwired.dev/handbook/installing#debugging
+// Use `window.Stimulus.debug = true` in the console to log actions and lifecycle hooks
+// on subsequent user interactions and Turbo page views.
+// Use `window.Stimulus.router.modulesByIdentifier` for a list of loaded controllers.
+window.Stimulus = application
+
 // Load all the controllers within this directory and all subdirectories.
 // Controller files must be named *_controller.js.
 import { context as controllersContext } from './**/*_controller.js';


### PR DESCRIPTION
To help debug Stimulus controllers, this PR adds `window.Stimulus` and a comment to hint on two common ways to use it (debugging events and finding the list of loaded controllers).

It's arguably safe to use in production, unless Stimulus controllers expose methods that access resources that aren't protected by the application, which should be dealt with at the application level.