### PR TITLE
Add the Roles::User module to User

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ApplicationRecord
   include Users::Base
+  include Roles::User
   # 🚅 add concerns above.
 
   # 🚅 add belongs_to associations above.


### PR DESCRIPTION
The bullet_train-roles gem requires this module to be included in the User model.

We didn't notice it was missing before because we were accidentally overloading the methods it adds in the bullet_train-base gem.

We're currently working on an update (https://github.com/bullet-train-co/bullet_train-roles/pull/20) to the roles gem that changes some of the method signatures and breaks the overloaded versions of the methods.  I've added another PR to remove the overloaded methods from the bullet_train-base gem here (https://github.com/bullet-train-co/bullet_train-base/pull/121).

In order to do the update to the roles gem, we need to remove the overloaded versions of the methods _and_ add the required module in to the User class.

We can either add the `Roles::User` module directly to the User class like I've done in this PR, or we could add it into the `Users::Base` module.  My feeling is that is should actually go directly into the User class because it demonstrates to developers what they would need to do if they want to add another model to their application that could also have roles.  However, I'm happy to move it into the `Users::Base` module instead if you think that's a better place for it (it does keep the User class clean that way!).