### PR TITLE
Add CI/CD workflows for GitHub Actions

### DIFF
--- a/.circleci/db_schema_check
+++ b/.circleci/db_schema_check
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# https://gist.github.com/vncsna/64825d5609c146e80de8b1fd623011ca
+set -euxo pipefail
+
 bundle exec rails db:migrate
 GIT_STATUS=`git status db/schema.rb`
 echo $GIT_STATUS

--- a/.github/workflows/_database_schema_check.yml
+++ b/.github/workflows/_database_schema_check.yml
@@ -1,4 +1,4 @@
-1.2.13# This workflow will ensure that when we run `rails db:migrate` that no changes are made to `db/schema.rb`.
+# This workflow will ensure that when we run `rails db:migrate` that no changes are made to `db/schema.rb`.
 #
 # This workflow is pimarily meant to be called by other workflows, but it can be run manually.
 name: "🔎 ~ Database Schema Check"

--- a/.github/workflows/_database_schema_check.yml
+++ b/.github/workflows/_database_schema_check.yml
@@ -1,0 +1,27 @@
+# This workflow will ensure that when we run `rails db:migrate` that no changes are made to `db/schema.rb`.
+#
+# This workflow is pimarily meant to be called by other workflows, but it can be run manually.
+name: "🔎 ~ Database Schema Check"
+on:
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    env:
+      RAILS_ENV: test
+      BUNDLE_JOBS: 2
+      BUNDLE_RETRY: 3
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Ruby and gems
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Database Schema Check
+        id: db-schema-check
+        run : bash ./.circleci/db_schema_check

--- a/.github/workflows/_database_schema_check.yml
+++ b/.github/workflows/_database_schema_check.yml
@@ -26,6 +26,7 @@ jobs:
           --health-retries 5
     env:
       RAILS_ENV: test
+      DATABASE_URL: "postgres://rails:password@localhost:5432/rails_test"
       BUNDLE_JOBS: 2
       BUNDLE_RETRY: 3
     steps:
@@ -36,9 +37,6 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-
-      - name: Set up database schema
-        run: bin/rails db:schema:load
 
       - name: Database Schema Check
         id: db-schema-check

--- a/.github/workflows/_database_schema_check.yml
+++ b/.github/workflows/_database_schema_check.yml
@@ -37,7 +37,10 @@ jobs:
         with:
           bundler-cache: true
 
+      - name: Set up database schema
+        run: bin/rails db:schema:load
+
       - name: Database Schema Check
         id: db-schema-check
-        run : bash ./.circleci/db_schema_check
+        run : ./.circleci/db_schema_check
         continue-on-error: false

--- a/.github/workflows/_database_schema_check.yml
+++ b/.github/workflows/_database_schema_check.yml
@@ -1,4 +1,4 @@
-# This workflow will ensure that when we run `rails db:migrate` that no changes are made to `db/schema.rb`.
+1.2.13# This workflow will ensure that when we run `rails db:migrate` that no changes are made to `db/schema.rb`.
 #
 # This workflow is pimarily meant to be called by other workflows, but it can be run manually.
 name: "🔎 ~ Database Schema Check"
@@ -9,6 +9,21 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:11-alpine
+        ports:
+          - "5432:5432"
+        env:
+          POSTGRES_DB: rails_test
+          POSTGRES_USER: rails
+          POSTGRES_PASSWORD: password
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     env:
       RAILS_ENV: test
       BUNDLE_JOBS: 2

--- a/.github/workflows/_database_schema_check.yml
+++ b/.github/workflows/_database_schema_check.yml
@@ -40,3 +40,4 @@ jobs:
       - name: Database Schema Check
         id: db-schema-check
         run : bash ./.circleci/db_schema_check
+        continue-on-error: false

--- a/.github/workflows/_deploy_heroku.yml
+++ b/.github/workflows/_deploy_heroku.yml
@@ -1,0 +1,30 @@
+# This workflow will deploy an app to heroku.
+#
+# The name of the app to deploy must be passed in.
+# HEROKU_API_KEY & HEROKU_EMAIL should be added to your repo secrets to provide deployment credentials.
+#
+# This workflow is pimarily meant to be called by other workflows, but it can be run manually.
+name: 🚢 ~ Deploy to Heroku
+
+on:
+  workflow_call:
+    inputs:
+      heroku-app-name:
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      heroku-app-name:
+        required: true
+        type: string
+
+jobs:
+  heroku:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: akhileshns/heroku-deploy@v3.12.12 # This is the action
+        with:
+          heroku_api_key: ${{secrets.HEROKU_API_KEY}}
+          heroku_app_name: ${{ inputs.heroku-app-name }} #Must be unique in Heroku
+          heroku_email: ${{secrets.HEROKU_EMAIL}}

