### PR TITLE
Ensure new attributes get Super Scaffolded to `Team` and `User` controllers

### DIFF
--- a/app/controllers/account/teams_controller.rb
+++ b/app/controllers/account/teams_controller.rb
@@ -4,11 +4,15 @@ class Account::TeamsController < Account::ApplicationController
   private
 
   def permitted_fields
-    []
+    [
+      # 🚅 super scaffolding will insert new fields above this line.
+    ]
   end
 
   def permitted_arrays
-    {}
+    {
+      # 🚅 super scaffolding will insert new arrays above this line.
+    }
   end
 
   def process_params(strong_params)

--- a/app/controllers/account/users_controller.rb
+++ b/app/controllers/account/users_controller.rb
@@ -4,11 +4,15 @@ class Account::UsersController < Account::ApplicationController
   private
 
   def permitted_fields
-    []
+    [
+      # 🚅 super scaffolding will insert new fields above this line.
+    ]
   end
 
   def permitted_arrays
-    {}
+    {
+      # 🚅 super scaffolding will insert new arrays above this line.
+    }
   end
 
   def process_params(strong_params)


### PR DESCRIPTION
Closes #619

## Set up
I changed the migration we're working with slightly to make testing easier:
```
rails g migration add_weight_goal_to_teams weight_goal:string
bin/super-scaffold crud-field Team weight_goal:text_field
```

## Details
When we Super Scaffold a new attribute, it gets scaffolded to the API controller but not the regular controller. You can tell in this test (`bundle exec rails test test/controllers/account/teams_controller_test.rb:29`) that we handle the strong parameters in [base the API controller in bullet_train-api](https://github.com/bullet-train-co/bullet_train-core/blob/7cf007def6104e2f95a445e218f76148ce249db1/bullet_train-api/app/controllers/concerns/api/v1/teams/controller_base.rb#L6) as expected, but it grabs `permitted_fields` and `permitted_arrays` from the [regular controller](https://github.com/bullet-train-co/bullet_train/blob/main/app/controllers/account/teams_controller.rb), which simply contain empty values:

```
     6: def team_params
     7:   strong_params = params.require(:team).permit(
     8:     *permitted_fields,
     9:     :name,
    10:     :time_zone,
    11:     :locale,
    12:     # 🚅 super scaffolding will insert new fields above this line.
    13:     *permitted_arrays,
    14:     # 🚅 super scaffolding will insert new arrays above this line.
    15:   )
 => 16:   binding.pry
    17: 
    18:   process_params(strong_params)
    19: 
    20:   strong_params
    21: end

[1] pry(#<Account::TeamsController>)> self
=> #<Account::TeamsController:0x00000000035e80>
[2] pry(#<Account::TeamsController>)> permitted_fields
=> []

```

This fix ensures the new attributes get included in `permitted_fields` and `permitted_arrays` when handling strong parameters in the regular `Team` and `User` controllers.

## Newly Super Scaffolded models
Sifting through the code, I noticed we don't have a place for developers to declare `permitted_fields` or `permitted_arrays` for newly Super Scaffolded models. If we have the following model...

```
rails g model Foo team:references title:string
bin/super-scaffold crud Foo Team title:text_field
```

...`permitted_fields` and `permitted_arrays` here simply go back to the base controller, as opposed to an API controller or regular controller that would exist in the starter repository:
```
[1] pry(#<Api::V1::FoosController>)> self.method(:permitted_fields).source_location
=> ["/home/gazayas/work/bt/bullet_train/local/bullet_train-core/bullet_train-api/app/controllers/concerns/api/controllers/base.rb", 56]
[2] pry(#<Api::V1::FoosController>)> self.method(:permitted_arrays).source_location
=> ["/home/gazayas/work/bt/bullet_train/local/bullet_train-core/bullet_train-api/app/controllers/concerns/api/controllers/base.rb", 60]
```

I can work on this next if we want to populate these two methods with new attributes when Super Scaffolding a model.

## Designing our controllers
At first I wanted one place to handle all of the attributes because we're duplicating code here. For example, I thought of adding an `AttributePermissions` module under `app/controllers/concerns`, and then the regular controller and the API controller could both refer to the information there.

After looking through the code a bit more, I noticed we have a few duplicate methods between the `bullet_train` and `bullet_train-api` base controllers. From a design standpoint, my first instinct is to give them ANOTHER base one level below them and put any duplicates we have in there instead. I think that would take some effort though, so I just went with the code in this PR to take care of the issue at hand.