### PR TITLE
Add `ruby-vips` in the `:development` group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,10 +65,6 @@ group :development, :test do
 
   # Generate test objects.
   gem "factory_bot_rails"
-
-  # Workaround to get image process to behave on a Mac in development
-  # https://github.com/libvips/ruby-vips/issues/155#issuecomment-1047370993
-  gem "ruby-vips"
 end
 
 group :development do
@@ -80,6 +76,10 @@ group :development do
 
   # Speed up commands on slow machines / big apps [https://github.com/rails/spring]
   # gem "spring"
+
+  # Workaround to get image process to behave on a Mac in development
+  # https://github.com/libvips/ruby-vips/issues/155#issuecomment-1047370993
+  gem "ruby-vips"
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -65,6 +65,10 @@ group :development, :test do
 
   # Generate test objects.
   gem "factory_bot_rails"
+
+  # Workaround to get image process to behave on a Mac in development
+  # https://github.com/libvips/ruby-vips/issues/155#issuecomment-1047370993
+  gem "ruby-vips"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -657,6 +657,7 @@ DEPENDENCIES
   rails_best_practices
   redis (~> 5.0.5)
   rqrcode
+  ruby-vips
   selenium-webdriver
   sentry-rails
   sentry-ruby


### PR DESCRIPTION
This (mostly) fixes the problem reported in https://github.com/bullet-train-co/bullet_train-core/issues/464

However, due to https://github.com/bullet-train-co/bullet_train-core/issues/498 we don't currently try to show a user profile photo if we're using ActiveStorage instead of Cloudinary.

Here's some context about why we need to add this directly to the `Gemfile`.
https://github.com/libvips/ruby-vips/issues/155#issuecomment-1047370993