--- a/.github/workflows/_reusable_workflows.yml
+++ b/.github/workflows/_reusable_workflows.yml
@@ -8,5 +8,4 @@ jobs:
   nothing:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+      - run: echo "Nothing to see here. Move along. 🎇"

--- a/.github/workflows/_reusable_workflows.yml
+++ b/.github/workflows/_reusable_workflows.yml
@@ -1,6 +1,6 @@
 # This is a dummy workflow that's just here to add a bit of organization to the workflow list.
 # Too bad they don't allow you to hide workflows or something.
-name: " 🚫 |----- Reusable Worflows Below"
+name: " 🚫 |----- Reusable Worfklows Below"
 on:
   workflow_call:
 

--- a/.github/workflows/_reusable_workflows.yml
+++ b/.github/workflows/_reusable_workflows.yml
@@ -1,0 +1,12 @@
+# This is a dummy workflow that's just here to add a bit of organization to the workflow list.
+# Too bad they don't allow you to hide workflows or something.
+name: " 🚫 |----- Reusable Worflows Below"
+on:
+  workflow_call:
+
+jobs:
+  nothing:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4

--- a/.github/workflows/_run_super_scaffolding_tests.yml
+++ b/.github/workflows/_run_super_scaffolding_tests.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         # For super scaffolding tests we need to have exactly 7 runners.
-        ci_runners: [TestSite, Project, Project::Step, Insight, Personality::Disposition, Personality::Observation, TestFile]
+        ci_runners: [TestSite, Project, 'Project::Step', Insight, 'Personality::Disposition', 'Personality::Observation', TestFile]
     services:
       postgres:
         image: postgres:11-alpine

--- a/.github/workflows/_run_super_scaffolding_tests.yml
+++ b/.github/workflows/_run_super_scaffolding_tests.yml
@@ -12,13 +12,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Set N number of parallel jobs you want to run tests on.
-        # Use higher number if you have slow tests to split them on more parallel jobs.
-        # Remember to update ci_node_index below to 0..N-1
-        ci_node_total: [7]
-        # set N-1 indexes for parallel jobs
-        # When you run 2 parallel jobs then first job will have index 0, the second job will have index 1 etc
-        ci_node_index: [0, 1, 2, 3, 4, 5, 6]
+        # For super scaffolding tests we need to have exactly 7 runners.
+        ci_runners: [TestSite, Project, Project::Step, Insight, Personality::Disposition, Personality::Observation, TestFile]
     services:
       postgres:
         image: postgres:11-alpine
@@ -92,7 +87,7 @@ jobs:
       - name: 'Setup Super Scaffolding System Test'
         run: bundle exec test/bin/setup-super-scaffolding-system-test
         env:
-          CIRCLE_NODE_INDEX: ${{ matrix.ci_node_index }}
+          CIRCLE_NODE_INDEX: ${{ strategy.job-index }}
 
       - name: 'Run Super Scaffolding Test'
         run: bundle exec rails test test/system/super_scaffolding_test.rb

--- a/.github/workflows/_run_super_scaffolding_tests.yml
+++ b/.github/workflows/_run_super_scaffolding_tests.yml
@@ -58,25 +58,10 @@ jobs:
         with:
           bundler-cache: true
 
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - name: Cache yarn cache directory
-        uses: actions/cache@v3
+      - uses: actions/setup-node@v3
         with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-
-      - name: Cache node_modules
-        uses: actions/cache@v3
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-node-modules-
+          node-version-file: .nvmrc
+          cache: 'yarn'
 
       - name: asset cache
         uses: actions/cache@v3

