### PR TITLE
Skip API configuration if API gem isn't updated

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -28,6 +28,6 @@ module UntitledApplication
     config.i18n.default_locale = config.i18n.available_locales.first
     config.assets.paths << Rails.root.join("app", "assets", "fonts")
 
-    BulletTrain::Api.set_configuration(self)
+    BulletTrain::Api.set_configuration(self) if BulletTrain::Api.respond_to?(:set_configuration)
   end
 end


### PR DESCRIPTION
I don't really want to have this line here long term, but if developers update the starter repository before updating core, they'll get this error:

```
> rake db:migrate
rake aborted!
NoMethodError: undefined method `set_configuration' for BulletTrain::Api:Module
/home/gazayas/work/bt/bullet_train/config/application.rb:31:in `<class:Application>'
/home/gazayas/work/bt/bullet_train/config/application.rb:13:in `<module:UntitledApplication>'
/home/gazayas/work/bt/bullet_train/config/application.rb:12:in `<top (required)>'
/home/gazayas/work/bt/bullet_train/Rakefile:4:in `require_relative'
/home/gazayas/work/bt/bullet_train/Rakefile:4:in `<top (required)>'
(See full trace by running task with --trace)
```

This is because the API gem hasn't been updated yet, which has the `set_configuration` method.