### PR TITLE
Fix package.json syntax for running bundle script

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "scripts": {
     "build": "THEME=\"light\" node esbuild.config.js",
     "build:css": "bin/link; THEME=\"light\" yarn build; yarn light:build:css; yarn light:build:mailer:css",
-    "light:build:css": "THEME=\"light\" NODE_PATH=./node_modules tailwindcss -c tailwind.config.js -i `bundle exec bin/theme tailwind-stylesheet light` -o ./app/assets/builds/application.light.css --postcss ./postcss.config.js",
-    "light:build:mailer:css": "NODE_PATH=./node_modules tailwindcss -c `bundle exec bin/theme tailwind-mailer-config light` -i `bundle exec bin/theme tailwind-stylesheet light` -o ./app/assets/builds/application.mailer.light.css --postcss ./postcss.mailer.config.js"
+    "light:build:css": "THEME=\"light\" NODE_PATH=./node_modules tailwindcss -c tailwind.config.js -i $(bundle exec bin/theme tailwind-stylesheet light) -o ./app/assets/builds/application.light.css --postcss ./postcss.config.js",
+    "light:build:mailer:css": "NODE_PATH=./node_modules tailwindcss -c $(bundle exec bin/theme tailwind-mailer-config light) -i $(bundle exec bin/theme tailwind-stylesheet light) -o ./app/assets/builds/application.mailer.light.css --postcss ./postcss.mailer.config.js"
   }
 }


### PR DESCRIPTION
Closes #744

I was running into a lot of issues with bootsnap, but eventually got things to work on both MacOS and Ubuntu. [This issue here](https://github.com/Shopify/bootsnap/issues/73) talks about cleaning out bootsnap's cache, so if developers are having trouble after using the new syntax, they can refer to that issue if they're getting the same error output.