### PR TITLE
Remove JSON API related code

### DIFF
--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -1,6 +1,0 @@
-# Be sure to restart your server when you modify this file.
-
-# Add new mime types for use in respond_to blocks:
-# Mime::Type.register "text/richtext", :rtf
-
-Mime::Type.register "application/vnd.api+json", :jsonapi

--- a/test/controllers/api/test.rb
+++ b/test/controllers/api/test.rb
@@ -1,9 +1,4 @@
 class Api::Test < ActionDispatch::IntegrationTest
-  # Since response.parsed_body only works with :json out of the box,
-  # we register this encoder so rails knows how to parse a JSON:API response.
-  ActionDispatch::IntegrationTest.register_encoder :jsonapi,
-    response_parser: ->(body) { JSON.parse(body) }
-
   def access_token
     params = {
       client_id: @platform_application.uid,


### PR DESCRIPTION
There were still a few lines related to JSON API that we don't need anymore, so I deleted them.

I poked around just to make sure there wasn't anything else, but I think that's it. I thought the `to_json_api` method we have in `bullet_train-base` might need to be edited, but we definitely need it get parse the object correctly.