### PR TITLE
Edit commands to install Redis for Gitpod

### DIFF
--- a/gitpod.Dockerfile
+++ b/gitpod.Dockerfile
@@ -8,7 +8,8 @@ RUN _ruby_version=ruby-3.1.2 \
     && printf '{ rvm use $(rvm current); } >/dev/null 2>&1\n' >> "$HOME/.bashrc.d/70-ruby"
 
 # Install Redis.
-RUN sudo apt-get update \
- && sudo apt-get install -y \
-  redis-server \
+RUN curl https://packages.redis.io/gpg | sudo apt-key add - \
+ && echo "deb https://packages.redis.io/deb $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/redis.list \
+ && sudo apt-get update \
+ && sudo apt-get install -y redis \
  && sudo rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Closes #560.

## Now running on Redis v7.0.7
![image](https://user-images.githubusercontent.com/10546292/209270724-1ce38ed3-9dca-47c4-934e-a6d07dd1e730.png)

## Gitpod was installing Redis v5.0.7
We were getting the error because Sidekiq 7 needs Redis 6 to work, but Gitpod was installing v5.0.7.

This is how you install Redis according to [Gitpod's docs](https://www.gitpod.io/guides/gitpodify#redis):

```Dockerfile
FROM gitpod/workspace-full

# Install Redis.
RUN sudo apt-get update \
 && sudo apt-get install -y \
  redis-server \
 && sudo rm -rf /var/lib/apt/lists/*
```

Besides the `gitpod/workspace-full` line, we had everything written correctly. Using `gitpod/workspace-full` doesn't allow us to use our Postgres database, and it doesn't update to the latest version of Redis either.

![image](https://user-images.githubusercontent.com/10546292/209270960-97b492ec-5fa6-4e79-abce-2fd68f9e6146.png)

## Download latest stable version of Redis
I thought it would be best to download the latest stable version, so I'm not pulling Redis from the latest development branch. Also, the original command only installs `redis-server`, but if you install `redis` it will install `redis-server` along with it.

## Test it out
This PR is ready to merge as is, but since Gitpod opens the repository in the branch it's referring to, I made a [test branch here](https://github.com/gazayas/bullet_train/tree/fixes/redis-on-gitpod-test) here in case anyone wants to try it out.

