### PR TITLE
Replace a lingering instance of `resize_for`

### DIFF
--- a/test/system/animations_test.rb
+++ b/test/system/animations_test.rb
@@ -14,7 +14,7 @@ class AnimationsTest < ApplicationSystemTestCase
 
     display_details = {resolution: [750, 1334], mobile: true, high_dpi: true}
     animation_duration = 0.5
-    resize_for(display_details)
+    resize_display(display_details)
     login_as(@jane, scope: :user)
     visit root_path
     if billing_enabled?


### PR DESCRIPTION
We cleaned up most of these in
https://github.com/bullet-train-co/bullet_train/pull/720 but the conversion script couldn't see this one.

Fixes https://github.com/bullet-train-co/bullet_train/issues/1094