--- a/.github/workflows/_run_super_scaffolding_tests.yml
+++ b/.github/workflows/_run_super_scaffolding_tests.yml
@@ -1,0 +1,125 @@
+# This workflow will run a few super scaffolding commands and then run tests against the generated code.
+#
+# This workflow is pimarily meant to be called by other workflows, but it can be run manually.
+name: 🏗️ ~ Run super scaffolding tests
+on:
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Set N number of parallel jobs you want to run tests on.
+        # Use higher number if you have slow tests to split them on more parallel jobs.
+        # Remember to update ci_node_index below to 0..N-1
+        ci_node_total: [7]
+        # set N-1 indexes for parallel jobs
+        # When you run 2 parallel jobs then first job will have index 0, the second job will have index 1 etc
+        ci_node_index: [0, 1, 2, 3, 4, 5, 6]
+    services:
+      postgres:
+        image: postgres:11-alpine
+        ports:
+          - "5432:5432"
+        env:
+          POSTGRES_DB: rails_test
+          POSTGRES_USER: rails
+          POSTGRES_PASSWORD: password
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      redis:
+        image: redis
+        ports:
+          - "6379:6379"
+        # Set health checks to wait until redis has started
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      RAILS_ENV: test
+      DATABASE_URL: "postgres://rails:password@localhost:5432/rails_test"
+      BUNDLE_JOBS: 2
+      BUNDLE_RETRY: 3
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Ruby and gems
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - name: Cache yarn cache directory
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Cache node_modules
+        uses: actions/cache@v3
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-node-modules-
+
+      - name: asset cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            public/assets
+            tmp/cache/assets/sprockets
+          key: asset-cache-${{ runner.os }}-${{ github.ref }}-${{ github.sha }}
+          restore-keys: |
+            asset-cache-${{ runner.os }}-${{ github.ref }}-${{ github.sha }}
+            asset-cache-${{ runner.os }}-${{ github.ref }}-
+            asset-cache-${{ runner.os }}-
+
+      - name: Set up database schema
+        run: bin/rails db:schema:load
+
+      - run: yarn install
+      - run: yarn build
+      - run: yarn build:css
+
+      # TODO: This might be a bad idea. Maybe we should just have spring in the Gemfile all the time.
+      - name: Allow adding of spring
+        run: bundle config unset deployment
+
+      - name: Add spring
+        run: bundle add spring
+
+      - name: 'Setup Super Scaffolding System Test'
+        run: bundle exec test/bin/setup-super-scaffolding-system-test
+        env:
+          CIRCLE_NODE_INDEX: ${{ matrix.ci_node_index }}
+
+      - name: 'Run Super Scaffolding Test'
+        run: bundle exec rails test test/system/super_scaffolding_test.rb
+
+      - name: 'Run Super Scaffolding Partial Test'
+        run: bundle exec rails test test/system/super_scaffolding_partial_test.rb
+
+      - name: 'Run Super Scaffolding Incoming Webhooks Test'
+        run: bundle exec rails test test/controllers/webhooks/incoming/some_provider_webhooks_controller_test.rb
+
+      - name: Test Summary
+        uses: test-summary/action@v2
+        with:
+          paths: "test/reports/**/TEST-*.xml"
+        if: always()

--- a/.github/workflows/_run_super_scaffolding_tests.yml
+++ b/.github/workflows/_run_super_scaffolding_tests.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    name: "🏗️"
+    name: ""
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/_run_super_scaffolding_tests.yml
+++ b/.github/workflows/_run_super_scaffolding_tests.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   test:
+    name: "🏗️"
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/_run_super_scaffolding_tests.yml
+++ b/.github/workflows/_run_super_scaffolding_tests.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    name: ""
+    name: "🏗️"
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/_run_tests.yml
+++ b/.github/workflows/_run_tests.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    name: ""
+    name: "🧪"
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/_run_tests.yml
+++ b/.github/workflows/_run_tests.yml
@@ -58,25 +58,10 @@ jobs:
         with:
           bundler-cache: true
 
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - name: Cache yarn cache directory
-        uses: actions/cache@v3
+      - uses: actions/setup-node@v3
         with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-
-      - name: Cache node_modules
-        uses: actions/cache@v3
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-node-modules-
+          node-version-file: .nvmrc
+          cache: 'yarn'
 
       - name: asset cache
         uses: actions/cache@v3

