### PR TITLE
Prompt developers to run `bin/dev` after `bin/setup`

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -77,6 +77,5 @@ FileUtils.chdir APP_ROOT do
     exit 1
   end
 
-  puts "\n== Restarting application server =="
-  system! "bin/rails restart"
+  puts "You're set! Now you can run bin/dev to boot your server and access your new application."
 end

--- a/bin/setup
+++ b/bin/setup
@@ -77,5 +77,6 @@ FileUtils.chdir APP_ROOT do
     exit 1
   end
 
-  puts "You're set! Now you can run bin/dev to boot your server and access your new application."
+  puts ""
+  puts "You're set! Now you can run bin/dev to boot your server and access your new application.".blue
 end


### PR DESCRIPTION
Continuation of #919.

We tell developers in the README and in `bin/configure` to run `bin/dev` after they're setup, but it's probably most helpful to tell them RIGHT AFTER running `bin/setup`, which this PR does.

Also, since they're initially getting setup, I'm operating under the assumption that they don't have a server running yet, so I deleted to server restart text that we have in `main` right now.

![Screenshot from 2023-08-28 20-30-47](https://github.com/bullet-train-co/bullet_train/assets/10546292/bb1e754c-5a8f-426e-a0e6-4afa92b5d4d6)
