### PR TITLE
Remove testing for use_device_test transition script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,16 +125,6 @@ jobs:
           environment:
             KNAPSACK_PRO_CI_NODE_TOTAL: 2
 
-      # Run any update scripts + retest
-      - run: bin/updates/system_tests/use_device_test
-      - run:
-          name: Rerun system tests after update
-          command: |
-            export RAILS_ENV=test
-            KNAPSACK_TEST_FILE_PATTERN="test/system/**/*.rb" bundle exec rails "knapsack_pro:queue:minitest[--verbose]"
-          environment:
-            KNAPSACK_PRO_CI_NODE_TOTAL: 16
-
       # If you don't want to use Knapsack Pro, then use this configuration:
       #
       # - run:


### PR DESCRIPTION
In #720 we added a bit of setup to the CircleCI tests to run the `use_device_test` script in CI and then re-run the tests.

Now that we've merged that PR and the follow-on PR that changed the format of all the system tests, we no longer need to run that script and re-test in CI.