### PR TITLE
Update app.json to reference correct honeybadger addon name

### DIFF
--- a/app.json
+++ b/app.json
@@ -26,7 +26,7 @@
     "cloudinary:starter",
     "scheduler:standard",
     "rails-autoscale:free",
-    "honeybadger:free",
+    "honeybadger:basic",
     "sentry:f1",
     "realemail:free"
   ],


### PR DESCRIPTION
Issue described in #489.

It turns out the free version of the addon is now(?) called `basic` rather than `free`