### PR TITLE
Memberships API

### DIFF
--- a/app/controllers/api/v1/memberships_controller.rb
+++ b/app/controllers/api/v1/memberships_controller.rb
@@ -1,0 +1,21 @@
+class Api::V1::MembershipsController < Api::V1::ApplicationController
+  include Api::V1::Memberships::ControllerBase
+
+  private
+
+  def permitted_fields
+    [
+      # 🚅 super scaffolding will insert new fields above this line.
+    ]
+  end
+
+  def permitted_arrays
+    {
+      # 🚅 super scaffolding will insert new arrays above this line.
+    }
+  end
+
+  def process_params(strong_params)
+    strong_params
+  end
+end

--- a/app/views/api/v1/memberships/_membership.json.jbuilder
+++ b/app/views/api/v1/memberships/_membership.json.jbuilder
@@ -1,0 +1,16 @@
+json.extract! membership,
+  :id,
+  :user_id,
+  :team_id,
+  :invitation_id,
+  :user_first_name,
+  :user_last_name,
+  :user_profile_photo_id,
+  :user_email,
+  :added_by_id,
+  :platform_agent_of_id,
+  :role_ids,
+  :platform_agent,
+  # 🚅 super scaffolding will insert new fields above this line.
+  :created_at,
+  :updated_at

--- a/app/views/api/v1/open_api/index.yaml.erb
+++ b/app/views/api/v1/open_api/index.yaml.erb
@@ -17,6 +17,7 @@ components:
   schemas:
     <%= automatic_components_for Team %>
     <%= automatic_components_for User %>
+    <%= automatic_components_for Membership %>
     <%= automatic_components_for Webhooks::Outgoing::Endpoint %>
     <%= automatic_components_for Webhooks::Outgoing::Event %>
     <%= automatic_components_for Scaffolding::CompletelyConcrete::TangibleThing unless scaffolding_things_disabled? %>
@@ -49,6 +50,7 @@ security:
 paths:
   <%= paths_for Team %>
   <%= paths_for User %>
+  <%= automatic_paths_for Membership, Team %>
   <%= automatic_paths_for Webhooks::Outgoing::Endpoint, Team %>
   <%= automatic_paths_for Webhooks::Outgoing::Event, Team, except: %i[create update delete] %>
   <%= automatic_paths_for Scaffolding::CompletelyConcrete::TangibleThing, Scaffolding::AbsolutelyAbstract::CreativeConcept unless scaffolding_things_disabled? %>

--- a/test/factories/memberships.rb
+++ b/test/factories/memberships.rb
@@ -2,5 +2,19 @@ FactoryBot.define do
   factory :membership do
     association :user
     association :team
+
+    factory :membership_example do
+      team { FactoryBot.example(:team) }
+      user { FactoryBot.example(:user, teams: [team]) }
+      invitation_id { nil }
+      user_first_name { user.first_name }
+      user_last_name { user.last_name }
+      user_profile_photo_id { 1 }
+      user_email { user.email }
+      added_by_id { FactoryBot.example(:user).id }
+      platform_agent_of_id { nil }
+      platform_agent { false }
+      role_ids { ["admin"] }
+    end
   end
 end


### PR DESCRIPTION
That implements memberships API, adds OpenAPI specs, and fixes path examples generation.
Required by https://github.com/bullet-train-co/bullet_train-core/pull/237