--- a/.github/workflows/_run_tests.yml
+++ b/.github/workflows/_run_tests.yml
@@ -12,13 +12,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Set N number of parallel jobs you want to run tests on.
-        # Use higher number if you have slow tests to split them on more parallel jobs.
-        # Remember to update ci_node_index below to 0..N-1
-        ci_node_total: [7]
-        # set N-1 indexes for parallel jobs
-        # When you run 2 parallel jobs then first job will have index 0, the second job will have index 1 etc
-        ci_node_index: [0, 1, 2, 3, 4, 5, 6]
+        # Set identifiers for parallel jobs. These can be anything.
+        # For instance if you want a Three Amigos themed pipeline you could use:
+        # ci_node_index: [Dusty, Ned, Lucky]
+        ci_runners: [1,2,3,4]
     services:
       postgres:
         image: postgres:11-alpine
@@ -87,8 +84,8 @@ jobs:
         env:
           AUTH_ENDPOINT: https://no-site.nowhere
           AWS_REGION: us-east-1
-          CI_NODE_TOTAL: ${{ matrix.ci_node_total }}
-          CI_NODE_INDEX: ${{ matrix.ci_node_index }}
+          CI_NODE_TOTAL: ${{ strategy.job-total }}
+          CI_NODE_INDEX: ${{ strategy.job-index }}
         continue-on-error: false
         run : ./bin/parallel-ci
         shell: bash

--- a/.github/workflows/_run_tests.yml
+++ b/.github/workflows/_run_tests.yml
@@ -1,0 +1,115 @@
+# This workflow runs the main test suite.
+#
+# This workflow is pimarily meant to be called by other workflows, but it can be run manually.
+name: "🧪 ~ Run tests"
+on:
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Set N number of parallel jobs you want to run tests on.
+        # Use higher number if you have slow tests to split them on more parallel jobs.
+        # Remember to update ci_node_index below to 0..N-1
+        ci_node_total: [7]
+        # set N-1 indexes for parallel jobs
+        # When you run 2 parallel jobs then first job will have index 0, the second job will have index 1 etc
+        ci_node_index: [0, 1, 2, 3, 4, 5, 6]
+    services:
+      postgres:
+        image: postgres:11-alpine
+        ports:
+          - "5432:5432"
+        env:
+          POSTGRES_DB: rails_test
+          POSTGRES_USER: rails
+          POSTGRES_PASSWORD: password
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      redis:
+        image: redis
+        ports:
+          - "6379:6379"
+        # Set health checks to wait until redis has started
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      RAILS_ENV: test
+      DATABASE_URL: "postgres://rails:password@localhost:5432/rails_test"
+      BUNDLE_JOBS: 2
+      BUNDLE_RETRY: 3
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Ruby and gems
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - name: Cache yarn cache directory
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Cache node_modules
+        uses: actions/cache@v3
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-node-modules-
+
+      - name: asset cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            public/assets
+            tmp/cache/assets/sprockets
+          key: asset-cache-${{ runner.os }}-${{ github.ref }}-${{ github.sha }}
+          restore-keys: |
+            asset-cache-${{ runner.os }}-${{ github.ref }}-${{ github.sha }}
+            asset-cache-${{ runner.os }}-${{ github.ref }}-
+            asset-cache-${{ runner.os }}-
+
+      - name: Set up database schema
+        run: bin/rails db:schema:load
+
+      - run: yarn install
+      - run: yarn build
+      - run: yarn build:css
+
+      - name: Run Tests
+        id: run-tests
+        env:
+          AUTH_ENDPOINT: https://no-site.nowhere
+          AWS_REGION: us-east-1
+          CI_NODE_TOTAL: ${{ matrix.ci_node_total }}
+          CI_NODE_INDEX: ${{ matrix.ci_node_index }}
+        continue-on-error: false
+        run : ./bin/parallel-ci
+        shell: bash
+
+      - name: Test Summary
+        uses: test-summary/action@v2
+        with:
+          paths: "test/reports/**/TEST-*.xml"
+        if: always()

--- a/.github/workflows/_run_tests.yml
+++ b/.github/workflows/_run_tests.yml
@@ -8,14 +8,15 @@ on:
 
 jobs:
   test:
+    name: "🧪"
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        # Set identifiers for parallel jobs. These can be anything.
+        # Set identifiers for parallel jobs. These can be anything. Just include as many items as you want parallelism.
         # For instance if you want a Three Amigos themed pipeline you could use:
         # ci_node_index: [Dusty, Ned, Lucky]
