### PR TITLE
Use `build` in ExampleBot instead of `create` + `rollback`

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -28,7 +28,6 @@ Rails.application.configure do
     config.action_controller.perform_caching = true
     config.action_controller.enable_fragment_cache_logging = true
 
-    config.cache_store = :memory_store
     config.public_file_server.headers = {
       "Cache-Control" => "public, max-age=#{2.days.to_i}"
     }

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -28,6 +28,7 @@ Rails.application.configure do
     config.action_controller.perform_caching = true
     config.action_controller.enable_fragment_cache_logging = true
 
+    config.cache_store = :memory_store
     config.public_file_server.headers = {
       "Cache-Control" => "public, max-age=#{2.days.to_i}"
     }

--- a/test/factories/invitations.rb
+++ b/test/factories/invitations.rb
@@ -6,6 +6,8 @@ FactoryBot.define do
     sequence(:email) { |n| "example#{n}@email.com" }
 
     factory :invitation_example do
+      id { "42" }
+      from_membership_id { "42" }
       team { FactoryBot.example(:team) }
       membership { FactoryBot.example(:membership) }
     end

--- a/test/factories/invitations.rb
+++ b/test/factories/invitations.rb
@@ -6,8 +6,8 @@ FactoryBot.define do
     sequence(:email) { |n| "example#{n}@email.com" }
 
     factory :invitation_example do
-      id { "42" }
-      from_membership_id { "42" }
+      id { 42 }
+      from_membership_id { 42 }
       team { FactoryBot.example(:team) }
       membership { FactoryBot.example(:membership) }
     end

--- a/test/factories/memberships.rb
+++ b/test/factories/memberships.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
     association :team
 
     factory :membership_example do
+      id { "42" }
       team { FactoryBot.example(:team) }
       user { FactoryBot.example(:user, teams: [team]) }
       invitation_id { nil }

--- a/test/factories/memberships.rb
+++ b/test/factories/memberships.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
     association :team
 
     factory :membership_example do
-      id { "42" }
+      id { 42 }
       team { FactoryBot.example(:team) }
       user { FactoryBot.example(:user, teams: [team]) }
       invitation_id { nil }
@@ -15,6 +15,8 @@ FactoryBot.define do
       platform_agent_of_id { nil }
       platform_agent { false }
       role_ids { ["admin"] }
+      created_at { DateTime.new(2023, 1, 1) }
+      updated_at { DateTime.new(2023, 1, 2) }
 
       # The `added_by` attribute is an optional foreign_key which points
       # to another membership and is automatically populated when someone

--- a/test/factories/scaffolding/completely_concrete/tangible_things.rb
+++ b/test/factories/scaffolding/completely_concrete/tangible_things.rb
@@ -15,8 +15,8 @@ FactoryBot.define do
     sort_order { 1 }
 
     factory :scaffolding_completely_concrete_tangible_thing_example do
-      id{ "42" }
-      absolutely_abstract_creative_concept_id{ "42" }
+      id { "42" }
+      absolutely_abstract_creative_concept_id { "42" }
       text_field_value { "Example" }
     end
   end

--- a/test/factories/scaffolding/completely_concrete/tangible_things.rb
+++ b/test/factories/scaffolding/completely_concrete/tangible_things.rb
@@ -15,6 +15,8 @@ FactoryBot.define do
     sort_order { 1 }
 
     factory :scaffolding_completely_concrete_tangible_thing_example do
+      id{ "42" }
+      absolutely_abstract_creative_concept_id{ "42" }
       text_field_value { "Example" }
     end
   end

--- a/test/factories/scaffolding/completely_concrete/tangible_things.rb
+++ b/test/factories/scaffolding/completely_concrete/tangible_things.rb
@@ -15,9 +15,11 @@ FactoryBot.define do
     sort_order { 1 }
 
     factory :scaffolding_completely_concrete_tangible_thing_example do
-      id { "42" }
-      absolutely_abstract_creative_concept_id { "42" }
+      id { 42 }
+      absolutely_abstract_creative_concept_id { 42 }
       text_field_value { "Example" }
+      created_at { DateTime.new(2023, 1, 1) }
+      updated_at { DateTime.new(2023, 1, 2) }
     end
   end
 end

