### PR TITLE
Upgrade to Devise 4.9.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -232,7 +232,7 @@ GEM
       irb (>= 1.5.0)
       reline (>= 0.3.1)
     debug_inspector (1.1.0)
-    devise (4.8.1)
+    devise (4.9.0)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
       railties (>= 4.1.0)

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,6 +1,9 @@
 # Use this hook to configure devise mailer, warden hooks and so forth.
 # Many of these configuration options can be set straight in your model.
 Devise.setup do |config|
+  config.responder.error_status = :unprocessible_entity
+  config.responder.redirect_status = :see_other
+
   config.omniauth :stripe_connect, ENV["STRIPE_CLIENT_ID"], ENV["STRIPE_SECRET_KEY"], scope: "read_write"
   # 🚅 super scaffolding will insert new oauth providers above this line.
 
@@ -32,7 +35,6 @@ Devise.setup do |config|
 
   # NOTE: This is a workaround to get Devise working with Turbo
   # Configure the parent controller.
-  config.parent_controller = "TurboDeviseController"
   config.navigational_formats = ["*/*", :html, :turbo_stream]
 
   # ==> ORM configuration

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,7 +1,7 @@
 # Use this hook to configure devise mailer, warden hooks and so forth.
 # Many of these configuration options can be set straight in your model.
 Devise.setup do |config|
-  config.responder.error_status = :unprocessible_entity
+  config.responder.error_status = :unprocessable_entity
   config.responder.redirect_status = :see_other
 
   config.omniauth :stripe_connect, ENV["STRIPE_CLIENT_ID"], ENV["STRIPE_SECRET_KEY"], scope: "read_write"


### PR DESCRIPTION
Joint PR
- https://github.com/bullet-train-co/bullet_train-core/pull/123

## Details
Looking at the [upgrade guide](https://github.com/heartcombo/devise/wiki/How-To:-Upgrade-to-Devise-4.9.0-%5BHotwire-Turbo-integration%5D), it seems that the change here in the initalizer is the only change we'll need.

These two lines are now added by default in v4.9.0 when running `rails g devise:install`.

We may have to make some changes concerning `data-confirm` and `data-method`, but tests are passing locally for me with https://github.com/bullet-train-co/bullet_train-core/pull/123, so I think we should be okay for now.