### PR TITLE
Added support for Webhooks::Outgoing::Event to OpenAPI

### DIFF
--- a/app/views/api/v1/open_api/index.yaml.erb
+++ b/app/views/api/v1/open_api/index.yaml.erb
@@ -18,6 +18,7 @@ components:
     <%= automatic_components_for Team %>
     <%= automatic_components_for User %>
     <%= automatic_components_for Webhooks::Outgoing::Endpoint %>
+    <%= automatic_components_for Webhooks::Outgoing::Event %>
     <%= automatic_components_for Scaffolding::CompletelyConcrete::TangibleThing unless scaffolding_things_disabled? %>
     <%# 🚅 super scaffolding will insert new components above this line. %>
   parameters:
@@ -49,5 +50,6 @@ paths:
   <%= paths_for Team %>
   <%= paths_for User %>
   <%= automatic_paths_for Webhooks::Outgoing::Endpoint, Team %>
+  <%= automatic_paths_for Webhooks::Outgoing::Event, Team, except: %i[create update delete] %>
   <%= automatic_paths_for Scaffolding::CompletelyConcrete::TangibleThing, Scaffolding::AbsolutelyAbstract::CreativeConcept unless scaffolding_things_disabled? %>
   <%# 🚅 super scaffolding will insert new paths above this line. %>


### PR DESCRIPTION
All the rest was merged into `bullet_train-outgoing_webhooks` here: https://github.com/bullet-train-co/bullet_train-core/pull/29