### PR TITLE
Update bin/theme for rails 7.1 compatibility

### DIFF
--- a/bin/theme
+++ b/bin/theme
@@ -3,6 +3,7 @@
 # We use this script to find Tailwind and JavaScript-related files according to the theme specified.
 
 require "active_support"
+require "active_support/core_ext"
 require "fileutils"
 
 if ARGV.size < 2


### PR DESCRIPTION
updates `bin/theme` to work with rails main branch. otherwise it breaks with following stacktrace when running `bin/dev`:

```
15:12:56 light-mailer-css.1 | bundler: failed to load command: bin/theme (bin/theme)
15:12:56 light-mailer-css.1 | bin/theme:36:in `select': undefined method `present?' for "/workspaces/workspace":String (NoMethodError)
15:12:56 light-mailer-css.1 | 
15:12:56 light-mailer-css.1 | @candidate_paths = [Dir.pwd, gem_path].select(&:present?)
15:12:56 light-mailer-css.1 |                                       ^^^^^^^
15:12:56 light-mailer-css.1 | Did you mean?  prepend
15:12:56 light-mailer-css.1 |   from bin/theme:36:in `<top (required)>'
15:12:56 light-mailer-css.1 |   from /usr/local/lib/ruby/3.2.0/bundler/cli/exec.rb:58:in `load'
15:12:56 light-mailer-css.1 |   from /usr/local/lib/ruby/3.2.0/bundler/cli/exec.rb:58:in `kernel_load'
15:12:56 light-mailer-css.1 |   from /usr/local/lib/ruby/3.2.0/bundler/cli/exec.rb:23:in `run'
15:12:56 light-mailer-css.1 |   from /usr/local/lib/ruby/3.2.0/bundler/cli.rb:492:in `exec'
15:12:56 light-mailer-css.1 |   from /usr/local/lib/ruby/3.2.0/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
15:12:56 light-mailer-css.1 |   from /usr/local/lib/ruby/3.2.0/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
15:12:56 light-mailer-css.1 |   from /usr/local/lib/ruby/3.2.0/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
15:12:56 light-mailer-css.1 |   from /usr/local/lib/ruby/3.2.0/bundler/cli.rb:34:in `dispatch'
15:12:56 light-mailer-css.1 |   from /usr/local/lib/ruby/3.2.0/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
15:12:56 light-mailer-css.1 |   from /usr/local/lib/ruby/3.2.0/bundler/cli.rb:28:in `start'
15:12:56 light-mailer-css.1 |   from /usr/local/lib/ruby/gems/3.2.0/gems/bundler-2.4.10/libexec/bundle:45:in `block in <top (required)>'
```

for reference see https://guides.rubyonrails.org/active_support_core_extensions.html#loading-all-core-extensions which specifically mentions that it wont load extensions unless explicitly asked to.

rails 7.0.x doesnt need this change; perhaps this was working accidentally. I haven't narrowed it down to the specific rails commit that broke it.

