### PR TITLE
Bug fix for #615

### DIFF
--- a/app/views/account/shared/_menu.html.erb
+++ b/app/views/account/shared/_menu.html.erb
@@ -7,13 +7,13 @@
     <% # added by super scaffolding. %>
   <% end %>
 
+  <% @last_menu_orientation = @menu_orientation %>
+  <% @menu_orientation = :side %>
   <% integrations = capture do %>
-    <% @last_menu_orientation = @menu_orientation %>
-    <% @menu_orientation = :side %>
     <%= render 'account/integrations/stripe_installations/menu_item' if stripe_enabled? %>
     <%# 🚅 super scaffolding will insert new oauth providers above this line. %>
-    <% @menu_orientation = @last_menu_orientation%>
   <% end %>
+  <% @menu_orientation = @last_menu_orientation %>
 
   <%# We don't want to show this menu section if the menu items only rendered annotations. %>
   <% if integrations.gsub(/<!--(.*)-->/, "").present? %>


### PR DESCRIPTION
I noticed after I merged #615 (😬 🤦‍♂️) that the tests in `main` were failing. It turns out that having the assignments for `@menu_orientation` inside of the `capture` block made it so that we didn't capture the `render` call, but instead we seem to capture a `nil`. I think this is because that final assignment returns nothing to the template. This moves the assignments outside of the `capture` block.

Fixes #829 
