### PR TITLE
Extract Doorkeeper config settings to `bullet_train-api`

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -27,31 +27,6 @@ module UntitledApplication
     config.i18n.available_locales = YAML.safe_load(File.read("config/locales/locales.yml"), aliases: true).with_indifferent_access.dig(:locales).keys.map(&:to_sym)
     config.i18n.default_locale = config.i18n.available_locales.first
 
-    config.to_prepare do
-      # TODO Is there a way to move this into `bullet_train-api`?
-      Doorkeeper::ApplicationController.layout "devise"
-
-      # TODO Is there a better way to implement this?
-      # This monkey patch is required to ensure the OAuth2 token includes which team was connected to.
-      if Doorkeeper::TokensController
-        class Doorkeeper::TokensController
-          def create
-            headers.merge!(authorize_response.headers)
-
-            user = if authorize_response.is_a?(Doorkeeper::OAuth::ErrorResponse)
-              nil
-            else
-              User.find(authorize_response.token.resource_owner_id)
-            end
-
-            # Add the selected `team_id` to this response.
-            render json: authorize_response.body.merge(user&.teams&.one? ? {"team_id" => user.team_ids.first} : {}),
-              status: authorize_response.status
-          rescue Doorkeeper::Errors::DoorkeeperError => e
-            handle_token_exception(e)
-          end
-        end
-      end
-    end
+    BulletTrain::Api.set_configuration(self)
   end
 end


### PR DESCRIPTION
Addresses the TODO in `config/application.rb` about extracting code in the `config.to_prepare` block to `bullet_train-api`.

Joint PR
- https://github.com/bullet-train-co/bullet_train-core/pull/93

You can see that we still get the devise layout string after loading the environment:
```
> rails c
Loading development environment (Rails 7.0.4)
irb(main):001:0> Doorkeeper::ApplicationController._layout
=> "devise"
```

Also, the code in the monkey patched class is only loaded when calling ` BulletTrain::Api.set_configuration(self)` which I've added here.