### PR TITLE
Add public home controller view

### DIFF
--- a/app/views/public/home/index.html.erb
+++ b/app/views/public/home/index.html.erb
@@ -1,0 +1,7 @@
+<%= render 'shared/page' do |p| %>
+  <% p.content_for :title, "Public Index Page" %>
+
+  <% p.content_for :body do %>
+    <p>Change the contents of `app/views/public/home/index.html.erb` to edit this view.</p>
+  <% end %>
+<% end %>


### PR DESCRIPTION
Joint PR:
- https://github.com/bullet-train-co/bullet_train-core/pull/119

Since we give developers the option to use `Public::HomeController`, I thought it would be good to provide the index view for them as well. Here's what it looks like when they comment out `include RootRedirect` in the controller and access `localhost:3000`:

![image](https://user-images.githubusercontent.com/10546292/233288582-335bd21c-621e-47c1-a519-ac87a639713a.png)
