### PR TITLE
Use the same ruby version in the Gemfile as in the .ruby-version file

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby "3.2.1"
+ruby(File.read(File.expand_path(".ruby-version", __dir__)))
 
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 7.0.0"


### PR DESCRIPTION
Ruby version (`3.2.1`) is specified in both Gemfile and .ruby-version, these two Ruby versions must be the same in theory. This PR just uses the same Ruby version (in `.ruby-version`) in the `Gemfile` to emphasize the consistency of the Ruby version, which may optimize the development experience a little.