### PR TITLE
Add `@rails/request.js` to starter repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@rails/actioncable": "^7.0.0",
     "@rails/actiontext": "^7.0.0",
     "@rails/activestorage": "^7.0.0",
+    "@rails/request.js": "^0.0.8",
     "@rails/ujs": "^7.0.0",
     "@redocly/cli": "^1.0.0-beta.111",
     "@tailwindcss/forms": "^0.5.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -409,6 +409,11 @@
   dependencies:
     spark-md5 "^3.0.1"
 
+"@rails/request.js@^0.0.8":
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/@rails/request.js/-/request.js-0.0.8.tgz#5e2e8da15013b1af7f04d759e4e9d1cff981865c"
+  integrity sha512-ysHYZDl+XjBwFVXz7EI7XW+ZWiTFY8t7TrC/ahpAPt0p7NE4DZxm1nJQY9gmF4PBf+4pAYa+D/rLIGmrn1ZMvg==
+
 "@rails/ujs@^7.0.0":
   version "7.0.4"
   resolved "https://registry.yarnpkg.com/@rails/ujs/-/ujs-7.0.4.tgz#7fe5387d2d82b0547fdfc6667b424ec119c86b1e"


### PR DESCRIPTION
When running `bin/hack --watch-js bullet_train-sortable`, we get the following error when trying to run the server, and then the server just shuts down. To compensate for this, I added a line in the `bin/hack` task which prompts the developer to have their server running before continuing so the server won't shut down. Either way, this error shows up in the logs.

```
js               | ✘ [ERROR] Could not resolve "@rails/request.js"
js               | 
js               |     .yalc/@bullet-train/bullet-train-sortable/app/assets/javascripts/bullet-train.esm.js:1:92:
js               |       1 │ ...";import{post as t}from"@rails/request.js";function a(e){var n=e...
js               |         ╵                           ~~~~~~~~~~~~~~~~~~~
js               | 
js               |   You can mark the path "@rails/request.js" as external to exclude it from the
js               |   bundle, which will remove this error.
js               | 
js               | resolveDir /home/gazayas/work/bt/bullet_train/app/javascript/controllers
js               | path ./**/*_controller.js
```

You can see at the end of the logs here where it mentions `./**/*_controller.js`. The path here is pointing to my starter repository JS controllers.

We already have [@rails/request.js](https://github.com/rails/requestjs-rails) in `bullet_train-sortable` [here](https://github.com/bullet-train-co/bullet_train-core/blob/fab77efab57126c083e0041f97c0e716560a2ffe/bullet_train-sortable/package.json#L56), so I tried the following things:
1. Updating it from v0.0.6 to 0.0.8
2. Running `yarn build` from within the `bullet_train-sortable` package

Neither of these fixed the issue, so I added the package here to the main repository, which takes care of the issue.

If this gets merged, we can delete these lines in the `bin/hack` task:
https://github.com/bullet-train-co/bullet_train-core/blob/fab77efab57126c083e0041f97c0e716560a2ffe/bullet_train/lib/tasks/bullet_train_tasks.rake#L255-L256