### PR TITLE
Ensure the setup script prompts developers to follow the correct setup steps

### DIFF
--- a/bin/configure
+++ b/bin/configure
@@ -287,5 +287,5 @@ end
 puts ""
 puts "OK, we're done, but at some point you should edit `config/locales/en/application.en.yml`!".yellow
 puts ""
-puts "Next you can run `bin/dev` to spawn a local instance, then navigate to http://localhost:3000.".green
+puts "Next you can run `bin/setup`, then `bin/dev` to spawn a local instance, and then you can navigate to http://localhost:3000 to access your new application.".green
 puts ""


### PR DESCRIPTION
Fixes #917.

There was some confusion surrounding #605 a while back and it was brought up a couple of times in Discord, so we should be telling developers to run `bin/setup` before they run `bin/dev`

Context:
- https://discord.com/channels/836637622432170028/836637623048601633/1131300251848945806
- https://discord.com/channels/836637622432170028/1116294694599663658/1116322544253947944

