### PR TITLE
Test Action Models error message for unneeded namespaces

### DIFF
--- a/test/system/action_models_test.rb
+++ b/test/system/action_models_test.rb
@@ -39,6 +39,12 @@ class ActionModelsSystemTest < ApplicationSystemTestCase
 
   # targets-many action
   if defined?(Projects::ArchiveAction)
+    # This error message is displayed for all actions, not just `targets-many`.
+    test "the proper error message is displayed for unneeded namespaces" do
+      output = `bin/super-scaffold action-model:targets-many Project::Publish Project Team`
+      assert output.include?("When creating an Action Model, you don\'t have to namespace the action")
+    end
+
     test "developers can archive a single project" do
       login_as(@jane, scope: :user)
       visit account_team_path(@jane.current_team)

--- a/test/system/action_models_test.rb
+++ b/test/system/action_models_test.rb
@@ -42,7 +42,7 @@ class ActionModelsSystemTest < ApplicationSystemTestCase
     # This error message is displayed for all actions, not just `targets-many`.
     test "the proper error message is displayed for unneeded namespaces" do
       output = `bin/super-scaffold action-model:targets-many Project::Publish Project Team`
-      assert output.include?("When creating an Action Model, you don\'t have to namespace the action")
+      assert output.include?("When creating an Action Model, you don't have to namespace the action")
     end
 
     test "developers can archive a single project" do


### PR DESCRIPTION
Joint PR
- https://github.com/bullet-train-pro/bullet_train-action_models/pull/90

As I mention in the comment, this error message is displayed for all actions, not just `targets-many`. I decided to place it here though because I don't think we need to go out of our way to create a parent model just to test this error message when we can test it against other models that are already in place.
