### PR TITLE
Implement mailer previews for built-in emails

### DIFF
--- a/test/mailers/previews/devise_mailer_preview.rb
+++ b/test/mailers/previews/devise_mailer_preview.rb
@@ -1,0 +1,23 @@
+class DeviseMailerPreview < ActionMailer::Preview
+  # TODO: We probably want to turn on the :confirmable feature
+  # def confirmation_instructions
+  #   Devise::Mailer.confirmation_instructions(User.first, "faketoken")
+  # end
+
+  def reset_password_instructions
+    Devise::Mailer.reset_password_instructions(User.first, "faketoken")
+  end
+
+  # TODO: Do we want to turn on the :lockable feature?
+  # def unlock_instructions
+  #   Devise::Mailer.unlock_instructions(User.first, "faketoken")
+  # end
+
+  def email_changed
+    Devise::Mailer.email_changed(User.first)
+  end
+
+  def password_changed
+    Devise::Mailer.password_change(User.first)
+  end
+end

--- a/test/mailers/previews/user_mailer_preview.rb
+++ b/test/mailers/previews/user_mailer_preview.rb
@@ -1,0 +1,11 @@
+class UserMailerPreview < ActionMailer::Preview
+  def welcome
+    random_user = User.order(Arel.sql('RANDOM()')).first
+    UserMailer.welcome random_user
+  end
+
+  def invited
+    random_invitation = Invitation.order(Arel.sql('RANDOM()')).first
+    UserMailer.invited random_invitation.uuid
+  end
+end

--- a/test/mailers/previews/user_mailer_preview.rb
+++ b/test/mailers/previews/user_mailer_preview.rb
@@ -1,11 +1,11 @@
 class UserMailerPreview < ActionMailer::Preview
   def welcome
-    random_user = User.order(Arel.sql('RANDOM()')).first
+    random_user = User.order(Arel.sql("RANDOM()")).first
     UserMailer.welcome random_user
   end
 
   def invited
-    random_invitation = Invitation.order(Arel.sql('RANDOM()')).first
+    random_invitation = Invitation.order(Arel.sql("RANDOM()")).first
     UserMailer.invited random_invitation.uuid
   end
 end


### PR DESCRIPTION
Fixes https://github.com/bullet-train-co/bullet_train-core/issues/266

Mailer previews can be found in `development` by going to:
<http://localhost:3000/rails/mailers/>


![CleanShot 2023-09-20 at 11 34 03](https://github.com/bullet-train-co/bullet_train/assets/58702/a1e7260d-eb6e-4323-8c46-504c3a57c449)

![CleanShot 2023-09-20 at 11 34 34](https://github.com/bullet-train-co/bullet_train/assets/58702/1d7eca0c-beac-4f7a-9f79-3ba5bee059ef)


