### PR TITLE
Use bundler/inline to install dependencies needed by setup script before bundler has run.

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -1,6 +1,12 @@
 #!/usr/bin/env ruby
-require "fileutils"
-require "colorize"
+
+require 'bundler/inline'
+
+gemfile do
+  source 'https://rubygems.org'
+  require 'fileutils'
+  require 'colorize'
+end
 
 # path to your application root.
 APP_ROOT = File.expand_path("..", __dir__)


### PR DESCRIPTION
Fixes First time bin/setup failures #788