### PR TITLE
Add tests for Stripe webhooks

### DIFF
--- a/test/factories/webhooks/incoming/stripe_installation_webhooks.rb
+++ b/test/factories/webhooks/incoming/stripe_installation_webhooks.rb
@@ -1,8 +1,0 @@
-FactoryBot.define do
-  factory :webhooks_incoming_stripe_installation_webhook, class: "Webhooks::Incoming::StripeInstallationWebhook" do
-    data { "" }
-    processed_at { "2021-03-16 18:04:09" }
-    verified_at { "2021-03-16 18:04:09" }
-    integrations_stripe_installation { nil }
-  end
-end

--- a/test/models/webhooks/incoming/stripe_webhook_test.rb
+++ b/test/models/webhooks/incoming/stripe_webhook_test.rb
@@ -73,7 +73,6 @@ if defined?(BulletTrain::Billing::Stripe)
       def setup
         team = create :team
         stripe_subscription = create :billing_stripe_subscription, team: team
-        puts stripe_subscription.as_json
         @generic_subscription = create :billing_subscription, provider_subscription: stripe_subscription, status: nil
         #create :billing_subscriptions_included_price, subscription: @generic_subscription
         @subscription_created_webhook = create :webhooks_incoming_stripe_webhook,
@@ -90,11 +89,14 @@ if defined?(BulletTrain::Billing::Stripe)
       end
     end
 
+    # Sometimes we recieve a subscription.updated webhook _before_ we recieve
+    # the subscription.created webhook for the same subscription. In that case
+    # we want to make sure that we don't erroneously set the subscription status
+    # back to 'pending' becasue that's confusing for everyone especially customers.
     class SubscriptionInvalidOrderTests < Webhooks::Incoming::StripeWebhookTest
       def setup
         team = create :team
         stripe_subscription = create :billing_stripe_subscription, team: team
-        puts stripe_subscription.as_json
         @generic_subscription = create :billing_subscription, provider_subscription: stripe_subscription, status: nil
         #create :billing_subscriptions_included_price, subscription: @generic_subscription
         @subscription_updated_webhook = create :webhooks_incoming_stripe_webhook,

--- a/test/models/webhooks/incoming/stripe_webhook_test.rb
+++ b/test/models/webhooks/incoming/stripe_webhook_test.rb
@@ -12,15 +12,12 @@ if defined?(BulletTrain::Billing::Stripe)
         "data" => {
           "object" => {
             "id" => stripe_subscription_id,
-            "plan" => {},
             "items" => { "data" => [] },
-            "object" => "subscription",
             "status" => "active",
             "created" => created_at.to_i,
           }
         },
         "type" => "customer.subscription.updated",
-        "object" => "event",
         "created" => created_at.to_i,
       }
     end
@@ -33,15 +30,12 @@ if defined?(BulletTrain::Billing::Stripe)
         "data" => {
           "object" => {
             "id" => stripe_subscription_id,
-            "plan" => {},
             "items" => { "data" => [] },
-            "object" => "subscription",
             "status" => "incomplete",
             "created" => created_at.to_i,
           }
         },
         "type" => "customer.subscription.created",
-        "object" => "event",
         "created" => created_at.to_i,
       }
     end

