### PR TITLE
Remove Knapsack Pro

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,21 +118,11 @@ jobs:
       - *wait_for_docker
 
       - run:
-          name: Run tests with Knapsack Pro
-          command: |
-            export RAILS_ENV=test
-            bundle exec rails "knapsack_pro:queue:minitest[--verbose]"
-          environment:
-            KNAPSACK_PRO_CI_NODE_TOTAL: 2
-
-      # If you don't want to use Knapsack Pro, then use this configuration:
-      #
-      # - run:
-      #     name: Run unit tests
-      #     command: bundle exec rails test
-      # - run:
-      #     name: Run system tests
-      #     command: bundle exec rails test:system
+          name: Run unit tests
+          command: bundle exec rails test
+      - run:
+          name: Run system tests
+          command: bundle exec rails test:system
 
       - store_test_results:
           path: test/reports
@@ -172,22 +162,11 @@ jobs:
       - *wait_for_docker
 
       - run:
-          name: Run tests with Knapsack Pro
-          command: |
-            export RAILS_ENV=test
-            bundle exec rails "knapsack_pro:queue:minitest[--verbose]"
-          environment:
-            KNAPSACK_PRO_CI_NODE_TOTAL: 2
-            HIDE_THINGS: true
-
-      # If you don't want to use Knapsack Pro, then use this configuration:
-      #
-      # - run:
-      #     name: Run unit tests with HIDE_THINGS
-      #     command: HIDE_THINGS=true bundle exec rails test
-      # - run:
-      #     name: Run system tests with HIDE_THINGS
-      #     command: HIDE_THINGS=true bundle exec rails test:system
+          name: Run unit tests with HIDE_THINGS
+          command: HIDE_THINGS=true bundle exec rails test
+      - run:
+          name: Run system tests with HIDE_THINGS
+          command: HIDE_THINGS=true bundle exec rails test:system
 
       - store_test_results:
           path: test/reports
@@ -287,15 +266,13 @@ jobs:
               sed -i'.orig' 's/gem "selenium-webdriver"/# gem "selenium-webdriver"/' Gemfile
               sed -i'.orig' 's/gem "webdrivers"/# gem "webdrivers"/' Gemfile
               bundle install
-              bundle exec rails "knapsack_pro:queue:minitest[--verbose]"
+              bundle exec rails test:system
             else
               echo "Skipping system tests with Cuprite"
               exit 0
             fi
           environment:
             RAILS_ENV: test
-            KNAPSACK_PRO_CI_NODE_TOTAL: 2
-            KNAPSACK_PRO_TEST_FILE_PATTERN: "test/system/**{,/*/**}/*_test.rb"
 
   # Uncomment the job at the bottom of this file to run these system tests.
   'System Tests for Action Models':

--- a/Gemfile
+++ b/Gemfile
@@ -163,9 +163,6 @@ group :test do
 
   # Write system tests by pointing and clicking in your browser.
   gem "magic_test"
-
-  # Increase parallelism to run CircleCI tests across multiple nodes
-  gem "knapsack_pro"
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -313,8 +313,6 @@ GEM
       railties (>= 6.0.0)
     json (2.6.3)
     jwt (2.7.1)
-    knapsack_pro (5.7.0)
-      rake
     language_server-protocol (3.17.0.3)
     launchy (2.5.2)
       addressable (~> 2.8)
@@ -665,7 +663,6 @@ DEPENDENCIES
   honeybadger
   jbuilder
   jsbundling-rails
-  knapsack_pro
   letter_opener
   magic_test
   minitest-reporters

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,10 +16,6 @@ I18n.default_locale = :en
 # of setup for things like the plans available for subscriptions and which outgoing webhooks are available to users.
 require File.expand_path("../../db/seeds", __FILE__)
 
-require "knapsack_pro"
-knapsack_pro_adapter = KnapsackPro::Adapters::MinitestAdapter.bind
-knapsack_pro_adapter.set_test_helper_path(__FILE__)
-
 require "sidekiq/testing"
 Sidekiq::Testing.inline!
 


### PR DESCRIPTION
Closes #1124.

We decreased our parallelism recently [here](https://github.com/bullet-train-co/bullet_train/pull/976), and with the current state of things we won't be needing Knapsack Pro anymore.

I believe there's an environment variable on CircleCI, so if this gets cleared we'll have to delete that as well. I'm also currently working on a PR to remove all knapsack pro remains from `bullet_train-core` (I don't think those tests are actually being run, but either way we should remove the Knapsack Pro lines that are still there).

The tests are currently failing due to an OpenAPI issue.
