### PR TITLE
Add configuration for incoming webhook parent class

### DIFF
--- a/config/initializers/bullet_train.rb
+++ b/config/initializers/bullet_train.rb
@@ -1,4 +1,7 @@
 BulletTrain.configure do |config|
   # Uncomment this line if you want to bypass strong passwords.
   # config.strong_passwords = false
+
+  # Change the parent class you want incoming webhooks to inherit from.
+  config.incoming_webhooks_parent_class_name = "ApplicationRecord"
 end


### PR DESCRIPTION
Closes https://github.com/bullet-train-co/bullet_train-core/issues/454.

Joint PR
- https://github.com/bullet-train-co/bullet_train-core/pull/461

We could technically put this in another file and write a block like this:

```ruby
BulletTrain::IncomingWebhooks::Configuration do |configure|
  ...
end
```

However, I think `BulletTrain::Configuration` is small enough right now so that we can put this all in one file.

I also used a String here and `constantize` it in the class itself to avoid constant loading issues on initialization.