### PR TITLE
Notify users when their email or password changes

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -127,8 +127,11 @@ Devise.setup do |config|
   # Set up a pepper to generate the hashed password.
   # config.pepper = '65ff7f551cdef089dc334e291c6d6907e3d0f8e1e10240fe9890103167a9c374ff59a4355db777edba0bbd5901ce81a3836c2897a27fef1fba34b9a397795422'
 
+  # Send a notification to the original email when the user's email is changed.
+  config.send_email_changed_notification = true
+
   # Send a notification email when the user's password is changed
-  # config.send_password_change_notification = false
+  config.send_password_change_notification = true
 
   # ==> Configuration for :confirmable
   # A period that the user is allowed to access the website even without


### PR DESCRIPTION
This helps in the "laptop left unlocked at a coffee shop" scenario.

If someone changes a user's email address, we'll send an email to the _original_ address to let them know.

![CleanShot 2023-09-12 at 11 39 53](https://github.com/bullet-train-co/bullet_train/assets/58702/18412db4-5397-47ed-8983-f515b163243e)

Likewise if someone changes a user's password, we'll send an email to let them know.

![CleanShot 2023-09-12 at 11 40 11](https://github.com/bullet-train-co/bullet_train/assets/58702/94e002bc-89ce-4df4-a29a-2a61f9bbfd96)
