### PR TITLE
Tests for redirecting to show page for new records

### DIFF
--- a/test/controllers/account/scaffolding/completely_concrete/tangible_things_controller_test.rb
+++ b/test/controllers/account/scaffolding/completely_concrete/tangible_things_controller_test.rb
@@ -47,7 +47,7 @@ class Account::Scaffolding::CompletelyConcrete::TangibleThingsControllerTest < A
         }
       end
 
-      assert_redirected_to url_for([:account, @absolutely_abstract_creative_concept, :completely_concrete_tangible_things])
+      assert_redirected_to url_for([:account, Scaffolding::CompletelyConcrete::TangibleThing.last])
     end
 
     test "should show tangible_thing" do

--- a/test/system/dates_helper_test.rb
+++ b/test/system/dates_helper_test.rb
@@ -32,6 +32,9 @@ class DatesHelperTest < ApplicationSystemTestCase
 
       time = Scaffolding::CompletelyConcrete::TangibleThing.first.created_at
 
+      # Go to the Tangible Thing's index page.
+      click_on "Back"
+
       # Assert today's date is displayed correctly.
       assert page.has_text? "Today at #{time.strftime("%l:%M %p").strip}"
 

--- a/test/system/super_scaffolding_partial_test.rb
+++ b/test/system/super_scaffolding_partial_test.rb
@@ -43,6 +43,7 @@ class SuperScaffoldingSystemTest < ApplicationSystemTestCase
       assert page.has_content?("Test Files")
       click_on "Add New Test File"
 
+      fill_in "Name", with: "Test File Name"
       assert page.has_content?("Upload New Document")
       attach_file("test/support/foo.txt", make_visible: true)
       click_on "Create Test File"

--- a/test/system/super_scaffolding_partial_test.rb
+++ b/test/system/super_scaffolding_partial_test.rb
@@ -135,7 +135,6 @@ class SuperScaffoldingSystemTest < ApplicationSystemTestCase
       assert page.has_content?("Partial Test was successfully created.")
 
       # Text field
-      click_on "Test Text"
       partial_test = PartialTest.first
       assert_equal partial_test.text_field_test, "Test Text"
       # Boolean Button

--- a/test/system/super_scaffolding_test.rb
+++ b/test/system/super_scaffolding_test.rb
@@ -57,6 +57,7 @@ class SuperScaffoldingSystemTest < ApplicationSystemTestCase
       fill_in "Url", with: "http://example.org/test"
 
       click_on "Create Test Site"
+      click_on "Back"
 
       assert page.has_content? "Below is a list of Test Sites that have been added for Your Team."
 
@@ -111,7 +112,6 @@ class SuperScaffoldingSystemTest < ApplicationSystemTestCase
       click_on "Create Project"
 
       assert page.has_content?("Project was successfully created.")
-      click_on "Some New Example Project"
 
       click_on "Add New Deliverable"
       click_on "Create Deliverable"
@@ -119,7 +119,6 @@ class SuperScaffoldingSystemTest < ApplicationSystemTestCase
       fill_in "Name", with: "Some New Example Deliverable"
       click_on "Create Deliverable"
       assert page.has_content?("Deliverable was successfully created.")
-      click_on "Some New Example Deliverable"
 
       within "ol.breadcrumb" do
         click_on "Projects"
@@ -160,12 +159,16 @@ class SuperScaffoldingSystemTest < ApplicationSystemTestCase
       click_on "Create Tag"
       assert page.has_content? "Tag was successfully created"
 
+      click_on "Back"
+
       click_on "Add New Tag"
       assert page.has_content? "Please provide the details of the new Tag"
 
       fill_in "Name", with: "Two"
       click_on "Create Tag"
       assert page.has_content? "Tag was successfully created"
+
+      click_on "Back"
 
       click_on "Add New Tag"
       assert page.has_content? "Please provide the details of the new Tag"
@@ -174,6 +177,8 @@ class SuperScaffoldingSystemTest < ApplicationSystemTestCase
       click_on "Create Tag"
       assert page.has_content? "Tag was successfully created"
 
+      click_on "Back"
+      assert page.has_content? "Your Team’s Tags"
       click_on "Back"
       assert page.has_content? "Your Team’s Dashboard"
 
@@ -185,7 +190,6 @@ class SuperScaffoldingSystemTest < ApplicationSystemTestCase
       click_on "Create Project"
       assert page.has_content? "Project was successfully created"
 
-      click_on "New Project with Tags"
       assert page.has_content? "Below are the details we have for New Project with Tags"
       assert page.has_content? "One and Two"
     end
