### PR TITLE
Switch to assert_text in some more tests

### DIFF
--- a/test/system/invitation_lists_test.rb
+++ b/test/system/invitation_lists_test.rb
@@ -26,7 +26,7 @@ class InvitationListsTest < ApplicationSystemTestCase
     fill_in "Confirm Password", with: example_password
     click_on "Sign Up"
 
-    assert page.has_content?("Tell us about you")
+    assert_text("Tell us about you")
     fill_in "First Name", with: "Hanako"
     fill_in "Last Name", with: "Tanaka"
     fill_in "Your Team Name", with: "The Testing Team"
@@ -40,7 +40,7 @@ class InvitationListsTest < ApplicationSystemTestCase
 
     # Click on next to show that bulk invitations will raise an error if not filled out properly.
     click_on "Next"
-    assert page.has_content?("Email can't be blank")
+    assert_text("Email can't be blank")
 
     # Fill in the email addresses.
     email_fields = page.all("label", text: "Email Address")
@@ -61,12 +61,12 @@ class InvitationListsTest < ApplicationSystemTestCase
       sleep 2
     end
 
-    assert page.has_content?("The Testing Team’s Dashboard")
+    assert_text("The Testing Team’s Dashboard")
     within_team_menu_for(display_details) do
       click_on "Team Members"
     end
 
-    assert page.has_content?("test-0@some-company.com")
+    assert_text("test-0@some-company.com")
     invitation = Invitation.find_by(email: "test-0@some-company.com")
     assert_equal invitation.membership.role_ids, ["admin", "editor"]
   end

--- a/test/system/super_scaffolding_partial_test.rb
+++ b/test/system/super_scaffolding_partial_test.rb
@@ -160,9 +160,9 @@ class SuperScaffoldingSystemTest < ApplicationSystemTestCase
       # Number Field Partial
       fill_in "Number Field Test", with: 47
 
-      assert page.has_content? "State / Province / Region"
+      assert_text "State / Province / Region"
       select "United States", from: "Country"
-      assert page.has_content? "State"
+      assert_text "State"
 
       fill_in "Address", with: "123 Main St."
       fill_in "City", with: "New York"

--- a/test/system/tangible_thing_test.rb
+++ b/test/system/tangible_thing_test.rb
@@ -53,11 +53,11 @@ unless scaffolding_things_disabled?
       fill_in "Password Field Value", with: "secure-password"
       fill_in "Phone Field Value", with: "(201) 551-8321"
 
-      assert page.has_content? "State / Province"
+      assert_text "State / Province"
       select "Japan", from: "Country"
-      assert page.has_content? "Prefecture"
+      assert_text "Prefecture"
       select "United States", from: "Country"
-      assert page.has_content? "State"
+      assert_text "State"
 
       fill_in "Address", with: "123 Main St."
       fill_in "City", with: "New York"


### PR DESCRIPTION
A few more instances of `assert page.has_content?` have crept in. Switching them to `assert_text` instead so that we get better error messages when tests fail.