### PR TITLE
Fix resolver system test for ejected themes

### DIFF
--- a/test/system/resolver_system_test.rb
+++ b/test/system/resolver_system_test.rb
@@ -10,7 +10,7 @@ class ResolverSystemTest < ApplicationSystemTestCase
   end
 
   test "bin/resolve can resolve `shared/attributes/text`" do
-    relative_view_path = "app/views/base/attributes/_text.html.erb"
+    relative_view_path = "app/views/themes/base/attributes/_text.html.erb"
     local_view_path = Dir.glob("#{Rails.root}/app/views/**/*/attributes/_text.html.erb").pop
     if local_view_path
       assert `bin/resolve shared/attributes/text`.include?(local_view_path)

--- a/test/system/resolver_system_test.rb
+++ b/test/system/resolver_system_test.rb
@@ -10,12 +10,13 @@ class ResolverSystemTest < ApplicationSystemTestCase
   end
 
   test "bin/resolve can resolve `shared/attributes/text`" do
-    view_path = "app/views/themes/base/attributes/_text.html.erb"
-    if File.exist?(view_path)
-      assert `bin/resolve shared/attributes/text`.include?("#{Rails.root}/#{view_path}")
+    relative_view_path = "app/views/base/attributes/_text.html.erb"
+    local_view_path = Dir.glob("#{Rails.root}/app/views/**/*/attributes/_text.html.erb").pop
+    if local_view_path
+      assert `bin/resolve shared/attributes/text`.include?(local_view_path)
     else
       themes_gem = `bundle show bullet_train-themes`.chomp
-      absolute_path = themes_gem + "/" + view_path
+      absolute_path = themes_gem + "/" + relative_view_path
       assert `bin/resolve shared/attributes/text`.include?(absolute_path)
     end
   end


### PR DESCRIPTION
Closes #1008.

Works if:
1. No files have been ejected
2. If just the one file has been ejected with `bin/resolve shared/attributes/text --eject`
3. If a custom theme has been ejected i.e. - `rake bullet_train:themes:light:eject[foo]`
