### PR TITLE
Directly check if node is installed in bin/configure

### DIFF
--- a/bin/configure
+++ b/bin/configure
@@ -90,20 +90,18 @@ end
 check_package("postgresql@14")
 check_package("redis")
 check_package("icu4c")
-check_package("node")
-
-if `yarn -v 2> /dev/null`.length > 0
-  puts "Yarn is installed.".green
-else
-  puts "You don't have Yarn installed. We can't proceed without it. Try `brew install yarn` or see the installation instructions at https://yarnpkg.com/getting-started/install .".red
-  exit
-end
-
 
 required_node = `cat ./.nvmrc`.strip
-actual_node = `node -v`.strip.gsub("v", "")
+actual_node = begin
+                `node -v`.strip.gsub("v", "")
+              rescue
+                :not_found
+              end
 message = "Bullet Train requires Node.js #{required_node} and `node -v` returns #{actual_node}."
-if Gem::Version.new(actual_node) >= Gem::Version.new(required_node)
+if actual_node == :not_found
+  puts "You don't have Node installed. We can't proceed without it. Try `brew install node`.".red
+  exit
+elsif Gem::Version.new(actual_node) >= Gem::Version.new(required_node)
   puts message.green
 else
   puts message.red
@@ -111,6 +109,13 @@ else
   if input.downcase[0] == "n"
     exit
   end
+end
+
+if `yarn -v 2> /dev/null`.length > 0
+  puts "Yarn is installed.".green
+else
+  puts "You don't have Yarn installed. We can't proceed without it. Try `brew install yarn` or see the installation instructions at https://yarnpkg.com/getting-started/install .".red
+  exit
 end
 
 if File.exist?('.github/workflows/main.yml')


### PR DESCRIPTION
While installing and configuring bullet_train, I noticed that it told me I didn't have node installed because it was checking whether I had installed it using homebrew. While I use homebrew for services, for language runtimes I use another package manager.

My thinking is that just directly checking if node is installed and that it's the right version is a somewhat user-friendlier approach, and that it matches how you handle the ruby version.

I moved the yarn check below the node check and now also fail if node isn't installed because I think this is probably the intended behavior if you're actually checking for presence of the runtime.

This is my first PR so please let me know if this type of PR is welcome and if I need to know anything else with respect to contributing.
