### PR TITLE
Add resolver test for partial invocation string

### DIFF
--- a/test/system/resolver_system_test.rb
+++ b/test/system/resolver_system_test.rb
@@ -9,6 +9,13 @@ class ResolverSystemTest < ApplicationSystemTestCase
     assert `bin/resolve BulletTrain::Resolver`.include?("lib/bullet_train/resolver.rb")
   end
 
+  test "bin/resolve can resolve `shared/attributes/text`" do
+    themes_gem = `bundle show bullet_train-themes`.chomp
+    view_path = "app/views/themes/base/attributes/_text.html.erb"
+    absolute_path = themes_gem + "/" + view_path
+    assert `bin/resolve shared/attributes/text`.include?(absolute_path)
+  end
+
   unless ENV["SKIP_RESOLVE_TEST"].present?
     test "`bin/resolve` can resolve `shared/box`" do
       # TODO Figure out how to make this test pass when we're working on a checked out copy of the theme.


### PR DESCRIPTION
Since `bin/resolve` depends on the gem installation path and gem version to return the proper result, we use `bundle show` to get the gem's proper path.

https://github.com/bullet-train-co/bullet_train-core/pull/350 uses mock strings to test resolving for annotated paths like `<!-- BEGIN ... -->`, and although we can use `bundle show` to access some of the gems in that directory, we don't have access to ones like `bullet_train-themes-light`.

This presents two issues for me. Writing tests long-term, I think that:
1. The tests should have knowledge of the environment so when we test the other functionalities of `bin/resolve`, we can write tests like the one I have written in this PR.
2. Because of that I would rather not split the tests between two different repositories, so I think it would be beneficial to keep them here instead of write new ones over at `bullet_train-core/bullet_train`.

The only thing is we don't have direct access to the rake tasks in the starter repository (See the [bin/resolve](https://github.com/bullet-train-co/bullet_train/blob/main/bin/resolve) file), so this complicates things when trying to write tests here.

I think there are parts of the resolver that are higher priority (like the locale issue we have at https://github.com/bullet-train-co/bullet_train-core/pull/303), but if we're going to test the `--interactive` flag, I'd rather test with knowledge of the environment. We can merge in https://github.com/bullet-train-co/bullet_train-core/pull/350, but I think it would be ideal to test annotated paths here.

@vfonic.