### PR TITLE
Add comment explaining added_by use in Membership factory

### DIFF
--- a/test/factories/memberships.rb
+++ b/test/factories/memberships.rb
@@ -11,19 +11,24 @@ FactoryBot.define do
       user_last_name { user.last_name }
       user_profile_photo_id { 1 }
       user_email { user.email }
-      # TODO: If we try to generate an `added_by` relationship in the factory we get stuck in an
-      # infinite loop that eventually results in the following error:
-      # Minitest::UnexpectedError: SystemStackError: stack level too deep
-      #
-      # Is there some way we can hadle this in the factory?
-      # And/or do we _need_ to? Maybe we can just remove this?
-      # Note: This used to incorrectly generate a :user instead of a :membership, but
-      # added_by_id is indexed to the `memberships` table, so generating a :user is not valid.
-      #
-      # added_by_id { FactoryBot.example(:membership).id }
       platform_agent_of_id { nil }
       platform_agent { false }
       role_ids { ["admin"] }
+
+      # The `added_by` attribute is an optional foreign_key which points
+      # to another membership and is automatically populated when someone
+      # on a team invites another person. We do not give it a value here
+      # in the factory because it will cause an infinite loop. If you
+      # want to populate this value for a Membership in your tests, you
+      # can do so by creating a Membership and passing it to an :invitation factory:
+      #
+      # # (Where `test_team`, `issuer_email`, and `receiver_email` are all custom values)
+      # invitation_issuer_membership = Membership.new(team: test_team, user_email: issuer_email)
+      # invitation_receiver_membership = Membership.new(team: test_team, user_email: receiver_email)
+      # create :invitation, team: test_team, from_membership: invitation_issuer_membership, email: receiver_email, membership: invitation_receiver_membership
+      #
+      # This will automatically populate the `added_by` attribute for `invitation_receiver_membership`.
+      added_by_id { nil }
     end
   end
 end


### PR DESCRIPTION
Adds comment concerning the `added_by` attribute in Membership as suggested in #926.