### PR TITLE
update `bin/configure` to prohibit empty application name

### DIFF
--- a/bin/configure
+++ b/bin/configure
@@ -143,6 +143,10 @@ if skip_github.downcase[0] == "y"
     `#{command} https://github.com/new`
 
     ssh_path = ask "OK, what was the SSH path? (It should look like `git@github.com:your-account/your-new-repo.git`.)"
+    while ssh_path == ""
+      puts "You must provide a path for your new repository.".red
+      ssh_path = ask "What was the SSH path? (It should look like `git@github.com:your-account/your-new-repo.git`.)"
+    end
     puts "Setting repository's `origin` remote to `#{ssh_path}`.".green
     puts `git remote add origin #{ssh_path}`.chomp
   end

--- a/bin/configure
+++ b/bin/configure
@@ -160,6 +160,10 @@ puts "Running `yarn install`.".green
 stream "yarn install"
 
 human = ask "What is the name of your new application in title case? (e.g. \"Some Great Application\")"
+while human == ""
+  puts "You must provide a name for your application.".red
+  human = ask "What is the name of your new application in title case? (e.g. \"Some Great Application\")"
+end
 
 require "rails"
 

--- a/bin/configure
+++ b/bin/configure
@@ -81,7 +81,7 @@ if `brew info 2> /dev/null`.length > 0
   puts "Homebrew is installed.".green
 else
   puts "You don't have Homebrew installed. This isn't necessarily a problem, you might not even be on macOS, but we can't check your dependencies without it.".red
-  input = ask "Try proceeding without Homebrew?"
+  input = ask "Try proceeding without Homebrew? [y/n]"
   if input.downcase[0] == "n"
     exit
   end

--- a/bin/configure
+++ b/bin/configure
@@ -81,7 +81,7 @@ if `brew info 2> /dev/null`.length > 0
   puts "Homebrew is installed.".green
 else
   puts "You don't have Homebrew installed. This isn't necessarily a problem, you might not even be on macOS, but we can't check your dependencies without it.".red
-  input = ask "Try proceeding without Homebrew? [y/n]"
+  input = ask "Try proceeding without Homebrew?"
   if input.downcase[0] == "n"
     exit
   end


### PR DESCRIPTION
On my first time using of Bullet Train, I've opened an issue #607 where I could resolve later the same day. 
I must have put an empty string for some reason when prompted about the name of an application which caused that issue. 

This PR is to prevent this problem if it occurs.

Also I have added `[y/n]` on the first question prompt. 