--- a/test/factories/teams.rb
+++ b/test/factories/teams.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
     locale { nil }
 
     factory :team_example do
+      id { "42" }
       sequence(:name) { |n| "EXAMPLE Generic Team #{n}" }
       sequence(:slug) { |n| "EXAMPLE team_#{n}" }
       time_zone { ActiveSupport::TimeZone.all.first.name }

--- a/test/factories/teams.rb
+++ b/test/factories/teams.rb
@@ -6,11 +6,13 @@ FactoryBot.define do
     locale { nil }
 
     factory :team_example do
-      id { "42" }
+      id { 42 }
       sequence(:name) { |n| "EXAMPLE Generic Team #{n}" }
       sequence(:slug) { |n| "EXAMPLE team_#{n}" }
       time_zone { ActiveSupport::TimeZone.all.first.name }
       locale { "en" }
+      created_at { DateTime.new(2023, 1, 1) }
+      updated_at { DateTime.new(2023, 1, 2) }
     end
   end
 end

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -22,6 +22,7 @@ FactoryBot.define do
       end
 
       factory :user_example do
+        id { "42" }
         first_name { "Example First Name" }
         last_name { "Example Last Name" }
       end

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -22,9 +22,11 @@ FactoryBot.define do
       end
 
       factory :user_example do
-        id { "42" }
+        id { 42 }
         first_name { "Example First Name" }
         last_name { "Example Last Name" }
+        created_at { DateTime.new(2023, 1, 1) }
+        updated_at { DateTime.new(2023, 1, 2) }
       end
     end
   end

--- a/test/factories/webhooks/outgoing/endpoints.rb
+++ b/test/factories/webhooks/outgoing/endpoints.rb
@@ -5,6 +5,8 @@ FactoryBot.define do
     url { "https://example.com/some-endpoint-url" }
 
     factory :webhooks_outgoing_endpoint_example do
+      id { "42" }
+      team_id { "42" }
       name { "Example Endpoint" }
     end
   end

--- a/test/factories/webhooks/outgoing/endpoints.rb
+++ b/test/factories/webhooks/outgoing/endpoints.rb
@@ -5,9 +5,11 @@ FactoryBot.define do
     url { "https://example.com/some-endpoint-url" }
 
     factory :webhooks_outgoing_endpoint_example do
-      id { "42" }
-      team_id { "42" }
+      id { 42 }
+      team_id { 42 }
       name { "Example Endpoint" }
+      created_at { DateTime.new(2023, 1, 1) }
+      updated_at { DateTime.new(2023, 1, 2) }
     end
   end
 end

--- a/test/factories/webhooks/outgoing/events.rb
+++ b/test/factories/webhooks/outgoing/events.rb
@@ -10,6 +10,9 @@ FactoryBot.define do
     end
 
     factory :webhooks_outgoing_event_example do
+      id { "42" }
+      subject_id { "42" }
+      team_id { "42" }
       data {
         {id: 1,
          created_at: Time.now.utc,

--- a/test/factories/webhooks/outgoing/events.rb
+++ b/test/factories/webhooks/outgoing/events.rb
@@ -10,13 +10,15 @@ FactoryBot.define do
     end
 
     factory :webhooks_outgoing_event_example do
-      id { "42" }
-      subject_id { "42" }
-      team_id { "42" }
+      id { 42 }
+      subject_id { 42 }
+      team_id { 42 }
+      created_at { DateTime.new(2023, 1, 1) }
+      updated_at { DateTime.new(2023, 1, 2) }
       data {
-        {id: 1,
-         created_at: Time.now.utc,
-         updated_at: Time.now.utc,
+        {id: 42,
+         created_at: DateTime.new(2023, 1, 1).utc,
+         updated_at: DateTime.new(2023, 1, 2).utc,
          value: "one"}.to_json
       }
     end


### PR DESCRIPTION
Joint PR: https://github.com/bullet-train-co/bullet_train-core/pull/524

This PR adds some dummy ids to some of the `*_example` factories. (But not any "live" factories that are used outside of `ExampleBot`.)

Doing this so that the values can be pre-populated for `ExampleBot` without us needing to actually create live records, clone them, rollback, then reset primary keys. Doing all of that work is slow so it's best to avoid doing it. (And having to reset primary keys for something that we expect to be a normal thing kind of gives me the willies.)