--- a/test/models/webhooks/incoming/stripe_webhook_test.rb
+++ b/test/models/webhooks/incoming/stripe_webhook_test.rb
@@ -12,7 +12,7 @@ if defined?(BulletTrain::Billing::Stripe)
         "data" => {
           "object" => {
             "id" => stripe_subscription_id,
-            "items" => { "data" => [] },
+            "items" => {"data" => []},
             "status" => "active",
             "created" => created_at.to_i,
           }
@@ -30,7 +30,7 @@ if defined?(BulletTrain::Billing::Stripe)
         "data" => {
           "object" => {
             "id" => stripe_subscription_id,
-            "items" => { "data" => [] },
+            "items" => {"data" => []},
             "status" => "incomplete",
             "created" => created_at.to_i,
           }

--- a/test/models/webhooks/incoming/stripe_webhook_test.rb
+++ b/test/models/webhooks/incoming/stripe_webhook_test.rb
@@ -1,8 +1,6 @@
 require "test_helper"
 
 if defined?(BulletTrain::Billing::Stripe)
-
-  puts Rails.configuration.factory_bot.definition_file_paths
   class Webhooks::Incoming::StripeWebhookTest < ActiveSupport::TestCase
     include ::FactoryBot::Syntax::Methods
     # TODO: Cut this down to just the attributes we need

--- a/test/models/webhooks/incoming/stripe_webhook_test.rb
+++ b/test/models/webhooks/incoming/stripe_webhook_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 if defined?(BulletTrain::Billing::Stripe)
 
@@ -12,8 +12,7 @@ if defined?(BulletTrain::Billing::Stripe)
         "data" => {
           "object" => {
             "id" => stripe_subscription_id,
-            "plan" => {
-            },
+            "plan" => {},
             "items" => {
               "data" => [],
             },
@@ -45,8 +44,7 @@ if defined?(BulletTrain::Billing::Stripe)
         "data" => {
           "object" => {
             "id" => stripe_subscription_id,
-            "plan" => {
-            },
+            "plan" => {},
             "items" => {
               "data" => [],
             },
@@ -76,7 +74,6 @@ if defined?(BulletTrain::Billing::Stripe)
         team = create :team
         stripe_subscription = create :billing_stripe_subscription, team: team
         @generic_subscription = create :billing_subscription, provider_subscription: stripe_subscription, status: nil
-        #create :billing_subscriptions_included_price, subscription: @generic_subscription
         @subscription_created_webhook = create :webhooks_incoming_stripe_webhook,
           data: customer_subscription_created_data(Time.now - 2.minutes, stripe_subscription.stripe_subscription_id)
         @subscription_updated_webhook = create :webhooks_incoming_stripe_webhook,
@@ -100,7 +97,6 @@ if defined?(BulletTrain::Billing::Stripe)
         team = create :team
         stripe_subscription = create :billing_stripe_subscription, team: team
         @generic_subscription = create :billing_subscription, provider_subscription: stripe_subscription, status: nil
-        #create :billing_subscriptions_included_price, subscription: @generic_subscription
         @subscription_updated_webhook = create :webhooks_incoming_stripe_webhook,
           data: customer_subscription_updated_data(Time.now - 2.minutes, stripe_subscription.stripe_subscription_id)
         @subscription_created_webhook = create :webhooks_incoming_stripe_webhook,
@@ -114,7 +110,5 @@ if defined?(BulletTrain::Billing::Stripe)
         assert_equal "active", @generic_subscription.reload.status
       end
     end
-
-
   end
 end

--- a/test/models/webhooks/incoming/stripe_webhook_test.rb
+++ b/test/models/webhooks/incoming/stripe_webhook_test.rb
@@ -1,0 +1,116 @@
+require 'test_helper'
+
+if defined?(BulletTrain::Billing::Stripe)
+  class Webhooks::Incoming::StripeWebhookTest < ActiveSupport::TestCase
+    include ::FactoryBot::Syntax::Methods
+    # TODO: Cut this down to just the attributes we need
+    def customer_subscription_updated_data(created_at, stripe_subscription_id)
+      {
+        "id" => "evt_1NgIq2BiWqhbiHpFXvtRJZtY",
+        "data" => {
+          "object" => {
+            "id" => stripe_subscription_id,
+            "plan" => {
+            },
+            "items" => {
+              "data" => [],
+            },
+            "object" => "subscription",
+            "status" => "active",
+            "created" => created_at.to_i,
+            "cancel_at_period_end" => false,
+            "cancellation_details" => {
+              "reason" => nil, "comment" => nil, "feedback" => nil
+            },
+          }
+        },
+        "type" => "customer.subscription.updated",
+        "object" => "event",
+        "created" => created_at.to_i,
+        "request" => {
+          "id" => "req_xecKk5kzBB6YxH", "idempotency_key" => "4b0d30d5-4bbd-400b-87ae-f551e3be0748"
+        },
+        "livemode" => true,
+        "api_version" => "2022-11-15",
+        "pending_webhooks" => 2
+      }
+    end
+
+    # TODO: Cut this down to just the attributes we need
+    def customer_subscription_created_data(created_at, stripe_subscription_id)
+      {
+        "id" => "evt_1NgIq1BiWqhbiHpFTeqASYDz",
+        "data" => {
+          "object" => {
+            "id" => stripe_subscription_id,
+            "plan" => {
+            },
+            "items" => {
+              "data" => [],
+            },
+            "object" => "subscription",
+            "status" => "incomplete",
+            "created" => created_at.to_i,
+            "cancel_at_period_end" => false,
+            "cancellation_details" => {
+              "reason" => nil, "comment" => nil, "feedback" => nil
+            },
+          }
+        },
+        "type" => "customer.subscription.created",
+        "object" => "event",
+        "created" => created_at.to_i,
+        "request" => {
+          "id" => "req_xecKk5kzBB6YxH", "idempotency_key" => "4b0d30d5-4bbd-400b-87ae-f551e3be0748"
+        },
+        "livemode" => true,
+        "api_version" => "2022-11-15",
+        "pending_webhooks" => 2
+      }
+    end
+
+    class SubscriptionValidOrderTests < Webhooks::Incoming::StripeWebhookTest
+      def setup
+        team = create :team
+        stripe_subscription = create :billing_stripe_subscription, team: team
+        puts stripe_subscription.as_json
+        @generic_subscription = create :billing_subscription, provider_subscription: stripe_subscription, status: nil
+        #create :billing_subscriptions_included_price, subscription: @generic_subscription
+        @subscription_created_webhook = create :webhooks_incoming_stripe_webhook,
+          data: customer_subscription_created_data(Time.now - 2.minutes, stripe_subscription.stripe_subscription_id)
+        @subscription_updated_webhook = create :webhooks_incoming_stripe_webhook,
+          data: customer_subscription_updated_data(Time.now - 1.minutes, stripe_subscription.stripe_subscription_id)
+      end
+
+      test "the subscription ends up as 'active'" do
+        @subscription_created_webhook.process
+        assert_equal "pending", @generic_subscription.reload.status
+        @subscription_updated_webhook.process
+        assert_equal "active", @generic_subscription.reload.status
+      end
+    end
+
+    class SubscriptionInvalidOrderTests < Webhooks::Incoming::StripeWebhookTest
+      def setup
+        team = create :team
+        stripe_subscription = create :billing_stripe_subscription, team: team
+        puts stripe_subscription.as_json
+        @generic_subscription = create :billing_subscription, provider_subscription: stripe_subscription, status: nil
+        #create :billing_subscriptions_included_price, subscription: @generic_subscription
+        @subscription_updated_webhook = create :webhooks_incoming_stripe_webhook,
+          data: customer_subscription_updated_data(Time.now - 2.minutes, stripe_subscription.stripe_subscription_id)
+        @subscription_created_webhook = create :webhooks_incoming_stripe_webhook,
+          data: customer_subscription_created_data(Time.now - 1.minutes, stripe_subscription.stripe_subscription_id)
+      end
+
+      test "the subscription ends up as 'active'" do
+        @subscription_updated_webhook.process
+        assert_equal "active", @generic_subscription.reload.status
+        @subscription_created_webhook.process
+        assert_equal "active", @generic_subscription.reload.status
+      end
+    end
+
+
+  end
+end

--- a/test/models/webhooks/incoming/stripe_webhook_test.rb
+++ b/test/models/webhooks/incoming/stripe_webhook_test.rb
@@ -3,7 +3,9 @@ require "test_helper"
 if defined?(BulletTrain::Billing::Stripe)
   class Webhooks::Incoming::StripeWebhookTest < ActiveSupport::TestCase
     include ::FactoryBot::Syntax::Methods
-    # TODO: Cut this down to just the attributes we need
+
+    # This is a _very_ minimal representation of a webhook payload. It's just
+    # enough for the purposes of these tests.
     def customer_subscription_updated_data(created_at, stripe_subscription_id)
       {
         "id" => "evt_1NgIq2BiWqhbiHpFXvtRJZtY",
@@ -11,31 +13,20 @@ if defined?(BulletTrain::Billing::Stripe)
           "object" => {
             "id" => stripe_subscription_id,
             "plan" => {},
-            "items" => {
-              "data" => [],
-            },
+            "items" => { "data" => [] },
             "object" => "subscription",
             "status" => "active",
             "created" => created_at.to_i,
-            "cancel_at_period_end" => false,
-            "cancellation_details" => {
-              "reason" => nil, "comment" => nil, "feedback" => nil
-            },
           }
         },
         "type" => "customer.subscription.updated",
         "object" => "event",
         "created" => created_at.to_i,
-        "request" => {
-          "id" => "req_xecKk5kzBB6YxH", "idempotency_key" => "4b0d30d5-4bbd-400b-87ae-f551e3be0748"
-        },
-        "livemode" => true,
-        "api_version" => "2022-11-15",
-        "pending_webhooks" => 2
       }
     end
 
-    # TODO: Cut this down to just the attributes we need
+    # This is a _very_ minimal representation of a webhook payload. It's just
+    # enough for the purposes of these tests.
     def customer_subscription_created_data(created_at, stripe_subscription_id)
       {
         "id" => "evt_1NgIq1BiWqhbiHpFTeqASYDz",
@@ -43,27 +34,15 @@ if defined?(BulletTrain::Billing::Stripe)
           "object" => {
             "id" => stripe_subscription_id,
             "plan" => {},
-            "items" => {
-              "data" => [],
-            },
+            "items" => { "data" => [] },
             "object" => "subscription",
             "status" => "incomplete",
             "created" => created_at.to_i,
-            "cancel_at_period_end" => false,
-            "cancellation_details" => {
-              "reason" => nil, "comment" => nil, "feedback" => nil
-            },
           }
         },
         "type" => "customer.subscription.created",
         "object" => "event",
         "created" => created_at.to_i,
-        "request" => {
-          "id" => "req_xecKk5kzBB6YxH", "idempotency_key" => "4b0d30d5-4bbd-400b-87ae-f551e3be0748"
-        },
-        "livemode" => true,
-        "api_version" => "2022-11-15",
-        "pending_webhooks" => 2
       }
     end
 

--- a/test/models/webhooks/incoming/stripe_webhook_test.rb
+++ b/test/models/webhooks/incoming/stripe_webhook_test.rb
@@ -111,6 +111,10 @@ if defined?(BulletTrain::Billing::Stripe)
         @subscription_created_webhook.process
         assert_equal "active", @generic_subscription.reload.status
       end
+
+      test "watch it fail in CI" do
+        assert_equal "are we running in CI?", "if so, this should fail"
+      end
     end
 
 

--- a/test/models/webhooks/incoming/stripe_webhook_test.rb
+++ b/test/models/webhooks/incoming/stripe_webhook_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 if defined?(BulletTrain::Billing::Stripe)
+
+  puts Rails.configuration.factory_bot.definition_file_paths
   class Webhooks::Incoming::StripeWebhookTest < ActiveSupport::TestCase
     include ::FactoryBot::Syntax::Methods
     # TODO: Cut this down to just the attributes we need
@@ -110,10 +112,6 @@ if defined?(BulletTrain::Billing::Stripe)
         assert_equal "active", @generic_subscription.reload.status
         @subscription_created_webhook.process
         assert_equal "active", @generic_subscription.reload.status
-      end
-
-      test "watch it fail in CI" do
-        assert_equal "are we running in CI?", "if so, this should fail"
       end
     end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -22,6 +22,21 @@ knapsack_pro_adapter.set_test_helper_path(__FILE__)
 require "sidekiq/testing"
 Sidekiq::Testing.inline!
 
+begin
+  require "bullet_train/billing/test_support"
+  FactoryBot.definition_file_paths << BulletTrain::Billing::TestSupport::FACTORY_PATH
+  FactoryBot.reload
+rescue LoadError
+end
+
+begin
+  require "bullet_train/billing/stripe/test_support"
+  FactoryBot.definition_file_paths << BulletTrain::Billing::Stripe::TestSupport::FACTORY_PATH
+  FactoryBot.reload
+rescue LoadError
+end
+
+
 ActiveSupport::TestCase.class_eval do
   # Run tests in parallel with specified workers
   # parallelize(workers: :number_of_processors)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -36,7 +36,6 @@ begin
 rescue LoadError
 end
 
-
 ActiveSupport::TestCase.class_eval do
   # Run tests in parallel with specified workers
   # parallelize(workers: :number_of_processors)


### PR DESCRIPTION
This PR implements some tests for https://github.com/bullet-train-pro/bullet_train-billing-stripe/pull/18. If the `bullet_train-billing-stripe` gem is not installed then these new tests will be skipped.

It also removes a (seemingly unused) factory that was duplicated out of `bullet_train-billing-stripe`.

This app still has access to that factory via the changes made to `test_helper.rb`.