### PR TITLE
[Action Required] Prevent merge conflicts for `device_test`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,6 +125,16 @@ jobs:
           environment:
             KNAPSACK_PRO_CI_NODE_TOTAL: 2
 
+      # Run any update scripts + retest
+      - run: bin/updates/system_tests/use_device_test
+      - run:
+          name: Rerun system tests after update
+          command: |
+            export RAILS_ENV=test
+            KNAPSACK_TEST_FILE_PATTERN="test/system/**/*.rb" bundle exec rails "knapsack_pro:queue:minitest[--verbose]"
+          environment:
+            KNAPSACK_PRO_CI_NODE_TOTAL: 16
+
       # If you don't want to use Knapsack Pro, then use this configuration:
       #
       # - run:

--- a/bin/updates/system_tests/use_device_test
+++ b/bin/updates/system_tests/use_device_test
@@ -1,0 +1,37 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "pathname"
+
+Pathname.glob("test/system/**/*.rb") do |path|
+  lines = path.readlines
+  if (devices_line = lines.grep(/@@test_devices\.each do/).first)
+    indentation = devices_line.match(/^\s+/).to_s
+    end_line_index = lines.rindex "#{indentation}end\n"
+
+    # Act on all the lines within the `@@test_devices.each` block
+    lines.slice(lines.index(devices_line).succ...end_line_index).each do |line|
+      # Replace `test` with `device_test`
+      if line.sub!(/(\s+)test/, "\\1device_test")
+        # We're on the test line so also delete the device name suffix pattern, if any
+        line.sub!(/ on(?: a)? #\{device_name\}/, "")
+      end
+
+      # Dedent line by two spaces
+      line.delete_prefix! "  "
+    end
+
+    # Remove `@@test_devices.each` and matching `end` line in reverse so `end` line index doesn't shift.
+    lines.delete_at end_line_index
+    lines.delete devices_line
+
+    # Remove now needless `resize_for(display_details)\n\n`
+    lines.grep(/resize_for\(display_details\)\n/m).each do
+      index = lines.index _1
+      lines.delete_at index # Remove `resize_for` line
+      lines.delete_at index if lines[index].match?(/^\s*\n$/) # Remove \n line, now at the same index.
+    end
+
+    path.write lines.join
+  end
+end


### PR DESCRIPTION
We're adding a new `device_test` helper that simplifies the structure of system tests.

In a following PR (#964) we'll update all of the system tests in the starter repo, but this might cause nasty merge conflicts for downstream developers. To reduce the chances of merge conflicts we're shipping a helper script that will make the expected changes to your system tests.

To use the helper to modify your tests run this in a console (after updating to v1.4.11):

```
bin/update/system_tests/use_device_test
```

Then you should:

* Run the tests to make sure they still pass
* Commit the updated test files
* Update to v1.5.0

### About this change

We've introduced a new `device_test` helper that wraps up some of the implementation
details about running system tests on a variety of devices.

It simplifies the way that we write system tests like this:

```diff
-  @@test_devices.each do |device_name, display_details|
-    test "user can so something on a #{device_name}" do
-      resize_for(display_details)
-      # actual tests here
-    end
-  end
+  device_test "user can do something" do
+    # actual test code
+  end
```

The specific changes are:

* Remove the enclosing @@test_devices.each do block
* Remove one level of indentation from test inside those blocks
* Remove the resize_for(display_details) from tests in those blocks
* Use `device_test` helper to handle running the test on different devices




### Original PR description

Currently, to get device specific tests users have to wrap their tests in `@@test_devices.each`, which kinda spills out implementation details to apps.

Instead, we can add a `device_test` to abstract those details, which means apps get less indentation and less details they need to care about.

We're also introducing a `bin/updates/system_tests/use_device_test` script to help update app system tests. Apps must run this as described in the commit message. In https://github.com/bullet-train-co/bullet_train/pull/964 we'll update Bullet Train itself via the script.

In a later PR, methods like `sign_out_for(display_details)` now being able to just be `sign_out`, as well as the other helpers doing the same.