### PR TITLE
Fix: Cuprite logger is defined in options

### DIFF
--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,3 +1,5 @@
+# Force rebuild.
+
 require "test_helper"
 require "capybara/email"
 require "support/waiting"

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -204,13 +204,13 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   end
 
   private def assert_no_js_errors_cuprite &block
-    last_timestamp = page.driver.browser.logger.logs
+    last_timestamp = page.driver.browser.options.logger.logs
       .map(&:timestamp)
       .last || 0
 
     yield
 
-    errors = page.driver.browser.logger.logs
+    errors = page.driver.browser.options.logger.logs
 
     errors = errors.reject { |e| e.timestamp.blank? || e.timestamp < last_timestamp } if last_timestamp > 0
     errors = errors.filter { |e| e.level == "error" }

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,5 +1,3 @@
-# Force rebuild.
-
 require "test_helper"
 require "capybara/email"
 require "support/waiting"


### PR DESCRIPTION
ref: https://github.com/rubycdp/cuprite/commit/682c723b26b7e949df5cba4c4eec302b0d1a20bf