### PR TITLE
Add `bin/secrets` to help configure encrypted secrets.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+/config/credentials/development.key
+/config/credentials/test.key
+/config/credentials/production.key
 
 /app/assets/builds/*
 !/app/assets/builds/.keep

--- a/bin/secrets
+++ b/bin/secrets
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+echo "Generating secret key and encrypted credentials for development."
+EDITOR="cat" bin/rails credentials:edit >> /dev/null
+# This makes sure we add `/config/credentials/development.key` to `.gitignore`.
+EDITOR="cat" bin/rails credentials:edit --environment development >> /dev/null
+mv config/master.key config/credentials/development.key
+mv config/credentials.yml.enc config/credentials/development.yml.enc
+
+echo "Generating secret key and encrypted credentials for test."
+EDITOR="cat" bin/rails credentials:edit >> /dev/null
+# This makes sure we add `/config/credentials/test.key` to `.gitignore`.
+EDITOR="cat" bin/rails credentials:edit --environment test >> /dev/null
+mv config/master.key config/credentials/test.key
+mv config/credentials.yml.enc config/credentials/test.yml.enc
+
+echo "Generating secret key and encrypted credentials for production."
+EDITOR="cat" bin/rails credentials:edit >> /dev/null
+# This makes sure we add `/config/credentials/production.key` to `.gitignore`.
+EDITOR="cat" bin/rails credentials:edit --environment production >> /dev/null
+mv config/master.key config/credentials/production.key
+mv config/credentials.yml.enc config/credentials/production.yml.enc
+
+echo "Finally, generating master secret key and global encrypted credentials."
+EDITOR="cat" bin/rails credentials:edit >> /dev/null

--- a/bin/secrets
+++ b/bin/secrets
@@ -22,4 +22,7 @@ mv config/master.key config/credentials/production.key
 mv config/credentials.yml.enc config/credentials/production.yml.enc
 
 echo "Finally, generating master secret key and global encrypted credentials."
+# This generates a key.
 EDITOR="cat" bin/rails credentials:edit >> /dev/null
+# This removes `secret_key_base` from the file, because we want that to be set on a per-environment basis.
+EDITOR="echo \"# aws:\n#   access_key_id: 123\n#   secret_access_key: 345\n\n\" > " bin/rails credentials:edit

--- a/bin/secrets
+++ b/bin/secrets
@@ -1,28 +1,75 @@
 #!/usr/bin/env bash
 
+echo ""
+echo "DEVELOPMENT"
 echo "Generating secret key and encrypted credentials for development."
 EDITOR="cat" bin/rails credentials:edit >> /dev/null
 # This makes sure we add `/config/credentials/development.key` to `.gitignore`.
 EDITOR="cat" bin/rails credentials:edit --environment development >> /dev/null
 mv config/master.key config/credentials/development.key
-mv config/credentials.yml.enc config/credentials/development.yml.enc
+mv config/credentials.yml.enc config/credentials/development.yml.enc 
+# This adds credentials for Active Record encrypted attributes.
+echo "Generating encrypted keys for Active Record Encryption in development."
+EDITOR="bin/rails db:encryption:init | grep -v 'Add this entry' >>" bin/rails credentials:edit --environment development
+echo ""
+echo "The encryption key for the development environment is stored in \`config/credentials/development.key\` and will not be (and should not be) committed to the repository. Store this somewhere safe and only share it with team members who you trust with your encrypted credentials for the development environment."
+echo ""
+echo "To edit the encrypted credentials for development with VS Code (for example), run:
 
+  EDITOR='code --wait' bin/rails credentials:edit --environment development
+"
+
+echo ""
+echo "TEST"
 echo "Generating secret key and encrypted credentials for test."
 EDITOR="cat" bin/rails credentials:edit >> /dev/null
 # This makes sure we add `/config/credentials/test.key` to `.gitignore`.
 EDITOR="cat" bin/rails credentials:edit --environment test >> /dev/null
 mv config/master.key config/credentials/test.key
 mv config/credentials.yml.enc config/credentials/test.yml.enc
+# This adds credentials for Active Record encrypted attributes.
+echo "Generating encrypted keys for Active Record Encryption in test."
+EDITOR="bin/rails db:encryption:init | grep -v 'Add this entry' >>" bin/rails credentials:edit --environment test
+echo ""
+echo "The encryption key for the test environment is stored in \`config/credentials/test.key\` and will not be (and should not be) committed to the repository. Store this somewhere safe and only share it with team members who you trust with your encrypted credentials for the test environment."
+echo ""
+echo "To edit the encrypted credentials for test with VS Code (for example), run:
 
+  EDITOR='code --wait' bin/rails credentials:edit --environment test
+"
+
+echo ""
+echo "PRODUCTION"
 echo "Generating secret key and encrypted credentials for production."
 EDITOR="cat" bin/rails credentials:edit >> /dev/null
 # This makes sure we add `/config/credentials/production.key` to `.gitignore`.
 EDITOR="cat" bin/rails credentials:edit --environment production >> /dev/null
 mv config/master.key config/credentials/production.key
 mv config/credentials.yml.enc config/credentials/production.yml.enc
+# This adds credentials for Active Record encrypted attributes.
+echo "Generating encrypted keys for Active Record Encryption in production."
+EDITOR="bin/rails db:encryption:init | grep -v 'Add this entry' >>" bin/rails credentials:edit --environment production
+echo ""
+echo "The encryption key for the production environment is stored in \`config/credentials/production.key\` and will not be (and should not be) committed to the repository. Store this somewhere safe and only share it with team members who you trust with your encrypted credentials for the production environment."
+echo ""
+echo "⚠️ Any developer who has access to this secret key and your repository can forge a session allowing them to sign in as any user in production."
+echo ""
+echo "To edit the encrypted credentials for production with VS Code (for example), run:
 
+  EDITOR='code --wait' bin/rails credentials:edit --environment production
+"
+
+echo ""
+echo "GLOBAL"
 echo "Finally, generating master secret key and global encrypted credentials."
 # This generates a key.
 EDITOR="cat" bin/rails credentials:edit >> /dev/null
 # This removes `secret_key_base` from the file, because we want that to be set on a per-environment basis.
-EDITOR="echo \"# aws:\n#   access_key_id: 123\n#   secret_access_key: 345\n\n\" > " bin/rails credentials:edit
+EDITOR="echo \"# aws:\n#   access_key_id: 123\n#   secret_access_key: 345\n\" > " bin/rails credentials:edit
+echo ""
+echo "The global encryption key for all environments is stored in \`config/master.key\` and will not be (and should not be) committed to the repository. Store this somewhere safe and only share it with team members who you trust with your encrypted credentials that are shared in all environments."
+echo ""
+echo "To edit the global encrypted credentials with VS Code (for example), run:
+
+  EDITOR='code --wait' bin/rails credentials:edit
+"


### PR DESCRIPTION
Example output:

```
andrewculver@Andrews-MacBook-Air bullet_train % bin/secrets

DEVELOPMENT
Generating secret key and encrypted credentials for development.
Generating encrypted keys for Active Record Encryption in development.
File encrypted and saved.

The encryption key for the development environment is stored in `config/credentials/development.key` and will not be (and should not be) committed to the repository. Store this somewhere safe and only share it with team members who you trust with your encrypted credentials for the development environment.

To edit the encrypted credentials for development with VS Code (for example), run:

  EDITOR='code --wait' bin/rails credentials:edit --environment development


TEST
Generating secret key and encrypted credentials for test.
Generating encrypted keys for Active Record Encryption in test.
File encrypted and saved.

The encryption key for the test environment is stored in `config/credentials/test.key` and will not be (and should not be) committed to the repository. Store this somewhere safe and only share it with team members who you trust with your encrypted credentials for the test environment.

To edit the encrypted credentials for test with VS Code (for example), run:

  EDITOR='code --wait' bin/rails credentials:edit --environment test


PRODUCTION
Generating secret key and encrypted credentials for production.
Generating encrypted keys for Active Record Encryption in production.
File encrypted and saved.

The encryption key for the production environment is stored in `config/credentials/production.key` and will not be (and should not be) committed to the repository. Store this somewhere safe and only share it with team members who you trust with your encrypted credentials for the production environment.

⚠️ Any developer who has access to this secret key and your repository can forge a session allowing them to sign in as any user in production.

To edit the encrypted credentials for production with VS Code (for example), run:

  EDITOR='code --wait' bin/rails credentials:edit --environment production


GLOBAL
Finally, generating master secret key and global encrypted credentials.
File encrypted and saved.

The global encryption key for all environments is stored in `config/master.key` and will not be (and should not be) committed to the repository. Store this somewhere safe and only share it with team members who you trust with your encrypted credentials that are shared in all environments.

To edit the global encrypted credentials with VS Code (for example), run:

  EDITOR='code --wait' bin/rails credentials:edit

```