### PR TITLE
Speed up Application Platform system test

### DIFF
--- a/test/system/application_platform_test.rb
+++ b/test/system/application_platform_test.rb
@@ -69,7 +69,7 @@ class ApplicationPlatformSystemTest < ApplicationSystemTestCase
         refute page.has_content?("Test Platform Application")
       end
       # The tombstones partial won't be rendered if there aren't any tombstoned memberships.
-      refute all("h2").map { |tag| tag.text }.include?("Former Team Members")
+      assert_no_selector "h2", text: "Former Team Members"
 
       # The Membership was archived but not destroyed.
       test_app_membership = Membership.find_by(user_first_name: "Test Platform Application")

--- a/test/system/application_platform_test.rb
+++ b/test/system/application_platform_test.rb
@@ -69,7 +69,7 @@ class ApplicationPlatformSystemTest < ApplicationSystemTestCase
         refute page.has_content?("Test Platform Application")
       end
       # The tombstones partial won't be rendered if there aren't any tombstoned memberships.
-      refute all('h2').map{|tag| tag.text}.include?("Former Team Members")
+      refute all("h2").map { |tag| tag.text }.include?("Former Team Members")
 
       # The Membership was archived but not destroyed.
       test_app_membership = Membership.find_by(user_first_name: "Test Platform Application")

--- a/test/system/application_platform_test.rb
+++ b/test/system/application_platform_test.rb
@@ -69,8 +69,7 @@ class ApplicationPlatformSystemTest < ApplicationSystemTestCase
         refute page.has_content?("Test Platform Application")
       end
       # The tombstones partial won't be rendered if there aren't any tombstoned memberships.
-      # TODO: This eats up a lot of time, look for a better way to check for this.
-      refute page.has_css?("tbody[data-model='Membership'][data-scope='tombstones']")
+      refute all('h2').map{|tag| tag.text}.include?("Former Team Members")
 
       # The Membership was archived but not destroyed.
       test_app_membership = Membership.find_by(user_first_name: "Test Platform Application")


### PR DESCRIPTION
Addresses the TODO in `test/system/application_platform_test.rb`

## Before
```
Finished in 37.252439s, 0.0268 runs/s, 0.2148 assertions/s.
1 runs, 8 assertions, 0 failures, 0 errors, 0 skips
```

## After
```
Finished in 21.607441s, 0.0463 runs/s, 0.3702 assertions/s.
1 runs, 8 assertions, 0 failures, 0 errors, 0 skips
```