### PR TITLE
[Discussion / WIP]: Allow glob imports / ESbuild config

### DIFF
--- a/app/javascript/channels/index.js
+++ b/app/javascript/channels/index.js
@@ -1,6 +1,4 @@
 // Load all the channels within this directory and all subdirectories.
 // Channel files must be named *_channel.js.
 
-// TODO This doesn't work in esbuild.
-// const channels = require.context('.', true, /_channel\.js$/)
-// channels.keys().forEach(channels)
+import "./channels/**/*_channel.js"


### PR DESCRIPTION
By shipping an ESBuild config, we could pull in Chris' ESbuild-Rails and get glob-imports working.

https://github.com/excid3/esbuild-rails#-usage

Of course it would mean no longer using the CLI and instead doing something like:

```json
{
  "scripts": {
    "build:js": "node esbuild.config.js"
  }
}
```

but it also allows more fine-grained control and allows for future improvements for things like Entrypoint / Shared module splitting when shipping in an ESM format.