### PR TITLE
Remove the webdrivers gem and update selenium-webdriver

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -87,11 +87,10 @@ group :test do
   # Selenium is the default default Capybara driver for system tests that ships with
   # Rails. Cuprite is an alternative driver that uses Chrome's native DevTools protocol
   # and offers improved speed and reliability, but only works with Chrome. If you want
-  # to switch to Cuprite, you can comment out the `selenium-webdriver` and `webdrivers`
-  # gems and uncomment the `cuprite` gem below. Bullet Train will automatically load
+  # to switch to Cuprite, you can comment out the `selenium-webdriver` gem
+  # and uncomment the `cuprite` gem below. Bullet Train will automatically load
   # the correct configuration based on which gem is included.
   gem "selenium-webdriver"
-  gem "webdrivers"
 
   # gem "cuprite"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -476,7 +476,7 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    rexml (3.2.5)
+    rexml (3.2.6)
     rotp (6.2.2)
     rqrcode (2.2.0)
       chunky_png (~> 1.0)
@@ -503,7 +503,7 @@ GEM
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
-    selenium-webdriver (4.9.1)
+    selenium-webdriver (4.11.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
@@ -583,10 +583,6 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    webdrivers (5.2.0)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0)
     websocket (1.2.9)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
@@ -656,7 +652,6 @@ DEPENDENCIES
   turbo-rails
   tzinfo-data
   web-console
-  webdrivers
 
 RUBY VERSION
    ruby 3.2.2


### PR DESCRIPTION
Fixes bullet-train-co/bullet_train/issues/818

Previously the `webdrivers` gem was trying to find a version of Chrome that doesn't exist in the old repository. It seems that Chrome has moved where they publish new versions.

The official recommendation from the `webdrivers` gem authors seems to be to remove the `webdrivers` gem entirely, and update `selenium-webdriver` to the latest version. This PR does that.

This gets system tests running, instead of crashing. But there seems to be on system test that fails, and I don't think it's related to a webdriver issue.

```
validating http://localhost:3001/api/v1/openapi.yaml...
Failed to resolve api definition at http://localhost:3001/api/v1/openapi.yaml:

  - request to http://localhost:3001/api/v1/openapi.yaml failed, reason: connect ECONNREFUSED ::1:3001.

/Users/jgreen/projects/bullet-train-co/bullet_train/node_modules/@redocly/openapi-core/lib/resolve.js:119
                throw new ResolveError(error);
                      ^

ResolveError: request to http://localhost:3001/api/v1/openapi.yaml failed, reason: connect ECONNREFUSED ::1:3001
    at BaseResolver.<anonymous> (/Users/jgreen/projects/bullet-train-co/bullet_train/node_modules/@redocly/openapi-core/lib/resolve.js:119:23)
    at Generator.throw (<anonymous>)
    at rejected (/Users/jgreen/projects/bullet-train-co/bullet_train/node_modules/@redocly/openapi-core/lib/resolve.js:6:65)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5) {
  originalError: FetchError: request to http://localhost:3001/api/v1/openapi.yaml failed, reason: connect ECONNREFUSED ::1:3001
      at ClientRequest.<anonymous> (/Users/jgreen/projects/bullet-train-co/bullet_train/node_modules/node-fetch/lib/index.js:1505:11)
      at ClientRequest.emit (node:events:513:28)
      at Socket.socketErrorListener (node:_http_client:490:9)
      at Socket.emit (node:events:513:28)
      at emitErrorNT (node:internal/streams/destroy:151:8)
      at emitErrorCloseNT (node:internal/streams/destroy:116:3)
      at process.processTicksAndRejections (node:internal/process/task_queues:82:21) {
    type: 'system',
    errno: 'ECONNREFUSED',
    code: 'ECONNREFUSED'
  }
}
```

I've had this particular test disabled in my own project ever since I started working with BT because it has never passed for me.