### PR TITLE
[release process] Pass the `--conservative` flag to `bundle update`

### DIFF
--- a/bin/bump-core
+++ b/bin/bump-core
@@ -40,7 +40,7 @@ class CoreBumpCLI < Thor
     end
 
     def bundle_update
-      puts `bundle update #{ruby_gems.join(" ")}`
+      puts `bundle update --conservative #{ruby_gems.join(" ")}`
     end
 
     def yarn_upgrade


### PR DESCRIPTION
This will ensure that our `core` version bump PRs are limited to just `core` gems. The last couple have gotten some minor rails version bumps, but we should probably not include those. Dependabot will open PRs for that kind of thing.