### PR TITLE
Add initializer for Bullet Train configuration

### DIFF
--- a/config/initializers/bullet_train.rb
+++ b/config/initializers/bullet_train.rb
@@ -1,0 +1,4 @@
+BulletTrain.configure do |config|
+  # Uncomment this line if you want to bypass strong passwords.
+  # config.strong_passwords = false
+end


### PR DESCRIPTION
We have a `BulletTrain::Configuration` class, but we don't implement it in any of our initializers, so I added one here.

Joint PR:
- https://github.com/bullet-train-co/bullet_train-core/pull/208