@@ -203,7 +207,6 @@ class SuperScaffoldingSystemTest < ApplicationSystemTestCase
       click_on "Create Step"
 
       assert page.has_content?("Step was successfully created.")
-      click_on "Some New Example Step"
 
       click_on "Add New Objective"
       click_on "Create Objective"
@@ -211,7 +214,6 @@ class SuperScaffoldingSystemTest < ApplicationSystemTestCase
       fill_in "Name", with: "Some New Example Objective"
       click_on "Create Objective"
       assert page.has_content?("Objective was successfully created.")
-      click_on "Some New Example Objective"
     end
   end
 
@@ -227,7 +229,6 @@ class SuperScaffoldingSystemTest < ApplicationSystemTestCase
       click_on "Create Insight"
 
       assert page.has_content?("Insight was successfully created.")
-      click_on "Some New Example Insight"
 
       click_on "Add New Character Trait"
       click_on "Create Character Trait"
@@ -235,7 +236,6 @@ class SuperScaffoldingSystemTest < ApplicationSystemTestCase
       fill_in "Name", with: "Some New Example Character Trait"
       click_on "Create Character Trait"
       assert page.has_content?("Character Trait was successfully created.")
-      click_on "Some New Example Character Trait"
     end
   end
 
@@ -251,7 +251,6 @@ class SuperScaffoldingSystemTest < ApplicationSystemTestCase
       click_on "Create Disposition"
 
       assert page.has_content?("Disposition was successfully created.")
-      click_on "Some New Example Disposition"
 
       click_on "Add New Note"
       click_on "Create Note"
@@ -259,7 +258,6 @@ class SuperScaffoldingSystemTest < ApplicationSystemTestCase
       fill_in "Name", with: "Some New Example Note"
       click_on "Create Note"
       assert page.has_content?("Note was successfully created.")
-      click_on "Some New Example Note"
     end
   end
 
@@ -275,7 +273,6 @@ class SuperScaffoldingSystemTest < ApplicationSystemTestCase
       click_on "Create Observation"
 
       assert page.has_content?("Observation was successfully created.")
-      click_on "Some New Example Observation"
 
       click_on "Add New Response"
       click_on "Create Response"
@@ -283,7 +280,6 @@ class SuperScaffoldingSystemTest < ApplicationSystemTestCase
       fill_in "Name", with: "Some New Example Response"
       click_on "Create Response"
       assert page.has_content?("Response was successfully created.")
-      click_on "Some New Example Response"
     end
   end
 

--- a/test/system/tangible_thing_test.rb
+++ b/test/system/tangible_thing_test.rb
@@ -42,7 +42,7 @@ unless scaffolding_things_disabled?
         click_on "Create Tangible Thing"
         assert page.has_content? "Tangible Thing was successfully created."
 
-        click_on "My value for this text field"
+        # Creating a Tangible Thing redirects to its show page.
         assert page.has_content? "Tangible Thing Details"
 
         assert page.has_content? "My value for this text field"

--- a/test/system/webhooks_system_test.rb
+++ b/test/system/webhooks_system_test.rb
@@ -57,6 +57,9 @@ class WebhooksSystemTest < ApplicationSystemTestCase
           perform_enqueued_jobs
         end
 
+        # Go to index page.
+        click_on "Back"
+
         assert_difference "Webhooks::Incoming::BulletTrainWebhook.count", 1, "an inbound webhook should be received" do
           click_on "Add New Tangible Thing"
           fill_in "Text Field Value", with: "Some Other Thing"
@@ -67,7 +70,6 @@ class WebhooksSystemTest < ApplicationSystemTestCase
         end
 
         assert_difference "Webhooks::Outgoing::Delivery.count", 1, "an outbound webhook should be issued" do
-          click_on "Some Thing"
           assert page.has_content? "Tangible Thing Details"
           click_on "Edit Tangible Thing"
           assert page.has_content? "Edit Tangible Thing Details"


### PR DESCRIPTION
These are the tests for https://github.com/bullet-train-co/bullet_train-core/pull/49.
I also fixed a small bug in the Super Scaffolding Partial system test along the way.

These fixes mostly consist of:
1. Clicking "Back" so we can continue the system tests on the model's index page.
2. Deleting unneeded clicks which had no assertions after them inside the Super Scaffolding system test.

## Changelog
I think developers will need to change their tests for Super Scaffolded models, specifically for anything generated by `test/controllers/account/scaffolding/completely_concrete/tangible_things_controller_test.rb`.