### PR TITLE
[CI] Install only Chrome and not Firefox in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,9 +152,10 @@ jobs:
     executor: ruby/default
     parallelism: 2
     steps:
-      - browser-tools/install-browser-tools:
+      - browser-tools/install-chrome:
           chrome-version: "116.0.5845.96" # TODO: remove -> https://github.com/CircleCI-Public/browser-tools-orb/issues/75
-          replace-existing-chrome: true # TODO: remove -> https://github.com/CircleCI-Public/browser-tools-orb/issues/75
+          replace-existing: true # TODO: remove -> https://github.com/CircleCI-Public/browser-tools-orb/issues/75
+      - browser-tools/install-chromedriver
       - checkout
       - restore_cache: *restore_bundler_cache
       - restore_cache: *restore_yarn_cache


### PR DESCRIPTION
We don't actually use Firefox and we just waste time by installing it. It also seems to cause problems periodically as new versions are released. Removing it will allow us to sidestep those problems.