### PR TITLE
Work on invitation lists tests again

### DIFF
--- a/test/system/invitation_lists_test.rb
+++ b/test/system/invitation_lists_test.rb
@@ -5,6 +5,7 @@ class InvitationListsTest < ApplicationSystemTestCase
     # TODO: Capybara.current_driver is returning :selenium,
     # when it should be either :selenium_chrome or :selenium_chrome_headless.
     Capybara.current_driver = Capybara.default_driver
+    p Capybara.current_driver
 
     @current_bulk_invitations_setting = nil
     BulletTrain.configure do |config|
@@ -40,7 +41,10 @@ class InvitationListsTest < ApplicationSystemTestCase
 
     # Click on next to show that bulk invitations will raise an error if not filled out properly.
     click_on "Next"
-    sleep 3
+    puts "##############################"
+    puts "Debugging Invitation Lists"
+    p page.text.split("\n")
+    puts "##############################"
     assert_text("Email can't be blank")
 
     # Fill in the email addresses.

--- a/test/system/invitation_lists_test.rb
+++ b/test/system/invitation_lists_test.rb
@@ -44,6 +44,7 @@ class InvitationListsTest < ApplicationSystemTestCase
     puts "##############################"
     puts "Debugging Invitation Lists"
     p page.text.split("\n")
+    p page.text.split("\n")
     puts "##############################"
     assert_text("Email can't be blank")
 

--- a/test/system/invitation_lists_test.rb
+++ b/test/system/invitation_lists_test.rb
@@ -41,7 +41,7 @@ class InvitationListsTest < ApplicationSystemTestCase
     # Click on next to show that bulk invitations will raise an error if not filled out properly.
     click_on "Next"
     assert_text("Invite your team members")
-    assert_text("Email address")
+    assert_text("Email Address")
     assert_text("Email can't be blank")
 
     # Fill in the email addresses.

--- a/test/system/invitation_lists_test.rb
+++ b/test/system/invitation_lists_test.rb
@@ -5,7 +5,6 @@ class InvitationListsTest < ApplicationSystemTestCase
     # TODO: Capybara.current_driver is returning :selenium,
     # when it should be either :selenium_chrome or :selenium_chrome_headless.
     Capybara.current_driver = Capybara.default_driver
-    p Capybara.current_driver
 
     @current_bulk_invitations_setting = nil
     BulletTrain.configure do |config|
@@ -41,11 +40,8 @@ class InvitationListsTest < ApplicationSystemTestCase
 
     # Click on next to show that bulk invitations will raise an error if not filled out properly.
     click_on "Next"
-    puts "##############################"
-    puts "Debugging Invitation Lists"
-    p page.text.split("\n")
-    p page.text.split("\n")
-    puts "##############################"
+    assert_text("Invite your team members")
+    assert_text("Email address")
     assert_text("Email can't be blank")
 
     # Fill in the email addresses.


### PR DESCRIPTION
#1028.

Just going to leave this one open as a draft for now, but I'm still thinking it's related to how Capybara responds to `assert_text` after redirects. This time I've added a couple of `assert_text`s beforehand instead.

I've rerun multiple times (seven times to be exact) on the last commit, but again, will just leave this open as a draft for now and re-experiment later.

By the way, here is some debugging information which looks at the page text. The first image is from the first commit in this PR, and the second image from the second commit.

![Capybara 2](https://github.com/bullet-train-co/bullet_train/assets/10546292/1140e6b3-9fd5-4593-a1dd-6b7d96fc73f6)

![Capybara 1](https://github.com/bullet-train-co/bullet_train/assets/10546292/fea8c585-3b82-4847-ae67-527ad373451e)
