### PR TITLE
Check dependencies for Linux in bin/configure

### DIFF
--- a/bin/configure
+++ b/bin/configure
@@ -142,14 +142,6 @@ else
   end
 end
 
-if `yarn -v 2> /dev/null`.length > 0
-  puts "Yarn is installed.".green
-else
-  puts "You don't have Yarn installed. We can't proceed without it. Try `brew install yarn` or see the installation instructions at https://yarnpkg.com/getting-started/install .".red
-  exit
-end
-
-
 required_node = `cat ./.nvmrc`.strip
 actual_node = begin
                 `node -v`.strip.gsub("v", "")


### PR DESCRIPTION
This PR ensures we have the proper dependencies installed when running `bin/configure` on Linux. It's not as simple as running `check_package` like we do with MacOS, but grabbing the system packages with `dpkg` lets us know if the package is installed or not as long as we know the proper name for it.

I didn't bother too much with `node` because #786 is open, but we can figure out the details if we get a merge conflict later on.