-        ci_runners: [1,2,3,4]
+        ci_runners: ["Orient Express", "Shinkansen", "Eurostar", "Flying Scotsman"]
     services:
       postgres:
         image: postgres:11-alpine

--- a/.github/workflows/_run_tests.yml
+++ b/.github/workflows/_run_tests.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    name: "🧪"
+    name: ""
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -16,7 +16,7 @@ jobs:
         # Set identifiers for parallel jobs. These can be anything. Just include as many items as you want parallelism.
         # For instance if you want a Three Amigos themed pipeline you could use:
         # ci_node_index: [Dusty, Ned, Lucky]
-        ci_runners: ["Orient Express", "Shinkansen", "Eurostar", "Flying Scotsman"]
+        ci_runners: [1,2,3,4]
     services:
       postgres:
         image: postgres:11-alpine

--- a/.github/workflows/_standardrb.yml
+++ b/.github/workflows/_standardrb.yml
@@ -1,0 +1,27 @@
+# This workflow will run standardrb.
+#
+# This workflow is pimarily meant to be called by other workflows, but it can be run manually.
+name: "🔬 ~ Standardrb"
+on:
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    env:
+      RAILS_ENV: test
+      BUNDLE_JOBS: 2
+      BUNDLE_RETRY: 3
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Ruby and gems
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Run Standardrb
+        id: run-standardrb
+        run : bundle exec standardrb

--- a/.github/workflows/ci-cd-pipeline-bt-internal.yml
+++ b/.github/workflows/ci-cd-pipeline-bt-internal.yml
@@ -1,0 +1,20 @@
+# This workflow will run whenever a PR is opened or changed.
+#
+# It will run tests and a few safety checks.
+#
+# If everything passes it can be set to auto-deploy to your staging app on Heroku.
+#
+# This workflow is primarily meant to be triggered automatically, but it can be run manually.
+name: " 🚅 _ BT - Internal CI Pipeline"
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  push:
+    branches: [ "main" ]
+
+jobs:
+  super_scaffolding:
+    name: 🏗️ Super Scaffolding Tests
+    uses: ./.github/workflows/_run_super_scaffolding_tests.yml
+    secrets: inherit

--- a/.github/workflows/ci-cd-pipeline-bt-internal.yml
+++ b/.github/workflows/ci-cd-pipeline-bt-internal.yml
@@ -5,7 +5,7 @@
 # If everything passes it can be set to auto-deploy to your staging app on Heroku.
 #
 # This workflow is primarily meant to be triggered automatically, but it can be run manually.
-name: " 🚅 _ BT - Internal CI Pipeline"
+name: " 🚅 _ BT - Internal CI"
 on:
   workflow_dispatch:
   pull_request:

--- a/.github/workflows/ci-cd-pipeline-bt-internal.yml
+++ b/.github/workflows/ci-cd-pipeline-bt-internal.yml
@@ -15,6 +15,10 @@ on:
 
 jobs:
   super_scaffolding:
+    # This makes it so that this job only runs in the starter repo itself, and not in
+    # applications started from the starter repo. If you want to run super scaffolding
+    # test for your own app you can remove or comment out this next line.
+    if: github.repository == 'bullet-train-co/bullet_train'
     name: 🏗️ Super Scaffolding Tests
     uses: ./.github/workflows/_run_super_scaffolding_tests.yml
     secrets: inherit

--- a/.github/workflows/ci-cd-pipeline-main.yml
+++ b/.github/workflows/ci-cd-pipeline-main.yml
@@ -21,7 +21,7 @@ jobs:
     uses: ./.github/workflows/_standardrb.yml
     secrets: inherit
   db_schema:
-    name: 🔎 DB Schema Check
+    name: 🔎 DB Schema
     uses: ./.github/workflows/_database_schema_check.yml
     secrets: inherit
   # If you'd like to auto-deploy to your production environment you can uncomment this next block.
@@ -30,7 +30,7 @@ jobs:
   # deploy:
   #   name: 🚢 Deploy to Heroku
   #   uses: ./.github/workflows/_deploy_heroku.yml
-  #   needs: [mini_test, super_scaffolding, standardrb, db_schema]
+  #   needs: [mini_test, standardrb, db_schema]
   #   secrets: inherit
   #   with:
   #     heroku-app-name: ""

