### PR TITLE
[CI] Prevent dependencies from floating when linking core repo

### DIFF
--- a/bin/checkout-and-link-core-repo
+++ b/bin/checkout-and-link-core-repo
@@ -55,7 +55,7 @@ do
 done
 
 updates="${packages[@]}"
-bundle lock --update $updates
+bundle lock --conservative --update $updates
 
 
 packages=(


### PR DESCRIPTION
When we do `bundle lock --update ...` that allows various dependencies to float up to a new version if one has been released. This prevents that from happening.

For instance in `bullet_train-api` we specify a dependency on `jbuilder-schema` of `>= 2.4.0`. In `Gemfile.lock` of the starter repo we had it set to `2.5.0`. But when `2.6.0` was released we started to see failured in CI due to a bug. Since the version was just "floating" to `2.6.0` in CI it wasn't immediately obvious that `jbuilder-schema` was getting updated.

Ideally we want to see these kinds of failures when Dependabot generates a PR to update our dependencies. In which case it would be much more obvious that a new verison of a gem is being used.