### PR TITLE
Adjust `assert_text` for sign out method in application system test case

### DIFF
--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -150,7 +150,7 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
     click_on "Logout"
 
     # make sure we're actually signed out.
-    assert_text "Signed out successfully"
+    assert_text(/Signed out successfully|You need to sign in or sign up before continuing/)
   end
 
   def new_session_page_for(display_details)


### PR DESCRIPTION
We were getting a green check when merging #1018, and I'm not sure if something changed along the way, but when signing out we get one of two notifications:
1. Signed out successfully.
2. You need to sign in or sign up before continuing

The latter happens when the root is the Team dashboard but the user isn't signed it so the user is redirected to the sign in page (This is our default setup).

The first happens when we use a custom, public page and the user is redirected to a page that doesn't need authentication.