### PR TITLE
Set the default testing language to English

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,6 +3,9 @@ require_relative "../config/environment"
 require "rails/test_help"
 require "simplecov"
 
+# Set the default language we test in to English.
+I18n.default_locale = :en
+
 # Open coverage/index.html in your browser after
 # running your tests for test coverage results.
 SimpleCov.start "rails"


### PR DESCRIPTION
When setting the default locale to another language and running the tests, most of the test suite fails because we use a lot of string literals as opposed to I18n's `t` method:

[test/system/account_test.rb:40](https://github.com/bullet-train-co/bullet_train/blob/7ced0b8b8bab4c5a0a56f10c0df091411de69fb9/test/system/account_test.rb#LL40C7-L40C58)
```ruby
assert page.has_content?("Signed in successfully.")
```

Since the behavior of the system tests don't really depend on the what language is being output but on the flow of the system as a whole, I think this a viable way to handle our tests unless we want to replace all the strings with locales in the future.