### PR TITLE
Fix an unintended change to `Gemfile.lock`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,7 +133,7 @@ GEM
       bullet_train
       doorkeeper
       factory_bot
-      jbuilder-schema (>= 2.2.0)
+      jbuilder-schema (>= 2.0.0)
       pagy
       pagy_cursor
       rack-cors


### PR DESCRIPTION
In https://github.com/bullet-train-co/bullet_train/pull/749 we tried to bump the version of `jbuilder-schema`, but since it's a dependency of `bullet_train-api` we need to leave it alone and let it get upgraded naturally when we bump that gem.