### PR TITLE
Update `active_hash` to v3.1.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -165,7 +165,7 @@ group :production do
 end
 
 # TODO Have to specify this dependency here until our changes are in the original package.
-gem "active_hash", github: "bullet-train-co/active_hash"
+gem "active_hash"
 
 # A great debugger.
 gem "pry"

--- a/Gemfile
+++ b/Gemfile
@@ -164,7 +164,7 @@ group :production do
   gem "aws-sdk-s3", require: false
 end
 
-# TODO Have to specify this dependency here until our changes are in the original package.
+# Use Ruby hashes as readonly datasources for ActiveRecord-like models.
 gem "active_hash"
 
 # A great debugger.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,4 @@
 GIT
-  remote: https://github.com/bullet-train-co/active_hash.git
-  revision: a6628bc65e7c099ec9428c2bfe1e292ef01f1ef1
-  specs:
-    active_hash (3.1.0)
-      activesupport (>= 5.0.0)
-
-GIT
   remote: https://github.com/teamcapybara/capybara.git
   revision: 69abf9e24cc225aca1ef7e25b1bfb7b61017f017
   specs:
@@ -67,6 +60,8 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    active_hash (3.1.1)
+      activesupport (>= 5.0.0)
     activejob (7.0.4)
       activesupport (= 7.0.4)
       globalid (>= 0.3.6)
@@ -576,7 +571,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  active_hash!
+  active_hash
   aws-sdk-s3
   bootsnap
   bullet_train


### PR DESCRIPTION
Our tests are passing for the official release of `active_hash`, so we don't need to use our own branch for this anymore.
