### PR TITLE
Move duplicated code to application system test case

### DIFF
--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -118,6 +118,24 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
     yield
   end
 
+  def within_membership_row(membership)
+    within "tr[data-id='#{membership.id}']" do
+      yield
+    end
+  end
+
+  def within_current_memberships_table
+    within "tbody[data-model='Membership'][data-scope='current']" do
+      yield
+    end
+  end
+
+  def within_former_memberships_table
+    within "tbody[data-model='Membership'][data-scope='tombstones']" do
+      yield
+    end
+  end
+
   def open_mobile_menu
     find("#mobile-menu-open").click
   end

--- a/test/system/application_platform_test.rb
+++ b/test/system/application_platform_test.rb
@@ -1,19 +1,6 @@
 require "application_system_test_case"
 
 class ApplicationPlatformSystemTest < ApplicationSystemTestCase
-  # TODO: Duplicate code, add to application_system_test.rb
-  def within_membership_row(membership)
-    within "tr[data-id='#{membership.id}']" do
-      yield
-    end
-  end
-
-  def within_current_memberships_table
-    within "tbody[data-model='Membership'][data-scope='current']" do
-      yield
-    end
-  end
-
   @@test_devices.each do |device_name, display_details|
     test "visitors can sign-up and manage team members with subscriptions #{billing_enabled? ? "enabled" : "disabled"} on a #{device_name}" do
       resize_for(display_details)

--- a/test/system/invitations_test.rb
+++ b/test/system/invitations_test.rb
@@ -1,24 +1,6 @@
 require "application_system_test_case"
 
 class InvitationDetailsTest < ApplicationSystemTestCase
-  def within_membership_row(membership)
-    within "tr[data-id='#{membership.id}']" do
-      yield
-    end
-  end
-
-  def within_current_memberships_table
-    within "tbody[data-model='Membership'][data-scope='current']" do
-      yield
-    end
-  end
-
-  def within_former_memberships_table
-    within "tbody[data-model='Membership'][data-scope='tombstones']" do
-      yield
-    end
-  end
-
   @@test_devices.each do |device_name, display_details|
     test "visitors can sign-up and manage team members with subscriptions #{billing_enabled? ? "enabled" : "disabled"} on a #{device_name}" do
       resize_for(display_details)

--- a/test/system/membership_test.rb
+++ b/test/system/membership_test.rb
@@ -1,24 +1,6 @@
 require "application_system_test_case"
 
 class MembershipSystemTest < ApplicationSystemTestCase
-  def within_membership_row(membership)
-    within "tr[data-id='#{membership.id}']" do
-      yield
-    end
-  end
-
-  def within_current_memberships_table
-    within "tbody[data-model='Membership'][data-scope='current']" do
-      yield
-    end
-  end
-
-  def within_former_memberships_table
-    within "tbody[data-model='Membership'][data-scope='tombstones']" do
-      yield
-    end
-  end
-
   @@test_devices.each do |device_name, display_details|
     test "visitors can sign-up and manage team members with subscriptions #{billing_enabled? ? "enabled" : "disabled"} on a #{device_name}" do
       resize_for(display_details)


### PR DESCRIPTION
We had some duplicate methods in different places in the system tests, so I placed them all in `test/application_system_test_case.rb`.