### PR TITLE
Precompile and clean assets on Render worker's build command

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -29,7 +29,7 @@ services:
   - type: worker
     name: worker
     env: ruby
-    buildCommand: "bundle install"
+    buildCommand: "bundle install && bundle exec rake assets:precompile && bundle exec rake assets:clean"
     startCommand: "bundle exec sidekiq -t 25"
     envVars:
       - key: DATABASE_URL


### PR DESCRIPTION
Closes #509.

## The problem
For some reason, if we just use `bundle install` for the Sidekiq worker's build command, this won't read all of the assets that we should have available in the pipeline, resulting in a missing file error when trying to run a background job

## The fix
As you can see in [this post in the Render community](https://community.render.com/t/rails-worker-cant-find-assets/4885), other people are running into the same issue where their assets are missing, so they fixed it by changing their worker's build command to
`bundle install && bundle exec rake assets:precompile && bundle exec rake assets:clean`.

This is also showing up in other example blueprints
[Example 1](https://binarysolo.chapter24.blog/deploy-rails-and-sidekiq-to-render-com-using-yaml)
[Example 2](https://dev.to/ayushn21/deploy-rails-and-sidekiq-to-rendercom-using-yaml-346)

## Render's default settings
However, I'm confused because Render's official documentation doesn't tell us to do this.
[Docs with an example blueprint](https://render.com/docs/deploy-rails-sidekiq)
[Example blueprint from render-examples/sidekiq repository](https://github.com/render-examples/sidekiq/blob/27a9062ec43ad5bf38a0b4c849505e2ae1eca58d/render.yaml#L14) (this might be a little different because they're using Sinatra)

As you can see, they only use `bundle install` here.

I propose that we use this new build command, and if Render updates their docs, then we can post it here or in the related issue.