### PR TITLE
Fix Drop Down Menu for Integration

### DIFF
--- a/app/views/account/shared/_menu.html.erb
+++ b/app/views/account/shared/_menu.html.erb
@@ -8,8 +8,11 @@
   <% end %>
 
   <% integrations = capture do %>
+    <% @last_menu_orientation = @menu_orientation %>
+    <% @menu_orientation = :side %>
     <%= render 'account/integrations/stripe_installations/menu_item' if stripe_enabled? %>
     <%# 🚅 super scaffolding will insert new oauth providers above this line. %>
+    <% @menu_orientation = @last_menu_orientation%>
   <% end %>
 
   <%# We don't want to show this menu section if the menu items only rendered annotations. %>


### PR DESCRIPTION
https://github.com/bullet-train-co/bullet_train/issues/580

Issue:
![image](https://user-images.githubusercontent.com/23139057/211847162-964eb3c3-7863-484d-8199-606761105e0a.png)

The UI for the drop-down menu was broken as shown above because `@menu_orientation` was coming as `top` instead of `side`. The following hack has fixed the issue but I am not sure if this is the correct approach to fix this issue. 

Fixed:
![image](https://user-images.githubusercontent.com/23139057/211846880-ff13c72d-a40a-4786-be42-99f67d0a377a.png)

