### PR TITLE
Remove unneeded block from `bin/configure`

### DIFF
--- a/bin/configure
+++ b/bin/configure
@@ -169,11 +169,6 @@ else
   exit
 end
 
-if File.exist?('.github/workflows/main.yml')
-  puts "Removing default GitHub workflow.".yellow
-  File.delete('.github/workflows/main.yml')
-end
-
 
 puts "Next, let's push your application to GitHub."
 puts "If you would like to use another service like Gitlab to manage your repository,"


### PR DESCRIPTION
Closes #934.

This is a small detail, but there are two empty lines in place of this block now, and I decided to leave that much space instead of one line because there are some areas in this script where that extra space serves as a separator for meaningful chunks of code (and this part of the code is one of them).