### PR TITLE
Don't run scaffolding things related test if scaffolding things are hidden

### DIFF
--- a/test/concerns/fields/super_select_support_concern_test.rb
+++ b/test/concerns/fields/super_select_support_concern_test.rb
@@ -1,65 +1,67 @@
 require "test_helper"
 
-class Fields::SuperSelectSupportConcernTest < ActiveSupport::TestCase
-  class FakeController < Account::ApplicationController
-    include Fields::SuperSelectSupport
-  end
-
-  setup do
-    @controller = FakeController.new
-    @user = FactoryBot.create :onboarded_user
-    @team = @user.current_team
-  end
-
-  test "should not create new model for authorized singular id" do
-    creative_concept = FactoryBot.create :creative_concept, team: @team
-    strong_params = {id: creative_concept.id.to_s}
-
-    strong_params[:id] = @controller.ensure_backing_models_on(@team.scaffolding_absolutely_abstract_creative_concepts, id: strong_params[:id]) do |scope, id|
-      scope.find_or_create_by(name: id)
+unless scaffolding_things_disabled?
+  class Fields::SuperSelectSupportConcernTest < ActiveSupport::TestCase
+    class FakeController < Account::ApplicationController
+      include Fields::SuperSelectSupport
     end
 
-    assert_equal strong_params[:id], creative_concept.id.to_s
-  end
-
-  test "should create new model for unauthorized singular numerical id" do
-    @other_user = FactoryBot.create :onboarded_user
-    @other_team = @other_user.current_team
-    unauthorized_creative_concept = FactoryBot.create :creative_concept, team: @other_team
-    strong_params = {id: unauthorized_creative_concept.id.to_s}
-
-    strong_params[:id] = @controller.ensure_backing_models_on(@team.scaffolding_absolutely_abstract_creative_concepts, id: strong_params[:id]) do |scope, id|
-      scope.find_or_create_by(name: id)
+    setup do
+      @controller = FakeController.new
+      @user = FactoryBot.create :onboarded_user
+      @team = @user.current_team
     end
 
-    assert_not_equal strong_params[:id], unauthorized_creative_concept.id.to_s
-  end
+    test "should not create new model for authorized singular id" do
+      creative_concept = FactoryBot.create :creative_concept, team: @team
+      strong_params = {id: creative_concept.id.to_s}
 
-  test "should create new model for unauthorized singular new_text as id" do
-    creative_concept = nil
-    strong_params = {id: "creative concept one"}
+      strong_params[:id] = @controller.ensure_backing_models_on(@team.scaffolding_absolutely_abstract_creative_concepts, id: strong_params[:id]) do |scope, id|
+        scope.find_or_create_by(name: id)
+      end
 
-    strong_params[:id] = @controller.ensure_backing_models_on(@team.scaffolding_absolutely_abstract_creative_concepts, id: strong_params[:id]) do |scope, id|
-      creative_concept = scope.find_or_create_by(name: id)
-      creative_concept
+      assert_equal strong_params[:id], creative_concept.id.to_s
     end
 
-    assert_equal strong_params[:id], creative_concept.id.to_s
-    assert_equal @team.scaffolding_absolutely_abstract_creative_concepts.find(strong_params[:id])&.name, "creative concept one"
-  end
+    test "should create new model for unauthorized singular numerical id" do
+      @other_user = FactoryBot.create :onboarded_user
+      @other_team = @other_user.current_team
+      unauthorized_creative_concept = FactoryBot.create :creative_concept, team: @other_team
+      strong_params = {id: unauthorized_creative_concept.id.to_s}
 
-  test "should handle a list with authorized id and new text string" do
-    known_creative_concept = FactoryBot.create :creative_concept, team: @team
-    new_creative_concept = nil
-    strong_params = {ids: [known_creative_concept.id.to_s, "creative concept one"]}
+      strong_params[:id] = @controller.ensure_backing_models_on(@team.scaffolding_absolutely_abstract_creative_concepts, id: strong_params[:id]) do |scope, id|
+        scope.find_or_create_by(name: id)
+      end
 
-    strong_params[:ids] = @controller.ensure_backing_models_on(@team.scaffolding_absolutely_abstract_creative_concepts, ids: strong_params[:ids]) do |scope, id|
-      new_creative_concept = scope.find_or_create_by(name: id)
-      new_creative_concept
+      assert_not_equal strong_params[:id], unauthorized_creative_concept.id.to_s
     end
 
-    assert strong_params[:ids].include?(known_creative_concept.id.to_s)
-    assert strong_params[:ids].include?(new_creative_concept.id.to_s)
-    assert_equal @team.scaffolding_absolutely_abstract_creative_concepts.find(new_creative_concept.id)&.name, "creative concept one"
+    test "should create new model for unauthorized singular new_text as id" do
+      creative_concept = nil
+      strong_params = {id: "creative concept one"}
+
+      strong_params[:id] = @controller.ensure_backing_models_on(@team.scaffolding_absolutely_abstract_creative_concepts, id: strong_params[:id]) do |scope, id|
+        creative_concept = scope.find_or_create_by(name: id)
+        creative_concept
+      end
+
+      assert_equal strong_params[:id], creative_concept.id.to_s
+      assert_equal @team.scaffolding_absolutely_abstract_creative_concepts.find(strong_params[:id])&.name, "creative concept one"
+    end
+
+    test "should handle a list with authorized id and new text string" do
+      known_creative_concept = FactoryBot.create :creative_concept, team: @team
+      new_creative_concept = nil
+      strong_params = {ids: [known_creative_concept.id.to_s, "creative concept one"]}
+
+      strong_params[:ids] = @controller.ensure_backing_models_on(@team.scaffolding_absolutely_abstract_creative_concepts, ids: strong_params[:ids]) do |scope, id|
+        new_creative_concept = scope.find_or_create_by(name: id)
+        new_creative_concept
+      end
+
+      assert strong_params[:ids].include?(known_creative_concept.id.to_s)
+      assert strong_params[:ids].include?(new_creative_concept.id.to_s)
+      assert_equal @team.scaffolding_absolutely_abstract_creative_concepts.find(new_creative_concept.id)&.name, "creative concept one"
+    end
   end
 end


### PR DESCRIPTION
We added a new test in https://github.com/bullet-train-co/bullet_train/pull/1072 that we need to put behind the check for `HIDE_THINGS`.