### PR TITLE
Add commented-out theme configurations in initializer

### DIFF
--- a/config/initializers/theme.rb
+++ b/config/initializers/theme.rb
@@ -1,7 +1,7 @@
 # Bullet Train theme configuration.
 
 # Main color
-BulletTrain::Themes::Light.color = :slate
+BulletTrain::Themes::Light.color = :blue
 
 # Navbar orientation
 # BulletTrain::Themes::Light.navigation = :left

--- a/config/initializers/theme.rb
+++ b/config/initializers/theme.rb
@@ -1,1 +1,10 @@
-BulletTrain::Themes::Light.color = :blue
+# Bullet Train theme configuration.
+
+# Main color
+BulletTrain::Themes::Light.color = :slate
+
+# Navbar orientation
+# BulletTrain::Themes::Light.navigation = :left
+#
+# Logo
+# BulletTrain::Themes::Light.show_logo_in_account = true

--- a/config/initializers/theme.rb
+++ b/config/initializers/theme.rb
@@ -1,10 +1,10 @@
 # Bullet Train theme configuration.
 
-# Main color
+# The application's main color scheme.
 BulletTrain::Themes::Light.color = :blue
 
-# Navbar orientation
+# The orientation of the navbar.
 # BulletTrain::Themes::Light.navigation = :left
 #
-# Logo
+# The logo shown in the navbar.
 # BulletTrain::Themes::Light.show_logo_in_account = true


### PR DESCRIPTION
Addresses #666.

We have more options besides `BulletTrain::Themes::Light.color`, but I don't think we document them anywhere, and I think it makes sense to just comment them out here in the initializer similar to something you'd see in `config/environments/development.rb` for example.
```ruby
# Raises error for missing translations.
# config.i18n.raise_on_missing_translations = true
```
