### PR TITLE
Show BulletTrain gems in stack traces by default

### DIFF
--- a/config/initializers/backtrace_silencers.rb
+++ b/config/initializers/backtrace_silencers.rb
@@ -3,6 +3,16 @@
 # You can add backtrace silencers for libraries that you're using but don't wish to see in your backtraces.
 # Rails.backtrace_cleaner.add_silencer { |line| /my_noisy_library/.match?(line) }
 
+
+
 # You can also remove all the silencers if you're trying to debug a problem that might stem from framework code
 # by setting BACKTRACE=1 before calling your invocation, like "BACKTRACE=1 ./bin/rails runner 'MyClass.perform'".
-Rails.backtrace_cleaner.remove_silencers! if ENV["BACKTRACE"]
+Rails.backtrace_cleaner.remove_silencers!
+if !ENV["BACKTRACE"]
+  # If the user hasn't acked to see the FULL backtrace, we silece everything that rails silences by default,
+  # except for lines that look like they come from a BulletTrain gem.
+  Rails.backtrace_cleaner.add_silencer do |line|
+    (line !~ Rails::BacktraceCleaner::APP_DIRS_PATTERN) &&
+      (line !~ /^bullet_train/  )
+  end
+end

--- a/config/initializers/backtrace_silencers.rb
+++ b/config/initializers/backtrace_silencers.rb
@@ -3,8 +3,6 @@
 # You can add backtrace silencers for libraries that you're using but don't wish to see in your backtraces.
 # Rails.backtrace_cleaner.add_silencer { |line| /my_noisy_library/.match?(line) }
 
-
-
 # You can also remove all the silencers if you're trying to debug a problem that might stem from framework code
 # by setting BACKTRACE=1 before calling your invocation, like "BACKTRACE=1 ./bin/rails runner 'MyClass.perform'".
 Rails.backtrace_cleaner.remove_silencers!
@@ -13,6 +11,6 @@ if !ENV["BACKTRACE"]
   # except for lines that look like they come from a BulletTrain gem.
   Rails.backtrace_cleaner.add_silencer do |line|
     (line !~ Rails::BacktraceCleaner::APP_DIRS_PATTERN) &&
-      (line !~ /^bullet_train/  )
+      (line !~ /bullet_train/)
   end
 end


### PR DESCRIPTION
Fixes https://github.com/bullet-train-co/bullet_train/issues/681

Before:

```
Error:
Account::TeamsControllerTest#test_should_get_edit:
ActionView::Template::Error: heck
    test/controllers/account/teams_controller_test.rb:43:in `block in <class:TeamsControllerTest>'
```

After:

```
Error:
Account::TeamsControllerTest#test_should_get_edit:
ActionView::Template::Error: heck
    /Users/jgreen/projects/bullet-train-co/bullet_train-core/bullet_train/app/models/concerns/users/base.rb:56:in `name'
    bullet_train-themes-light (1.3.18) app/views/themes/light/menu/_user.html.erb:5
    bullet_train-themes (1.3.18) app/helpers/theme_helper.rb:19:in `render'
    bullet_train-themes-light (1.3.18) app/views/themes/light/menu/_account.html.erb:9
    bullet_train-themes (1.3.18) app/helpers/theme_helper.rb:19:in `render'
    bullet_train-themes-light (1.3.18) app/views/themes/light/menu/_sidebar.html.erb:9
    bullet_train-themes (1.3.18) app/helpers/theme_helper.rb:19:in `render'
    bullet_train-themes-light (1.3.18) app/views/themes/light/menu/_mobile.html.erb:36
    bullet_train-themes (1.3.18) app/helpers/theme_helper.rb:19:in `render'
    bullet_train-themes-light (1.3.18) app/views/themes/light/layouts/_account.html.erb:13
    bullet_train-themes (1.3.18) app/helpers/theme_helper.rb:19:in `render'
    /Users/jgreen/projects/bullet-train-co/bullet_train-core/bullet_train/app/views/layouts/account.html.erb:1
    /Users/jgreen/projects/bullet-train-co/bullet_train-core/bullet_train/app/controllers/concerns/controllers/base.rb:95:in `set_locale'
    test/controllers/account/teams_controller_test.rb:43:in `block in <class:TeamsControllerTest>'
```