### PR TITLE
Decrease parallelism in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,7 @@ jobs:
       - <<: *postgres_docker_image
       - image: cimg/redis:6.2.6
     executor: ruby/default
-    parallelism: 16
+    parallelism: 2
     steps:
       - browser-tools/install-chrome:
           chrome-version: "116.0.5845.96" # TODO: remove -> https://github.com/CircleCI-Public/browser-tools-orb/issues/75
@@ -123,7 +123,7 @@ jobs:
             export RAILS_ENV=test
             bundle exec rails "knapsack_pro:queue:minitest[--verbose]"
           environment:
-            KNAPSACK_PRO_CI_NODE_TOTAL: 16
+            KNAPSACK_PRO_CI_NODE_TOTAL: 2
 
       # If you don't want to use Knapsack Pro, then use this configuration:
       #
@@ -150,7 +150,7 @@ jobs:
       - <<: *postgres_docker_image
       - image: circleci/redis
     executor: ruby/default
-    parallelism: 16
+    parallelism: 2
     steps:
       - browser-tools/install-browser-tools:
           chrome-version: "116.0.5845.96" # TODO: remove -> https://github.com/CircleCI-Public/browser-tools-orb/issues/75
@@ -180,7 +180,7 @@ jobs:
             export RAILS_ENV=test
             bundle exec rails "knapsack_pro:queue:minitest[--verbose]"
           environment:
-            KNAPSACK_PRO_CI_NODE_TOTAL: 16
+            KNAPSACK_PRO_CI_NODE_TOTAL: 2
             HIDE_THINGS: true
 
       # If you don't want to use Knapsack Pro, then use this configuration:
@@ -254,7 +254,7 @@ jobs:
       - <<: *postgres_docker_image
       - image: cimg/redis:6.2.6
     executor: ruby/default
-    parallelism: 16
+    parallelism: 2
     steps:
       - browser-tools/install-chrome:
           chrome-version: "116.0.5845.96" # TODO: remove -> https://github.com/CircleCI-Public/browser-tools-orb/issues/75
@@ -295,7 +295,7 @@ jobs:
             fi
           environment:
             RAILS_ENV: test
-            KNAPSACK_PRO_CI_NODE_TOTAL: 16
+            KNAPSACK_PRO_CI_NODE_TOTAL: 2
             KNAPSACK_PRO_TEST_FILE_PATTERN: "test/system/**{,/*/**}/*_test.rb"
 
   # Uncomment the job at the bottom of this file to run these system tests.
@@ -308,7 +308,7 @@ jobs:
       - <<: *postgres_docker_image
       - image: cimg/redis:6.2.6
     executor: ruby/default
-    parallelism: 4
+    parallelism: 2
 
     steps:
       - browser-tools/install-chrome:


### PR DESCRIPTION
With parallelism set to 16 we spend about 75-80% of the time in any given job doing setup, and only 20-25% of the time running tests. Decreasing parallelism will give us a better ratio, and shouldn't increase testing time all that much.