### PR TITLE
Add Webhooks::Outgoing::Endpoint to OpenAPI documentation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -295,7 +295,7 @@ GEM
       railties (>= 6.0.0)
     json (2.6.2)
     jwt (2.5.0)
-    knapsack_pro (3.4.1)
+    knapsack_pro (3.4.2)
       rake
     launchy (2.5.0)
       addressable (~> 2.7)

--- a/app/views/api/v1/open_api/index.yaml.erb
+++ b/app/views/api/v1/open_api/index.yaml.erb
@@ -17,6 +17,7 @@ components:
   schemas:
     <%= automatic_components_for Team %>
     <%= automatic_components_for User %>
+    <%= automatic_components_for Webhooks::Outgoing::Endpoint %>
     <%= automatic_components_for Scaffolding::CompletelyConcrete::TangibleThing unless scaffolding_things_disabled? %>
     <%# 🚅 super scaffolding will insert new components above this line. %>
   parameters:
@@ -31,5 +32,6 @@ security:
 paths:
   <%= paths_for Team %>
   <%= paths_for User %>
+  <%= automatic_paths_for Webhooks::Outgoing::Endpoint, Team %>
   <%= automatic_paths_for Scaffolding::CompletelyConcrete::TangibleThing, Scaffolding::AbsolutelyAbstract::CreativeConcept unless scaffolding_things_disabled? %>
   <%# 🚅 super scaffolding will insert new paths above this line. %>


### PR DESCRIPTION
Closes 2nd part of https://github.com/bullet-train-co/bullet_train-outgoing_webhooks/issues/12

I assume tests should pass after https://github.com/bullet-train-co/bullet_train-outgoing_webhooks/pull/16 is merged.