--- a/.github/workflows/ci-cd-pipeline-main.yml
+++ b/.github/workflows/ci-cd-pipeline-main.yml
@@ -16,10 +16,6 @@ jobs:
     name: 🧪 MiniTest
     uses: ./.github/workflows/_run_tests.yml
     secrets: inherit
-  super_scaffolding:
-    name: 🏗️ Super Scaffolding Tests
-    uses: ./.github/workflows/_run_super_scaffolding_tests.yml
-    secrets: inherit
   standardrb:
     name: 🔬 Standardrb
     uses: ./.github/workflows/_standardrb.yml

--- a/.github/workflows/ci-cd-pipeline-main.yml
+++ b/.github/workflows/ci-cd-pipeline-main.yml
@@ -5,7 +5,7 @@
 # If everything passes it can be set to auto-deploy to your production app on Heroku.
 #
 # This workflow is primarily meant to be triggered automatically, but it can be run manually.
-name: " 🎥 Main CI/CD Pipeline (prod)"
+name: " 🎥 Main CI (prod)"
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/ci-cd-pipeline-main.yml
+++ b/.github/workflows/ci-cd-pipeline-main.yml
@@ -38,10 +38,3 @@ jobs:
   #   secrets: inherit
   #   with:
   #     heroku-app-name: ""
-  deploy:
-    name: 🚢 Deploy to Heroku
-    uses: ./.github/workflows/_deploy_heroku.yml
-    needs: [mini_test, super_scaffolding, standardrb, db_schema]
-    secrets: inherit
-    with:
-      heroku-app-name: "bullettrain-co"

--- a/.github/workflows/ci-cd-pipeline-main.yml
+++ b/.github/workflows/ci-cd-pipeline-main.yml
@@ -1,0 +1,47 @@
+# This workflow will run whenever commits land on the main branch.
+#
+# It will run tests and a few safety checks.
+#
+# If everything passes it can be set to auto-deploy to your production app on Heroku.
+#
+# This workflow is primarily meant to be triggered automatically, but it can be run manually.
+name: " 🎥 Main CI/CD Pipeline (prod)"
+on:
+  workflow_dispatch:
+  push:
+    branches: [ "main" ]
+
+jobs:
+  mini_test:
+    name: 🧪 MiniTest
+    uses: ./.github/workflows/_run_tests.yml
+    secrets: inherit
+  super_scaffolding:
+    name: 🏗️ Super Scaffolding Tests
+    uses: ./.github/workflows/_run_super_scaffolding_tests.yml
+    secrets: inherit
+  standardrb:
+    name: 🔬 Standardrb
+    uses: ./.github/workflows/_standardrb.yml
+    secrets: inherit
+  db_schema:
+    name: 🔎 DB Schema Check
+    uses: ./.github/workflows/_database_schema_check.yml
+    secrets: inherit
+  # If you'd like to auto-deploy to your production environment you can uncomment this next block.
+  # You'll need to set HEROKU_EMAIL and HEROKU_API_KEY in your repo secrets.
+  # Be sure to set the app name correctly below.
+  # deploy:
+  #   name: 🚢 Deploy to Heroku
+  #   uses: ./.github/workflows/_deploy_heroku.yml
+  #   needs: [mini_test, super_scaffolding, standardrb, db_schema]
+  #   secrets: inherit
+  #   with:
+  #     heroku-app-name: ""
+  deploy:
+    name: 🚢 Deploy to Heroku
+    uses: ./.github/workflows/_deploy_heroku.yml
+    needs: [mini_test, super_scaffolding, standardrb, db_schema]
+    secrets: inherit
+    with:
+      heroku-app-name: "bullettrain-co"

--- a/.github/workflows/ci-cd-pipeline-main.yml
+++ b/.github/workflows/ci-cd-pipeline-main.yml
@@ -12,8 +12,8 @@ on:
     branches: [ "main" ]
 
 jobs:
-  mini_test:
-    name: 🧪 MiniTest
+  minitest:
+    name: 🧪 Minitest
     uses: ./.github/workflows/_run_tests.yml
     secrets: inherit
   standardrb:

--- a/.github/workflows/ci-cd-pipeline.yml
+++ b/.github/workflows/ci-cd-pipeline.yml
@@ -21,7 +21,7 @@ jobs:
     uses: ./.github/workflows/_standardrb.yml
     secrets: inherit
   db_schema:
