### PR TITLE
[release process] Fix a bug that made the version bump PR confusing

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -46,7 +46,7 @@ jobs:
         title: "BT-Core version bump: ${{ inputs.versionBump }} - ${{ steps.bump-core.outputs.NEW_VERSION_NUMBER }}"
         add-paths: "Gemfile.lock,yarn.lock"
         body: |
-          Version bump of the `core` ruby gems and npm packages to version `{{ steps.bump-core.outputs.NEW_VERSION_NUMBER }}`
+          Version bump of the `core` ruby gems and npm packages to version `${{ steps.bump-core.outputs.NEW_VERSION_NUMBER }}`
 
           Tag v${{ steps.bump-core.outputs.NEW_VERSION_NUMBER }}
 


### PR DESCRIPTION
Somehow I dropped a `$` which was preventing a variable from being evaluated. Easy fix.