### PR TITLE
Update Gemfile.lock for compatibility with Linux

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -356,8 +356,6 @@ GEM
     nokogiri (1.13.10)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
-    nokogiri (1.13.10-x86_64-linux)
-      racc (~> 1.4)
     oauth2 (2.0.9)
       faraday (>= 0.17.3, < 3.0)
       jwt (>= 1.0, < 3.0)
@@ -575,7 +573,6 @@ GEM
     zeitwerk (2.6.6)
 
 PLATFORMS
-  ruby
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
Trying to run anything in the terminal yields the following error:

```
> rails c
Could not find nokogiri-1.13.10-x86_64-linux in locally installed gems
Run `bundle install` to install missing gems.
```

Just had to run `bundle install` and everything started to work as normal.

Details here in the Nokogiri repository: https://github.com/sparklemotion/nokogiri/issues/2740