### PR TITLE
Cleanup GitHub action when creating new application

### DIFF
--- a/bin/configure
+++ b/bin/configure
@@ -113,6 +113,9 @@ else
   end
 end
 
+File.open('.github/workflows/main.yml', 'w') do |f|
+  f.write("# Use GitHub Actions to automate development workflows for your application: https://docs.github.com/en/actions")
+end
 
 puts "Next, let's push your application to GitHub."
 puts "If you would like to use another service like Gitlab to manage your repository,"

--- a/bin/configure
+++ b/bin/configure
@@ -114,7 +114,7 @@ else
 end
 
 File.open('.github/workflows/main.yml', 'w') do |f|
-  f.write("# Use GitHub Actions to automate development workflows for your application: https://docs.github.com/en/actions")
+  f.write("# Use GitHub Actions to automate development workflows for your application: https://docs.github.com/en/actions\n")
 end
 
 puts "Next, let's push your application to GitHub."


### PR DESCRIPTION
Closes #714 and #703.

Besides changing the CircleCI config to run tests without Knapsack Pro, all tests will now pass when spinning up a new app:

<img width="754" alt="App Without GitHub Action Workflow" src="https://user-images.githubusercontent.com/10546292/229477353-6c25cc43-0a22-4ae0-acf7-c1b317b29049.png">
