### PR TITLE
Add message for non-MacOS developers in bin/configure

### DIFF
--- a/bin/configure
+++ b/bin/configure
@@ -45,11 +45,14 @@ def ask(string)
 end
 
 def not_installed?(package)
+  return unless Gem::Platform.local.os == "darwin"
   `brew info #{package} | grep "Not installed"`.strip.length > 0
 end
 
 def check_package(package)
-  if not_installed?(package)
+  if Gem::Platform.local.os != "darwin"
+    puts "Skipping check for #{package}, please check manually if you have this package installed on your machine.".yellow
+  elsif not_installed?(package)
     puts "#{package} is not installed via Homebrew. Try running `brew install #{package}`.".red
     input = ask "Try proceeding without #{package}? [y/n]"
     if input.downcase[0] == "n"


### PR DESCRIPTION
Related to #786.

Currently we get the following output when running `bin/configure` in Ubuntu:

```
> bin/configure

Successfully installed colorize-0.8.1
1 gem installed


Successfully installed activesupport-7.0.4.3
1 gem installed

Bullet Train requires Ruby 3.2.2 and `ruby -v` returns ruby 3.2.2 (2023-03-30 revision e51014f9c0) [x86_64-linux].
You don't have Homebrew installed. This isn't necessarily a problem, you might not even be on macOS, but we can't check your dependencies without it.
Try proceeding without Homebrew? [y/n]
y
sh: 1: brew: not found
postgresql@14 is installed via Homebrew.
sh: 1: brew: not found
redis is installed via Homebrew.
sh: 1: brew: not found
icu4c is installed via Homebrew.
sh: 1: brew: not found
node is installed via Homebrew.
Yarn is installed.
Bullet Train requires Node.js 19.3.0 and `node -v` returns 19.3.0.
```

I think checking for packages like what is in #786 is a good way to ensure we cover everything across all platforms. However, we'd have to be very specific for each package since each command and its output will look different.

For example, I wrote a tentative check like this:
```ruby
def not_installed?(package)
  case Gem::Platform.local.os
  when "darwin"
    `brew info #{package} | grep "Not installed"`.strip.length > 0
  when "linux"
    begin
      case package
      when "postgresql@14"
        version = `psql --version`
        version.split("\s")[2].match?(/^14/)
      when "redis"
        `redis-server --version`
      when "icu4c"
        version = `dpkg -l | grep libicu`
        raise Errno::ENOENT if version.empty?
      when "node"
        `node --version`
      end
    rescue Errno::ENOENT # Command not found
      "#{package} is not installed. Please install it first, and then run bin/configure again.".red
    end
  end
end
```

Granted, we can probably just check for these individually instead of through a method like we check for Ruby and Yarn. I think I'll end up doing things that way instead. Still definitely want to merge in #786 since it brought the current issue to attention.