### PR TITLE
Enroll in Showcase's testing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -178,3 +178,6 @@ gem "pry"
 # that you run into a merge conflict in the future.
 
 # 🚅 super scaffolding will insert new oauth providers above this line.
+
+gem "showcase-rails" # TODO: Remove after shipping >= 1.2.11 of bullet_train, where showcase-rails is a dependency.
+gem "rouge", "~> 4.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -470,6 +470,7 @@ GEM
       netrc (~> 0.8)
     rexml (3.2.5)
     rotp (6.2.2)
+    rouge (4.1.0)
     rqrcode (2.1.2)
       chunky_png (~> 1.0)
       rqrcode_core (~> 1.0)
@@ -505,6 +506,8 @@ GEM
       sentry-ruby (~> 5.8.0)
       sidekiq (>= 3.0)
     sexp_processor (4.16.1)
+    showcase-rails (0.2.5)
+      rails (>= 6.1.0)
     sidekiq (7.0.4)
       concurrent-ruby (< 2)
       connection_pool (>= 2.3.0)
@@ -623,11 +626,13 @@ DEPENDENCIES
   rails_autoscale_agent
   rails_best_practices
   redis (~> 5.0.5)
+  rouge (~> 4.1)
   rqrcode
   selenium-webdriver
   sentry-rails
   sentry-ruby
   sentry-sidekiq
+  showcase-rails (~> 0.2.5)
   simplecov
   sprockets-rails
   standard

--- a/test/views/showcase_test.rb
+++ b/test/views/showcase_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ShowcaseTest < Showcase::PreviewsTest
+  def assert_showcase_preview(id)
+    # Add any custom preview response body assertions here.
+  end
+end


### PR DESCRIPTION
This is just to get things going, we can wait on >= 1.2.11 of bullet_train, so we can remove showcase-rails from the app Gemfile here, I just need it to see the tests run right now.

We bundle `rouge` for out-of-the-box syntax highlighting in Showcase too.