### PR TITLE
Lock debug to prevent CI issue

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,7 +58,9 @@ gem "chronic"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
-  gem "debug", platforms: %i[mri mingw x64_mingw]
+  # TODO: Remove version restriction once Ruby 3.2.2 is released.
+  # See: https://github.com/ruby/debug/issues/898#issuecomment-1451804022
+  gem "debug", "1.7.0", platforms: %i[mri mingw x64_mingw]
 
   # A gem for generating test coverage results in your browser.
   gem "simplecov", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -229,7 +229,9 @@ GEM
     cssbundling-rails (1.1.2)
       railties (>= 6.0.0)
     date (3.3.3)
-    debug (1.7.1)
+    debug (1.7.0)
+      irb (>= 1.5.0)
+      reline (>= 0.3.1)
     debug_inspector (1.1.0)
     devise (4.9.0)
       bcrypt (~> 3.0)
@@ -286,6 +288,9 @@ GEM
       concurrent-ruby (~> 1.0)
     indefinite_article (0.2.5)
       activesupport
+    io-console (0.6.0)
+    irb (1.6.3)
+      reline (>= 0.3.0)
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
@@ -453,6 +458,8 @@ GEM
     redis-client (0.14.0)
       connection_pool
     regexp_parser (2.7.0)
+    reline (0.3.2)
+      io-console (~> 0.5)
     require_all (3.0.0)
     responders (3.1.0)
       actionpack (>= 5.2)
@@ -598,7 +605,7 @@ DEPENDENCIES
   chronic
   colorize
   cssbundling-rails
-  debug
+  debug (= 1.7.0)
   devise
   devise-two-factor
   factory_bot_rails
@@ -637,4 +644,4 @@ RUBY VERSION
    ruby 3.2.1p31
 
 BUNDLED WITH
-   2.4.1
+   2.4.8


### PR DESCRIPTION
On bullet_train-core and other gems, we're seeing CI issues when we're trying to bundle the starter repo Gemfile, which is this issue: https://github.com/ruby/debug/issues/898

Reference build:
https://app.circleci.com/pipelines/github/bullet-train-co/bullet_train-core/613/workflows/1ca785a1-60f4-445c-a7b2-826d27ed3cdb/jobs/1855?invite=true#step-111-220