### PR TITLE
YAML expects null, not nil

### DIFF
--- a/config/models/billing/products.yml
+++ b/config/models/billing/products.yml
@@ -14,7 +14,7 @@ basic:
   limits:
     memberships:
       have:
-        count: nil
+        count: null
     scaffolding/absolutely_abstract/creative_concepts:
       have:
         count: 50
@@ -45,7 +45,7 @@ pro:
         enforcement: soft
     scaffolding/absolutely_abstract/creative_concepts:
       have:
-        count: nil
+        count: null
   prices:
     pro_monthly_2022:
       amount: 10000


### PR DESCRIPTION
When a YAML parser encounters `nil` it is parsed as the literal string `'nil'`. But when a YAML parser encounters `null` it is parsed as `nil`.

This PR just changes instances of `nil` to `null` in `config/models/produts.yml`.