### PR TITLE
Avoid buggy versions of factory_bot_rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,7 +64,8 @@ group :development, :test do
   gem "simplecov", require: false
 
   # Generate test objects.
-  gem "factory_bot_rails"
+  # 6.3.0 and 6.4.0 have a bug https://github.com/thoughtbot/factory_bot_rails/issues/433
+  gem 'factory_bot_rails', '~> 6.2', "!= 6.3.0", "!= 6.4.0"
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -65,7 +65,7 @@ group :development, :test do
 
   # Generate test objects.
   # 6.3.0 and 6.4.0 have a bug https://github.com/thoughtbot/factory_bot_rails/issues/433
-  gem 'factory_bot_rails', '~> 6.2', "!= 6.3.0", "!= 6.4.0"
+  gem "factory_bot_rails", "~> 6.2", "!= 6.3.0", "!= 6.4.0"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -668,7 +668,7 @@ DEPENDENCIES
   debug
   devise
   devise-two-factor
-  factory_bot_rails
+  factory_bot_rails (~> 6.2, != 6.4.0, != 6.3.0)
   foreman
   honeybadger
   jbuilder


### PR DESCRIPTION
There's a bug in the latest version of `factory_bot_rails`: https://github.com/thoughtbot/factory_bot_rails/issues/433

There's also a fix that hasn't been merged or released yet: https://github.com/thoughtbot/factory_bot_rails/pull/432

I'm setting the `Gemfile` to specifically avoid those buggy versions so that we can get `depfu` un-blocked with keeping gems up to date.