### PR TITLE
Remove extraneous foreman call in bin/dev

### DIFF
--- a/bin/dev
+++ b/bin/dev
@@ -8,5 +8,3 @@ then
 else
   foreman start -f Procfile.dev "$@"
 fi
-
-bundle exec foreman start -f Procfile.dev "$@"


### PR DESCRIPTION
Extraneous foreman call in bin/dev cause foreman to run again after the initial overmind or foreman process is killed.