### PR TITLE
Eager load models when running `erd`

### DIFF
--- a/lib/tasks/auto_generate_diagram.rake
+++ b/lib/tasks/auto_generate_diagram.rake
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# TODO: This is a temporary fix so that rails-erd picks up all of our models.
+# https://github.com/voormedia/rails-erd/issues/322
+if Rails.env.development?
+  RailsERD.load_tasks
+  Rake::Task["erd:load_models"].clear
+
+  namespace :erd do
+    task :load_models do
+      puts "Loading application environment..."
+      Rake::Task[:environment].invoke
+
+      puts "Loading code in search of Active Record models..."
+      Zeitwerk::Loader.eager_load_all
+    end
+  end
+end


### PR DESCRIPTION
https://github.com/bullet-train-co/bullet_train/pull/1058

Reading up on https://github.com/voormedia/rails-erd/issues/322, `Zeitwork::Loader.eager_load_all` will ensure all of our application's models will be included when running `bundle exec erd`.

There were suggestions to put that line inside `config/environment.rb`, but I ultimately went with [this fix](https://github.com/voormedia/rails-erd/issues/322#issuecomment-517992445) which isolates it specifically to the scope of the `erd` command.

I'm not 100% happy having to include a file like this, but it seems like there [still isn't a fix for Rails 7](https://github.com/voormedia/rails-erd/issues/322#issuecomment-1153728972).

With that being said, the command is generating a PDF for the same amount of models (31) before and after this fix. I've decided to submit this PR though so we don't miss anymore models if some are added in the future and aren't captured if we aren't eager loading.

Just for reference, here's the output that I'm getting.

```
> bundle exec erd
Loading application in 'bullet_train'...
Generating entity-relationship diagram for 31 models...
Warning: Ignoring invalid model Scaffolding::AbsolutelyAbstract::CreativeConcepts::Collaborator (table scaffolding_absolutely_abstract_creative_concepts_collaborators does not exist)
Warning: Ignoring invalid association :event_type on Webhooks::Outgoing::Event (model Webhooks::Outgoing::EventType exists, but is not included in domain)
Warning: Ignoring invalid association :collaborators on Scaffolding::AbsolutelyAbstract::CreativeConcept (model Scaffolding::AbsolutelyAbstract::CreativeConcepts::Collaborator exists, but is not included in domain)
Warning: Ignoring invalid association :country on Address (model Addresses::Country exists, but is not included in domain)
Warning: Ignoring invalid association :region on Address (model Addresses::Region exists, but is not included in domain)
Warning: Ignoring invalid association :scaffolding_absolutely_abstract_creative_concepts_collaborators on Membership (model Scaffolding::AbsolutelyAbstract::CreativeConcepts::Collaborator exists, but is not included in domain)
Warning: Ignoring invalid association :scaffolding_absolutely_abstract_creative_concepts_collaborators on User (model Scaffolding::AbsolutelyAbstract::CreativeConcepts::Collaborator exists, but is not included in domain)
Diagram saved to 'erd.pdf'.
```

The tests are failing here, but after merging main on a [different branch](https://github.com/bullet-train-co/bullet_train/tree/rails-erd-extension) you can see that they're passing.

![Screenshot from 2023-11-25 14-52-03](https://github.com/bullet-train-co/bullet_train/assets/10546292/cacba30f-fd4a-49fb-9f94-83f62b7fc6d2)
