### PR TITLE
Fix: Properly assign entrypoints key-value pairs

### DIFF
--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -54,11 +54,11 @@ if (process.env.THEME) {
 
 // Could also swap to packs?
 const otherEntrypoints = {}
-glob("app/javascript/entrypoints/**/*.js")
+glob("app/javascript/entrypoints/**/*.*")
   .forEach((file) => {
     // strips app/javascript/entrypoints from the key.
-    const key = path.join(path.dirname(file), path.basename(file)).split(path.sep + "entrypoints" + path.sep)[1]
-    const value = "." + path.sep + path.join(path.dirname(file), path.basename(file), path.extname(file))
+    const key = path.join(path.dirname(file), path.parse(file).name).split(path.sep + "entrypoints" + path.sep)[1]
+    const value = "." + path.sep + path.join(path.dirname(file), path.basename(file))
     otherEntrypoints[key] = value
   });
 


### PR DESCRIPTION
I added a file to `app/javascript/entrypoints` and I couldn't start the server.

```js
// app/javascript/entrypoints/react.js

console.log("asd");
```

I got this error:

```
js        | Started with pid 42609...
yarn run v1.22.17
yarn run v1.22.17
$ THEME="light" node esbuild.config.js --watch
$ THEME="light" NODE_PATH=./node_modules tailwindcss -c tailwind.config.js -i $(bundle exec bin/theme tailwind-stylesheet light) -o ./app/assets/builds/application.light.css --postcss ./postcss.config.js --watch
js        | ✘ [ERROR] Cannot read directory "app/javascript/entrypoints/react.js": not a directory
js        |
js        | ✘ [ERROR] Cannot read directory "app/javascript/entrypoints/react.js": not a directory
js        |
js        | ✘ [ERROR] Could not resolve "./app/javascript/entrypoints/react.js/.js"
js        |
js        | resolveDir /Users/viktor/Developer/Shopify/Meillart/le-meillart-rails/app/javascript/controllers
js        | path ./**/*_controller.js
error Command failed with exit code 1.
```

Seems like `path.basename(file)` returns the file name with the extension:
https://nodejs.org/api/path.html#path_path_parse_path
https://nodejs.org/api/path.html#pathbasenamepath-suffix

So this part of code:

```js
// esbuild.config.js
const otherEntrypoints = {}
glob("app/javascript/entrypoints/**/*.js")
  .forEach((file) => {
    // strips app/javascript/entrypoints from the key.
    const key = path.join(path.dirname(file), path.basename(file)).split(path.sep + "entrypoints" + path.sep)[1]
    const value = "." + path.sep + path.join(path.dirname(file), path.basename(file), path.extname(file))
    console.log({key, value})
    otherEntrypoints[key] = value
  });
```

Prints this:

```js
{ key: 'react.js', value: './app/javascript/entrypoints/react.js/.js' }
```

Instead of this:

```js
{ key: 'react', value: './app/javascript/entrypoints/react.js' }
```

This PR fixes that and also allows any file extension for any file in `app/javascript/entrypoints`.
Why any file?

First because it's `app/javascript/entrypoints` and second because I want to use `app/javascript/entrypoints/react.jsx` and `app/javascript/entrypoints/react.tsx` for example.
And Vue has `.vue` files.

I'd say it's a mistake to put any non-entrypoint file in `app/javascript/entrypoints` (like images, fonts, etc.)

Allowing any file probably allows for having `.css` or `.scss` entrypoint files. These could be valid (stylesheet) entrypoint files, which is good. (`<%= stylesheet_link_tag "application"  %>`)

Cool thing is, I tried renaming `react.js` to `react.tsx`, ran `yarn add react react-dom typescript` and it worked!

Here's my simple TSX React component that renders just fine when included on the page with `<%= javascript_include_tag 'react' %>`:

```tsx
import React from "react";
import { createRoot } from "react-dom/client";

const asd: string = "asd";
console.log("asd");

// // Render your React component instead
const root = createRoot(document.getElementById("react-root"));
root.render(<h1>Hello, {asd}</h1>);
```