### PR TITLE
Add basic healthcheck endpoint

### DIFF
--- a/config/initializers/new_framework_defaults.rb
+++ b/config/initializers/new_framework_defaults.rb
@@ -22,6 +22,6 @@ Rails.application.config.active_record.belongs_to_required_by_default = true
 
 # Configure SSL options to enable HSTS with subdomains. Previous versions had false.
 Rails.application.config.ssl_options = {
-    hsts: {subdomains: true},
-    redirect: { exclude: -> request { request.path == "/healthcheck" } }
+  hsts: {subdomains: true},
+  redirect: {exclude: ->(request) { request.path == "/healthcheck" }}
 }

--- a/config/initializers/new_framework_defaults.rb
+++ b/config/initializers/new_framework_defaults.rb
@@ -21,4 +21,7 @@ Rails.application.config.active_record.belongs_to_required_by_default = true
 # ActiveSupport.halt_callback_chains_on_return_false = false
 
 # Configure SSL options to enable HSTS with subdomains. Previous versions had false.
-Rails.application.config.ssl_options = {hsts: {subdomains: true}}
+Rails.application.config.ssl_options = {
+    hsts: {subdomains: true},
+    redirect: { exclude: -> request { request.path == "/healthcheck" } }
+}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  get '/healthcheck', to: proc { [200, {}, ["ok"]] }
   # See `config/routes/*.rb` to customize these configurations.
   draw "concerns"
   draw "devise"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  get '/healthcheck', to: proc { [200, {}, ["ok"]] }
+  get "/healthcheck", to: proc { [200, {}, ["ok"]] }
   # See `config/routes/*.rb` to customize these configurations.
   draw "concerns"
   draw "devise"


### PR DESCRIPTION
Helpful for hosting environments which require/allow a healthcheck on the app. Some examples:

* https://docs.aws.amazon.com/apprunner/latest/dg/manage-configure-healthcheck.html
* https://cloud.google.com/run/docs/configuring/healthchecks
* https://render.com/docs/deploys#health-checks
