### PR TITLE
Make simplecov actually capture coverage data

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,14 +1,15 @@
+# Simplecov config has to come before literally everything else
+# Open coverage/index.html in your browser after
+# running your tests for test coverage results.
+require "simplecov"
+SimpleCov.start "rails"
+
 ENV["RAILS_ENV"] ||= "test"
 require_relative "../config/environment"
 require "rails/test_help"
-require "simplecov"
 
 # Set the default language we test in to English.
 I18n.default_locale = :en
-
-# Open coverage/index.html in your browser after
-# running your tests for test coverage results.
-SimpleCov.start "rails"
 
 # We've started loading seeds by default to try to reduce any duplication of effort trying to get the test
 # environment to look the same as the actual development and production environments. This means a consolidation


### PR DESCRIPTION
Fixes #657

Simplecov has to come before everything else in the test helper or it's unable to capture coverage information.