### PR TITLE
Remove default github workflow file in configure before pushing to github

### DIFF
--- a/bin/configure
+++ b/bin/configure
@@ -113,6 +113,11 @@ else
   end
 end
 
+if File.exist?('.github/workflows/main.yml')
+  puts "Removing default GitHub workflow.".yellow
+  File.delete('.github/workflows/main.yml')
+end
+
 
 puts "Next, let's push your application to GitHub."
 puts "If you would like to use another service like Gitlab to manage your repository,"


### PR DESCRIPTION
Resolves bug reported in the BT Discord channel about failing GitHub jobs

- Removes the included GitHub workflow config to merge main into edge in `bin/configure`
- Guards against throwing a failed job error after pushing to GitHub the first time.

Wasn't sure if it made sense to include a prompt before removing so left that out for the time being.