### PR TITLE
Update .gitignore to not ignore .tool-versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,7 +59,6 @@ Untitled
 .idea/
 
 # Ignore development tools files
-.tool-versions
 .byebug_history
 dump.rdb
 


### PR DESCRIPTION
We don't want to ignore `.tool-versions`.  It's used by `asdf` to determine which version to use for ruby, nodejs, and others.  Ignoring it would be like ignoring `.ruby-version`.