### PR TITLE
Allow theme tailwind.config.js overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "scripts": {
     "build": "THEME=\"light\" node esbuild.config.js",
     "build:css": "bin/link; THEME=\"light\" yarn build; yarn light:build:css; yarn light:build:mailer:css",
-    "light:build:css": "NODE_PATH=./node_modules tailwindcss -c `bundle exec bin/theme tailwind-config light` -i `bundle exec bin/theme tailwind-stylesheet light` -o ./app/assets/builds/application.light.css --postcss ./postcss.config.js",
+    "light:build:css": "THEME=\"light\" NODE_PATH=./node_modules tailwindcss -c tailwind.config.js -i `bundle exec bin/theme tailwind-stylesheet light` -o ./app/assets/builds/application.light.css --postcss ./postcss.config.js",
     "light:build:mailer:css": "NODE_PATH=./node_modules tailwindcss -c `bundle exec bin/theme tailwind-mailer-config light` -i `bundle exec bin/theme tailwind-stylesheet light` -o ./app/assets/builds/application.mailer.light.css --postcss ./postcss.mailer.config.js"
   }
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,25 @@
+const path = require('path');
+const { execSync } = require("child_process");
+const glob  = require('glob').sync
+
+if (!process.env.THEME) {
+  throw "tailwind.config.js: missing process.env.THEME"
+  process.exit(1)
+}
+  
+const themeConfigFile = execSync(`bundle exec bin/theme tailwind-config ${process.env.THEME}`).toString().trim()
+let themeConfig = require(themeConfigFile)
+
+// *** Uncomment these if required for your overrides ***
+
+// const defaultTheme = require('tailwindcss/defaultTheme')
+// const colors = require('tailwindcss/colors')
+
+// *** Add your own overrides here ***
+
+// themeConfig.theme.extend.fontFamily.sans = ['Custom Font Name', ...themeConfig.theme.extend.fontFamily.sans]
+// themeConfig.theme.extend.fontSize['2xs'] = '.75rem'
+// themeConfig.content.push('./app/additional/path')
+// themeConfig.plugins.push(require('additional-tailwind-plugin'))
+
+module.exports = themeConfig


### PR DESCRIPTION
Fixes #439 

This PR builds on the `execSync` technique introduced by @KonnorRogers in #521 for running `bin/theme` inside a local `tailwind.config.js` file for loading the current theme's tailwind config file and allowing overrides.

* Adds a local `tailwind.config.js`
* Modified `package.json` to load local `tailwind.config.js` with `THEME=\"light\"` ENV var set
* Shows example overrides in local `tailwind.config.js`