### PR TITLE
Redirect `device_test` definitions to correct test file.

### DIFF
--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -120,6 +120,10 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
     end
   end
 
+  # The `instance_eval` line in `device_test` adds 2 frames in the backtrace which test errors will erroneously point back to.
+  # So we silence those 2 frames.
+  Rails.backtrace_cleaner.add_silencer { /test\/application_system_test_case\.rb.*?(?:instance_eval|device_test)/.match? _1 }
+
   def resize_for(display_details)
     ActiveSupport::Deprecation.warn <<~END_OF_MESSAGE
       `resize_for` is deprecated.

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -128,8 +128,9 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
     @@test_devices.each_key do |device_name|
       test_name = ActiveSupport::Testing::Declarative.instance_method(:test).bind_call(@device_test_methods, "#{name} on a #{device_name}", &block)
 
+      # Standard recommends __FILE__ and __LINE__ + 1 here, which points to `application_system_test_case.rb`. It's wrong.
       # TODO: Figure out why the browser window opens if `resize_display` is done in `setup`.
-      class_eval <<~RUBY, location.path, location.lineno
+      class_eval <<~RUBY, location.path, location.lineno # standard:disable Style/EvalWithLocation
         def #{test_name}; resize_display; super; end # Use single line to match source line numbers properly.
       RUBY
     end

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -128,6 +128,7 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
     @@test_devices.each_key do |device_name|
       test_name = ActiveSupport::Testing::Declarative.instance_method(:test).bind_call(@device_test_methods, "#{name} on a #{device_name}", &block)
 
+      # TODO: Figure out why the browser window opens if `resize_display` is done in `setup`.
       class_eval <<~RUBY, location.path, location.lineno
         def #{test_name}; resize_display; super; end # Use single line to match source line numbers properly.
       RUBY


### PR DESCRIPTION
Fixes https://github.com/bullet-train-co/bullet_train/issues/1082

All this is because Rails' `test` method uses `define_method`, which will report this file as the `source_location`
and not the target test file where the test is actually defined.

`define_method` cannot be passed the correct location, we must use `class_eval` with a source string of Ruby for that.
But using a string means we can't refer to the block, like `define_method(name, &block)` would.

So we inject a module that we define methods via `test` to pass the block to, then we override that
via `class_eval` to point it to the correct location.