### PR TITLE
Add temporary fix to enable headless invitation lists tests

### DIFF
--- a/test/system/invitation_lists_test.rb
+++ b/test/system/invitation_lists_test.rb
@@ -3,6 +3,10 @@ require "application_system_test_case"
 class InvitationListsTest < ApplicationSystemTestCase
   @@test_devices.each do |device_name, display_details|
     def setup
+      # TODO: Capybara.current_driver is returning :selenium,
+      # when it should be either :selenium_chrome or :selenium_chrome_headless.
+      Capybara.current_driver = Capybara.default_driver
+
       @current_bulk_invitations_setting = nil
       BulletTrain.configure do |config|
         @current_bulk_invitations_setting = config.enable_bulk_invitations


### PR DESCRIPTION
Fixes #1029.

For some reason in the Invitation List tests only, we get the following value.
```
     5: def setup
 =>  6:   binding.pry
     7: 
     8:   @current_bulk_invitations_setting = nil
     9:   BulletTrain.configure do |config|
    10:     @current_bulk_invitations_setting = config.enable_bulk_invitations
    11:     config.enable_bulk_invitations = true
    12:   end
    13: end

[1] pry(#<InvitationListsTest>)> Capybara.current_driver
=> :selenium
```

However, in [application_system_test_case.rb](https://github.com/bullet-train-co/bullet_train/blob/main/test/application_system_test_case.rb), we only set one of these two keys explicitly.

https://github.com/bullet-train-co/bullet_train/blob/d95deaa09ed30441cd4c318bdff315e73a5c6a5a/test/application_system_test_case.rb#L26-L27

I'm guessing this is related to #1028 especially since it's a Selenium::Webdriver error that's being raised, but I'll have to investigate further to make sure.
