### PR TITLE
Fallback to English for locales

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -26,6 +26,7 @@ module UntitledApplication
     config.i18n.load_path += Dir[Rails.root.join("config", "locales", "**", "*.{rb,yml}")]
     config.i18n.available_locales = YAML.safe_load(File.read("config/locales/locales.yml"), aliases: true).with_indifferent_access.dig(:locales).keys.map(&:to_sym)
     config.i18n.default_locale = config.i18n.available_locales.first
+    config.i18n.fallbacks = [:en]
     config.assets.paths << Rails.root.join("app", "assets", "fonts")
 
     BulletTrain::Api.set_configuration(self)


### PR DESCRIPTION
I think we talked about this a long time ago, maybe even before the Tailwind repository, but an error is raised when we don't fallback to the default locale:

<img width="1016" alt="スクリーンショット 2023-04-04 18 39 20" src="https://user-images.githubusercontent.com/10546292/229753040-5fa7f6bb-c444-410b-82eb-e04adde0b6fd.png">

There are some other things I'd like to do with locales, but most of it will most likely take place over at `bullet_train-core`.