-    name: 🔎 DB Schema Check
+    name: 🔎 DB Schema
     uses: ./.github/workflows/_database_schema_check.yml
     secrets: inherit
   # If you'd like to auto-deploy to your staging environment you can uncomment this next block.
@@ -30,7 +30,7 @@ jobs:
   # deploy:
   #   name: 🚢 Deploy to Heroku
   #   uses: ./.github/workflows/_deploy_heroku.yml
-  #   needs: [mini_test, super_scaffolding, standardrb, db_schema]
+  #   needs: [mini_test, standardrb, db_schema]
   #   secrets: inherit
   #   with:
   #     heroku-app-name: ""

--- a/.github/workflows/ci-cd-pipeline.yml
+++ b/.github/workflows/ci-cd-pipeline.yml
@@ -16,10 +16,6 @@ jobs:
     name: 🧪 MiniTest
     uses: ./.github/workflows/_run_tests.yml
     secrets: inherit
-  super_scaffolding:
-    name: 🏗️ Super Scaffolding Tests
-    uses: ./.github/workflows/_run_super_scaffolding_tests.yml
-    secrets: inherit
   standardrb:
     name: 🔬 Standardrb
     uses: ./.github/workflows/_standardrb.yml

--- a/.github/workflows/ci-cd-pipeline.yml
+++ b/.github/workflows/ci-cd-pipeline.yml
@@ -5,7 +5,7 @@
 # If everything passes it can be set to auto-deploy to your staging app on Heroku.
 #
 # This workflow is primarily meant to be triggered automatically, but it can be run manually.
-name: " 💻 PR CI/CD Pipeline (staging)"
+name: " 💻 PR CI (staging)"
 on:
   workflow_dispatch:
   pull_request:

--- a/.github/workflows/ci-cd-pipeline.yml
+++ b/.github/workflows/ci-cd-pipeline.yml
@@ -1,0 +1,40 @@
+# This workflow will run whenever a PR is opened or changed.
+#
+# It will run tests and a few safety checks.
+#
+# If everything passes it can be set to auto-deploy to your staging app on Heroku.
+#
+# This workflow is primarily meant to be triggered automatically, but it can be run manually.
+name: " 💻 PR CI/CD Pipeline (staging)"
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  mini_test:
+    name: 🧪 MiniTest
+    uses: ./.github/workflows/_run_tests.yml
+    secrets: inherit
+  super_scaffolding:
+    name: 🏗️ Super Scaffolding Tests
+    uses: ./.github/workflows/_run_super_scaffolding_tests.yml
+    secrets: inherit
+  standardrb:
+    name: 🔬 Standardrb
+    uses: ./.github/workflows/_standardrb.yml
+    secrets: inherit
+  db_schema:
+    name: 🔎 DB Schema Check
+    uses: ./.github/workflows/_database_schema_check.yml
+    secrets: inherit
+  # If you'd like to auto-deploy to your staging environment you can uncomment this next block.
+  # You'll need to set HEROKU_EMAIL and HEROKU_API_KEY in your repo secrets.
+  # Be sure to set the app name correctly below.
+  # deploy:
+  #   name: 🚢 Deploy to Heroku
+  #   uses: ./.github/workflows/_deploy_heroku.yml
+  #   needs: [mini_test, super_scaffolding, standardrb, db_schema]
+  #   secrets: inherit
+  #   with:
+  #     heroku-app-name: ""

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,4 +1,4 @@
-name: "Tag & Release"
+name: " 🚅 _ BT - Tag & Release"
 on:
   # Should trigger only when a Pull Request is Merged
   # (the action will not create the Tag if the Pull Request is discarded - closed without merge)

--- a/.github/workflows/upgrade-bullet-train.yml
+++ b/.github/workflows/upgrade-bullet-train.yml
@@ -1,4 +1,6 @@
-name: "Create Bullet Train Upgrade PR"
+# This workflow will create a pull request in your repo that will update
+# your app to whatever version of Bullet Train that you specify.
+name: " ↗️  Create Bullet Train Upgrade PR"
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,4 +1,4 @@
-name: "Create Version Bump PR For Core Gems & NPM Packages"
+name: " 🚅 _ BT - Create Version Bump PR For Core Gems & NPM Packages"
 
 on:
   workflow_dispatch:

