### PR TITLE
Run tests against released gems and `main` in `core`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,10 @@ jobs:
       - restore_cache: *restore_bundler_cache
       - restore_cache: *restore_yarn_cache
 
-      - run: ./bin/checkout-and-link-core-repo
+      - when:
+          condition: << parameters.use-core-repo >>
+          steps:
+            - run: ./bin/checkout-and-link-core-repo
 
       # Install dependencies
       - ruby/bundle-install
@@ -146,7 +149,10 @@ jobs:
       - restore_cache: *restore_bundler_cache
       - restore_cache: *restore_yarn_cache
 
-      - run: ./bin/checkout-and-link-core-repo
+      - when:
+          condition: << parameters.use-core-repo >>
+          steps:
+            - run: ./bin/checkout-and-link-core-repo
 
       # Install dependencies
       - ruby/bundle-install
@@ -199,7 +205,10 @@ jobs:
       - restore_cache: *restore_bundler_cache
       - restore_cache: *restore_yarn_cache
 
-      - run: ./bin/checkout-and-link-core-repo
+      - when:
+          condition: << parameters.use-core-repo >>
+          steps:
+            - run: ./bin/checkout-and-link-core-repo
 
       # Install dependencies
       - ruby/bundle-install
@@ -235,7 +244,10 @@ jobs:
       - restore_cache: *restore_bundler_cache
       - restore_cache: *restore_yarn_cache
 
-      - run: ./bin/checkout-and-link-core-repo
+      - when:
+          condition: << parameters.use-core-repo >>
+          steps:
+            - run: ./bin/checkout-and-link-core-repo
 
       # Install dependencies
       - ruby/bundle-install
@@ -282,7 +294,10 @@ jobs:
       - restore_cache: *restore_bundler_cache
       - restore_cache: *restore_yarn_cache
 
-      - run: ./bin/checkout-and-link-core-repo
+      - when:
+          condition: << parameters.use-core-repo >>
+          steps:
+            - run: ./bin/checkout-and-link-core-repo
 
       # Install dependencies
       - ruby/bundle-install
@@ -307,8 +322,17 @@ workflows:
     jobs:
       - 'Standard Ruby'
       - 'Database Schema Check'
-      - 'Minitest'
+      - 'Minitest':
+        use-core-repo: true
+      - 'Minitest':
+        use-core-repo: false
       - 'Minitest with HIDE_THINGS'
+        use-core-repo: true
+      - 'Minitest with HIDE_THINGS'
+        use-core-repo: false
       - 'Minitest for Super Scaffolding'
+        use-core-repo: true
+      - 'Minitest for Super Scaffolding'
+        use-core-repo: false
       # - 'System Tests with Cuprite'
       # - 'System Tests for Action Models'

--- a/bin/checkout-and-link-core-repo
+++ b/bin/checkout-and-link-core-repo
@@ -19,45 +19,42 @@ then
 fi
 
 
-if [ $CORE_REPO_BRANCH != "main" ]
-then
-  mkdir core
+mkdir core
 
-  echo "Cloning from ${CORE_REPO_BRANCH}..."
-  git clone -b $CORE_REPO_BRANCH --depth 1 https://github.com/bullet-train-co/bullet_train-core.git ./core
+echo "Cloning from ${CORE_REPO_BRANCH}..."
+git clone -b $CORE_REPO_BRANCH --depth 1 https://github.com/bullet-train-co/bullet_train-core.git ./core
 
-  # TODO: Maybe generate this list automatically based on the subdirectories in core that contain a .gemspec?
-  packages=(
-    "bullet_train"
-    "bullet_train-api"
-    "bullet_train-fields"
-    "bullet_train-has_uuid"
-    "bullet_train-incoming_webhooks"
-    "bullet_train-integrations"
-    "bullet_train-integrations-stripe"
-    "bullet_train-obfuscates_id"
-    "bullet_train-outgoing_webhooks"
-    "bullet_train-roles"
-    "bullet_train-scope_questions"
-    "bullet_train-scope_validator"
-    "bullet_train-sortable"
-    "bullet_train-super_load_and_authorize_resource"
-    "bullet_train-super_scaffolding"
-    "bullet_train-themes"
-    "bullet_train-themes-light"
-    "bullet_train-themes-tailwind_css"
-  )
+# TODO: Maybe generate this list automatically based on the subdirectories in core that contain a .gemspec?
+packages=(
+  "bullet_train"
+  "bullet_train-api"
+  "bullet_train-fields"
+  "bullet_train-has_uuid"
+  "bullet_train-incoming_webhooks"
+  "bullet_train-integrations"
+  "bullet_train-integrations-stripe"
+  "bullet_train-obfuscates_id"
+  "bullet_train-outgoing_webhooks"
+  "bullet_train-roles"
+  "bullet_train-scope_questions"
+  "bullet_train-scope_validator"
+  "bullet_train-sortable"
+  "bullet_train-super_load_and_authorize_resource"
+  "bullet_train-super_scaffolding"
+  "bullet_train-themes"
+  "bullet_train-themes-light"
+  "bullet_train-themes-tailwind_css"
+)
 
-  for package in "${packages[@]}"
-  do
-    :
-    grep -v "gem \"$package\"" Gemfile > Gemfile.tmp
-    mv Gemfile.tmp Gemfile
-    echo "gem \"$package\", path: \"./core/$package\"" >> Gemfile
-  done
+for package in "${packages[@]}"
+do
+  :
+  grep -v "gem \"$package\"" Gemfile > Gemfile.tmp
+  mv Gemfile.tmp Gemfile
+  echo "gem \"$package\", path: \"./core/$package\"" >> Gemfile
+done
 
-  updates="${packages[@]}"
-  bundle lock --update $updates
-fi
+updates="${packages[@]}"
+bundle lock --update $updates
 
 


### PR DESCRIPTION
This makes it so that every PR and every merge to main will run tests in CI against both the released versions of the `core` gems and against a branch in the `core` repo.

For merges to `main` in the starter repo, they'll always run against the latest state of `main` in `core`.

For PRs we'll attempt to find a branch in `core` that matches the name of the branch being tested. If we can find one, we'll test against that. If not we'll test the PR branch against `main` in `core`.

The tests that we run against the released versions of the gems can probably be expected to fail with some regularity since we sometimes introduce changes into the starter repo that depend on particular changes in `core`. But this will help us to know when we've made changes in the starter repo that mean that we need to relase a new version of the `core` gems.