### PR TITLE
Add `current_version_number` as attribute for API

### DIFF
--- a/config/initializers/api.rb
+++ b/config/initializers/api.rb
@@ -1,1 +1,2 @@
 BulletTrain::Api.current_version = "v1"
+BulletTrain::Api.current_version_number = 1 # Added for performance reasons.


### PR DESCRIPTION
Details in main PR:
- https://github.com/bullet-train-co/bullet_train-base/pull/127

Joint PR
- https://github.com/bullet-train-co/bullet_train-api/pull/34