--- a/bin/parallel-ci
+++ b/bin/parallel-ci
@@ -1,0 +1,15 @@
+#!/usr/bin/env ruby
+
+sha = ENV['GITHUB_SHA'] || `git rev-parse HEAD`
+node_total = ENV["CI_NODE_TOTAL"] || 1
+node_index = ENV["CI_NODE_INDEX"] || 0
+tests = Dir["test/**/*_test.rb"].
+  sort.
+  # Add randomization seed based on SHA of each commit
+  shuffle(random: Random.new(sha.to_i(16))).
+  select.
+  with_index do |el, i|
+    i % node_total.to_i == node_index.to_i
+  end
+
+system "bundle exec rails test #{tests.join(" ")}", exception: true

--- a/postcss.mailer.config.js
+++ b/postcss.mailer.config.js
@@ -4,7 +4,7 @@ module.exports = {
     require('postcss-extend-rule'),
     require('postcss-nested'),
     require('tailwindcss'),
-    require('postcss-css-variables'),
+    //require('postcss-css-variables'),
     require('autoprefixer'),
   ]
 }

--- a/postcss.mailer.config.js
+++ b/postcss.mailer.config.js
@@ -4,7 +4,7 @@ module.exports = {
     require('postcss-extend-rule'),
     require('postcss-nested'),
     require('tailwindcss'),
-    //require('postcss-css-variables'),
+    require('postcss-css-variables'),
     require('autoprefixer'),
   ]
 }

--- a/test/system/super_scaffolding_test.rb
+++ b/test/system/super_scaffolding_test.rb
@@ -284,8 +284,8 @@ class SuperScaffoldingSystemTest < ApplicationSystemTestCase
   end
 
   test "OpenAPI V3 document is still valid" do
-    visit "http://localhost:3001/api/v1/openapi.yaml"
-    puts(output = `yarn exec redocly lint http://localhost:3001/api/v1/openapi.yaml 1> /dev/stdout 2> /dev/stdout; rm openapi.yaml`)
+    visit "http://127.0.0.1:3001/api/v1/openapi.yaml"
+    puts(output = `yarn exec redocly lint http://127.0.0.1:3001/api/v1/openapi.yaml 1> /dev/stdout 2> /dev/stdout; rm openapi.yaml`)
     # redocly/openapi-core changed the format of their success message in version 1.2.0.
     # https://github.com/Redocly/redocly-cli/pull/1239
     # We use a robust regex here so that we can match both formats.


### PR DESCRIPTION
Fixes https://github.com/bullet-train-co/bullet_train/issues/764
Partially addresses https://github.com/bullet-train-co/bullet_train/issues/1010

This adds several new workflows for GitHub actions (and slightly tweaks some existing workflows to get them to display nicer with the new ones).

![CleanShot 2023-10-20 at 13 04 28](https://github.com/bullet-train-co/bullet_train/assets/58702/59133ce3-8282-4488-a03b-537d428dc62b)

The `💻 PR CI/CD Pipeline (staging)` workflow is configured to automatically run whenever a PR is opened. It will run the main test suite, the super scaffolding tests, standardrb, and a database schema check. Tests are run in a matrix to speed things up, and the matrix can be configured in the workflow. The workflow can also be configured to auto-deploy to a staging app once the tests pass.

![CleanShot 2023-10-20 at 13 18 51](https://github.com/bullet-train-co/bullet_train/assets/58702/88538732-042b-477b-ad41-3788ac66054d)

The `🎥 Main CI/CD Pipeline (prod)` is configured to automatically run whenever a commit lands on `main` either via a PR being merged or from a direct push. It does all the same stuff as the PR workflow, and it can also be configured to auto deploy to a production app once tests pass.

![CleanShot 2023-10-20 at 13 24 12](https://github.com/bullet-train-co/bullet_train/assets/58702/671e5c23-9312-4225-8005-caca8a79a20f)

### Note for internal Bullet Train team

I think these pipelines should also be useful for the starter repo itself and could potentially be a stepping stone to moving stuff from CircleCI to GitHub actions. As they stand now I think these pipelines would replace 4 of the 8 jobs that we run in CircleCI.

![CleanShot 2023-10-20 at 13 31 21](https://github.com/bullet-train-co/bullet_train/assets/58702/294bd48c-1a81-411e-b531-97594a8ddd2a)
