### PR TITLE
Remove version restriction for the debug gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,9 +58,7 @@ gem "chronic"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
-  # TODO: Remove version restriction once Ruby 3.2.2 is released.
-  # See: https://github.com/ruby/debug/issues/898#issuecomment-1451804022
-  gem "debug", "1.8.0", platforms: %i[mri mingw x64_mingw]
+  gem "debug", platforms: %i[mri mingw x64_mingw]
 
   # A gem for generating test coverage results in your browser.
   gem "simplecov", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -623,7 +623,7 @@ DEPENDENCIES
   chronic
   colorize
   cssbundling-rails
-  debug (= 1.8.0)
+  debug
   devise
   devise-two-factor
   factory_bot_rails


### PR DESCRIPTION
The issue over at `debug` is now closed and we're using Ruby 3.2.2, so I removed the version restriction.