### PR TITLE
Edit Render deploy button to deploy per application

### DIFF
--- a/README.example.md
+++ b/README.example.md
@@ -20,3 +20,11 @@
 
 ## Information about Bullet Train
 If this is your first time working on a Bullet Train application, be sure to review the [Bullet Train Basic Techniques](https://bullettrain.co/docs/getting-started) and the [Bullet Train Developer Documentation](https://bullettrain.co/docs).
+
+### Render
+
+[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/bullet-train-co/bullet_train)
+
+Clicking this button will take you to the first step of a process that, when completed, will provision production-grade infrastructure for your Bullet Train application which will cost about **$30/month**.
+
+When you're done deploying to Render, you need to go into "Dashboard" > "web", copy the server URL, and then go into "Env Groups" > "settings" and paste the URL into the value for `BASE_URL`.

--- a/bin/configure
+++ b/bin/configure
@@ -185,12 +185,14 @@ replace_in_file("./config/locales/en/application.en.yml", "untitled application"
 replace_in_file("./config/locales/en/user_mailer.en.yml", "Untitled Application", human)
 puts ""
 
+if skip_github
+  original_repo_link = "https://github.com/bullet-train-co/bullet_train"
+  new_repo_link = ask "What is the link to your repository? We will use this to enable the one-click deploy to Render button for your application."
+  replace_in_file("README.md", original_repo_link, new_repo_link, /repo=#{original_repo_link}/)
+end
+
 puts "Moving `./README.example.md` to `./README.md`.".green
 puts `mv ./README.example.md ./README.md`.chomp
-
-unless skip_github
-  repo_link = ask "What is the link to your repository? We will use this to enable the one-click deploy to Render button for your application."
-end
 
 puts `rm .github/FUNDING.yml`.chomp
 

--- a/bin/configure
+++ b/bin/configure
@@ -188,7 +188,7 @@ puts ""
 if skip_github
   original_repo_link = "https://github.com/bullet-train-co/bullet_train"
   new_repo_link = ask "What is the link to your repository? We will use this to enable the one-click deploy to Render button for your application."
-  replace_in_file("README.md", original_repo_link, new_repo_link, /repo=#{original_repo_link}/)
+  replace_in_file("README.example.md", original_repo_link, new_repo_link, /repo=#{original_repo_link}/)
 end
 
 puts "Moving `./README.example.md` to `./README.md`.".green

--- a/bin/configure
+++ b/bin/configure
@@ -185,7 +185,7 @@ replace_in_file("./config/locales/en/application.en.yml", "untitled application"
 replace_in_file("./config/locales/en/user_mailer.en.yml", "Untitled Application", human)
 puts ""
 
-if skip_github
+unless skip_github
   original_repo_link = "https://github.com/bullet-train-co/bullet_train"
   new_repo_link = ask "What is the link to your repository? We will use this to enable the one-click deploy to Render button for your application."
   replace_in_file("README.example.md", original_repo_link, new_repo_link, /repo=#{original_repo_link}/)

--- a/bin/configure
+++ b/bin/configure
@@ -188,6 +188,10 @@ puts ""
 puts "Moving `./README.example.md` to `./README.md`.".green
 puts `mv ./README.example.md ./README.md`.chomp
 
+unless skip_github
+  repo_link = ask "What is the link to your repository? We will use this to enable the one-click deploy to Render button for your application."
+end
+
 puts `rm .github/FUNDING.yml`.chomp
 
 # We can only do this after the README is moved into place.


### PR DESCRIPTION
Context: https://discord.com/channels/836637622432170028/836637623048601633/1024027106189000714

The Render deploy button deploys whichever repo is passed to the `repo` parameter in the link. This PR makes sure the deploy button points to the right repo whenever a developer creates a new Bullet Train application.

The README looks like this after running the script in `bin/configure`.
![render deploy](https://user-images.githubusercontent.com/10546292/192463349-80de2cf7-2098-46a9-a408-80ba46ac8d25.png)
