### PR TITLE
[release process] Fix the yarn update statement in bump-core

### DIFF
--- a/bin/bump-core
+++ b/bin/bump-core
@@ -33,7 +33,7 @@ npm_packages=%w(
   @bullet-train/bullet-train-sortable
 )
 
-puts `yarn upgrade #{packages.join(" ")}`
+puts output = `yarn upgrade #{npm_packages.join(" ")}`
 
 puts output = `bundle show bullet_train` # => /some/path/bullet_train-1.3.2
 


### PR DESCRIPTION
Previously we were joining the rub gems names and passing that to `yarn upgrade`, which had no effect. Now we'll pass the actual npm packages that we want to update.