### PR TITLE
Remove unneeded ignore lines in `.standard.yml`

### DIFF
--- a/.standard.yml
+++ b/.standard.yml
@@ -7,8 +7,3 @@ ignore:
     - Style/CommentedKeyword
   - 'app/controllers/**/*':
     - Style/RedundantAssignment
-  # TODO Remove once https://github.com/testdouble/standard/issues/497 is fixed.
-  - 'config/routes.rb':
-    - Lint/UselessAssignment
-  - 'config/routes/api/v1.rb':
-    - Lint/UselessAssignment


### PR DESCRIPTION
The bug in https://github.com/testdouble/standard/issues/497 has been fixed, so we don't need to ignore these files in `.standard.yml` anymore.

Here are the files where `disable` is being used:
```
> git grep standard:disable
config/routes.rb:  collection_actions = [:index, :new, :create] # standard:disable Lint/UselessAssignment
config/routes/api/v1.rb:collection_actions = [:index, :new, :create] # standard:disable Lint/UselessAssignment
```