### PR TITLE
[CI] Run CORE tests in GitHub Actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -343,7 +343,6 @@ jobs:
 workflows:
   version: 2.1
   build:
-    when: false
     jobs:
       - 'Standard Ruby'
       - 'Database Schema Check'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -340,29 +340,30 @@ jobs:
           name: 'Run Action Models Test'
           command: bundle exec rails test test/system/action_models_test.rb
 
-#workflows:
-  #version: 2.1
-  #build:
-    #jobs:
-      #- 'Standard Ruby'
-      #- 'Database Schema Check'
-      #- 'Minitest':
-          #name: 'Core: Minitest'
-          #use-core-repo: true
-      #- 'Minitest':
-          #name: 'Release: Minitest'
-          #use-core-repo: false
-      #- 'Minitest with HIDE_THINGS':
-          #name: 'Core: Minitest with HIDE_THINGS'
-          #use-core-repo: true
-      #- 'Minitest with HIDE_THINGS':
-          #name: 'Release: Minitest with HIDE_THINGS'
-          #use-core-repo: false
-      #- 'Minitest for Super Scaffolding':
-          #name: 'Core: Minitest for Super Scaffolding'
-          #use-core-repo: true
-      #- 'Minitest for Super Scaffolding':
-          #name: 'Release: Minitest for Super Scaffolding'
-          #use-core-repo: false
-      ## - 'System Tests with Cuprite'
-      ## - 'System Tests for Action Models'
+workflows:
+  version: 2.1
+  build:
+    when: false
+    jobs:
+      - 'Standard Ruby'
+      - 'Database Schema Check'
+      - 'Minitest':
+          name: 'Core: Minitest'
+          use-core-repo: true
+      - 'Minitest':
+          name: 'Release: Minitest'
+          use-core-repo: false
+      - 'Minitest with HIDE_THINGS':
+          name: 'Core: Minitest with HIDE_THINGS'
+          use-core-repo: true
+      - 'Minitest with HIDE_THINGS':
+          name: 'Release: Minitest with HIDE_THINGS'
+          use-core-repo: false
+      - 'Minitest for Super Scaffolding':
+          name: 'Core: Minitest for Super Scaffolding'
+          use-core-repo: true
+      - 'Minitest for Super Scaffolding':
+          name: 'Release: Minitest for Super Scaffolding'
+          use-core-repo: false
+      # - 'System Tests with Cuprite'
+      # - 'System Tests for Action Models'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -340,29 +340,29 @@ jobs:
           name: 'Run Action Models Test'
           command: bundle exec rails test test/system/action_models_test.rb
 
-workflows:
-  version: 2.1
-  build:
-    jobs:
-      - 'Standard Ruby'
-      - 'Database Schema Check'
-      - 'Minitest':
-          name: 'Core: Minitest'
-          use-core-repo: true
-      - 'Minitest':
-          name: 'Release: Minitest'
-          use-core-repo: false
-      - 'Minitest with HIDE_THINGS':
-          name: 'Core: Minitest with HIDE_THINGS'
-          use-core-repo: true
-      - 'Minitest with HIDE_THINGS':
-          name: 'Release: Minitest with HIDE_THINGS'
-          use-core-repo: false
-      - 'Minitest for Super Scaffolding':
-          name: 'Core: Minitest for Super Scaffolding'
-          use-core-repo: true
-      - 'Minitest for Super Scaffolding':
-          name: 'Release: Minitest for Super Scaffolding'
-          use-core-repo: false
-      # - 'System Tests with Cuprite'
-      # - 'System Tests for Action Models'
+#workflows:
+  #version: 2.1
+  #build:
+    #jobs:
+      #- 'Standard Ruby'
+      #- 'Database Schema Check'
+      #- 'Minitest':
+          #name: 'Core: Minitest'
+          #use-core-repo: true
+      #- 'Minitest':
+          #name: 'Release: Minitest'
+          #use-core-repo: false
+      #- 'Minitest with HIDE_THINGS':
+          #name: 'Core: Minitest with HIDE_THINGS'
+          #use-core-repo: true
+      #- 'Minitest with HIDE_THINGS':
+          #name: 'Release: Minitest with HIDE_THINGS'
+          #use-core-repo: false
+      #- 'Minitest for Super Scaffolding':
+          #name: 'Core: Minitest for Super Scaffolding'
+          #use-core-repo: true
+      #- 'Minitest for Super Scaffolding':
+          #name: 'Release: Minitest for Super Scaffolding'
+          #use-core-repo: false
+      ## - 'System Tests with Cuprite'
+      ## - 'System Tests for Action Models'

--- a/.github/workflows/_run_super_scaffolding_tests.yml
+++ b/.github/workflows/_run_super_scaffolding_tests.yml
@@ -91,13 +91,7 @@ jobs:
           CIRCLE_NODE_INDEX: ${{ strategy.job-index }}
 
       - name: 'Run Super Scaffolding Test'
-        run: bundle exec rails test test/system/super_scaffolding_test.rb
-
-      - name: 'Run Super Scaffolding Partial Test'
-        run: bundle exec rails test test/system/super_scaffolding_partial_test.rb
-
-      - name: 'Run Super Scaffolding Incoming Webhooks Test'
-        run: bundle exec rails test test/controllers/webhooks/incoming/some_provider_webhooks_controller_test.rb
+        run: bundle exec rails test test/system/super_scaffolding_test.rb test/system/super_scaffolding_partial_test.rb test/controllers/webhooks/incoming/some_provider_webhooks_controller_test.rb
 
       - name: Test Summary
         uses: test-summary/action@v2

--- a/.github/workflows/_run_super_scaffolding_tests.yml
+++ b/.github/workflows/_run_super_scaffolding_tests.yml
@@ -80,6 +80,13 @@ jobs:
           cache: 'yarn'
           cache-dependency-path: tmp/starter/yarn.lock
 
+      - name: Link Core Repo
+        uses: bullet-train-co/link-core-gems@v1
+        if: ${{ inputs.use-core-repo == true }}
+        with:
+          application_dir: tmp/starter
+          core_dir: tmp/core
+
       - name: asset cache
         uses: actions/cache@v3
         with:

--- a/.github/workflows/_run_super_scaffolding_tests.yml
+++ b/.github/workflows/_run_super_scaffolding_tests.yml
@@ -4,7 +4,17 @@
 name: 🏗️ ~ Run super scaffolding tests
 on:
   workflow_call:
+    inputs:
+      use-core-repo:
+        required: false
+        type: boolean
+        default: false
   workflow_dispatch:
+    inputs:
+      use-core-repo:
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   test:
@@ -48,23 +58,34 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          path: tmp/starter
+
+      - name: Checkout Core Repo
+        uses: bullet-train-co/checkout-repo-with-matching-branch@v1
+        if: ${{ inputs.use-core-repo == true }}
+        with:
+          target_dir: tmp/core
+          repository: bullet-train-co/bullet_train-core
 
       - name: Install Ruby and gems
         uses: ruby/setup-ruby@v1
         with:
+          working-directory: tmp/starter
           bundler-cache: true
 
       - uses: actions/setup-node@v3
         with:
-          node-version-file: .nvmrc
+          node-version-file: tmp/starter/.nvmrc
           cache: 'yarn'
+          cache-dependency-path: tmp/starter/yarn.lock
 
       - name: asset cache
         uses: actions/cache@v3
         with:
           path: |
-            public/assets
-            tmp/cache/assets/sprockets
+            tmp/starter/public/assets
+            tmp/starter/tmp/cache/assets/sprockets
           key: asset-cache-${{ runner.os }}-${{ github.ref }}-${{ github.sha }}
           restore-keys: |
             asset-cache-${{ runner.os }}-${{ github.ref }}-${{ github.sha }}
@@ -73,28 +94,36 @@ jobs:
 
       - name: Set up database schema
         run: bin/rails db:schema:load
+        working-directory: tmp/starter
 
       - run: yarn install
+        working-directory: tmp/starter
       - run: yarn build
+        working-directory: tmp/starter
       - run: yarn build:css
+        working-directory: tmp/starter
 
       # TODO: This might be a bad idea. Maybe we should just have spring in the Gemfile all the time.
       - name: Allow adding of spring
         run: bundle config unset deployment
+        working-directory: tmp/starter
 
       - name: Add spring
         run: bundle add spring
+        working-directory: tmp/starter
 
       - name: 'Setup Super Scaffolding System Test'
         run: bundle exec test/bin/setup-super-scaffolding-system-test
+        working-directory: tmp/starter
         env:
           CIRCLE_NODE_INDEX: ${{ strategy.job-index }}
 
       - name: 'Run Super Scaffolding Test'
         run: bundle exec rails test test/system/super_scaffolding_test.rb test/system/super_scaffolding_partial_test.rb test/controllers/webhooks/incoming/some_provider_webhooks_controller_test.rb
+        working-directory: tmp/starter
 
       - name: Test Summary
         uses: test-summary/action@v2
         with:
-          paths: "test/reports/**/TEST-*.xml"
+          paths: "tmp/starter/test/reports/**/TEST-*.xml"
         if: always()

--- a/.github/workflows/_run_tests.yml
+++ b/.github/workflows/_run_tests.yml
@@ -6,13 +6,13 @@ on:
   workflow_call:
     inputs:
       use-core-repo:
-        required: true
+        required: false
         type: boolean
         default: false
   workflow_dispatch:
     inputs:
       use-core-repo:
-        required: true
+        required: false
         type: boolean
         default: false
 

--- a/.github/workflows/_run_tests.yml
+++ b/.github/workflows/_run_tests.yml
@@ -4,7 +4,17 @@
 name: "🧪 ~ Run tests"
 on:
   workflow_call:
+    inputs:
+      use-core-repo:
+        required: true
+        type: boolean
+        default: false
   workflow_dispatch:
+    inputs:
+      use-core-repo:
+        required: true
+        type: boolean
+        default: false
 
 jobs:
   test:
@@ -50,23 +60,41 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          path: tmp/starter
+
+      - name: Checkout Core Repo
+        uses: bullet-train-co/checkout-repo-with-matching-branch@v1
+        if: ${{ inputs.use-core-repo == true }}
+        with:
+          target_dir: tmp/core
+          repository: bullet-train-co/bullet_train-core
 
       - name: Install Ruby and gems
         uses: ruby/setup-ruby@v1
         with:
+          working-directory: tmp/starter
           bundler-cache: true
 
       - uses: actions/setup-node@v3
         with:
-          node-version-file: .nvmrc
+          node-version-file: tmp/starter/.nvmrc
           cache: 'yarn'
+          cache-dependency-path: tmp/starter/yarn.lock
+
+      - name: Link Core Repo
+        uses: bullet-train-co/link-core-gems@v1
+        if: ${{ inputs.use-core-repo == true }}
+        with:
+          application_dir: tmp/starter
+          core_dir: tmp/core
 
       - name: asset cache
         uses: actions/cache@v3
         with:
           path: |
-            public/assets
-            tmp/cache/assets/sprockets
+            tmp/starter/public/assets
+            tmp/starter/tmp/cache/assets/sprockets
           key: asset-cache-${{ runner.os }}-${{ github.ref }}-${{ github.sha }}
           restore-keys: |
             asset-cache-${{ runner.os }}-${{ github.ref }}-${{ github.sha }}
@@ -75,10 +103,14 @@ jobs:
 
       - name: Set up database schema
         run: bin/rails db:schema:load
+        working-directory: tmp/starter
 
       - run: yarn install
+        working-directory: tmp/starter
       - run: yarn build
+        working-directory: tmp/starter
       - run: yarn build:css
+        working-directory: tmp/starter
 
       - name: Run Tests
         id: run-tests
@@ -89,10 +121,11 @@ jobs:
           CI_NODE_INDEX: ${{ strategy.job-index }}
         continue-on-error: false
         run : ./bin/parallel-ci
+        working-directory: tmp/starter
         shell: bash
 
       - name: Test Summary
         uses: test-summary/action@v2
         with:
-          paths: "test/reports/**/TEST-*.xml"
+          paths: "tmp/starter/test/reports/**/TEST-*.xml"
         if: always()

--- a/.github/workflows/ci-cd-pipeline-bt-internal.yml
+++ b/.github/workflows/ci-cd-pipeline-bt-internal.yml
@@ -22,3 +22,9 @@ jobs:
     name: 🏗️ Super Scaffolding Tests
     uses: ./.github/workflows/_run_super_scaffolding_tests.yml
     secrets: inherit
+  mini_test:
+    name: 🧪 Core: Minitest
+    uses: ./.github/workflows/_run_tests.yml
+    secrets: inherit
+    with:
+      use_core_repo: true

--- a/.github/workflows/ci-cd-pipeline-bt-internal.yml
+++ b/.github/workflows/ci-cd-pipeline-bt-internal.yml
@@ -22,9 +22,23 @@ jobs:
     name: 🏗️ Super Scaffolding Tests
     uses: ./.github/workflows/_run_super_scaffolding_tests.yml
     secrets: inherit
-  mini_test:
+  core_mini_test:
+    # This makes it so that this job only runs in the starter repo itself, and not in
+    # applications started from the starter repo. If you want to run super scaffolding
+    # test for your own app you can remove or comment out this next line.
+    if: github.repository == 'bullet-train-co/bullet_train'
     name: "🧪 Core: Minitest"
     uses: ./.github/workflows/_run_tests.yml
+    secrets: inherit
+    with:
+      use-core-repo: true
+  core_super_scaffolding:
+    # This makes it so that this job only runs in the starter repo itself, and not in
+    # applications started from the starter repo. If you want to run super scaffolding
+    # test for your own app you can remove or comment out this next line.
+    if: github.repository == 'bullet-train-co/bullet_train'
+    name: 🏗️ Super Scaffolding Tests
+    uses: ./.github/workflows/_run_super_scaffolding_tests.yml
     secrets: inherit
     with:
       use-core-repo: true

--- a/.github/workflows/ci-cd-pipeline-bt-internal.yml
+++ b/.github/workflows/ci-cd-pipeline-bt-internal.yml
@@ -23,7 +23,7 @@ jobs:
     uses: ./.github/workflows/_run_super_scaffolding_tests.yml
     secrets: inherit
   mini_test:
-    name: 🧪 Core: Minitest
+    name: "🧪 Core: Minitest"
     uses: ./.github/workflows/_run_tests.yml
     secrets: inherit
     with:

--- a/.github/workflows/ci-cd-pipeline-bt-internal.yml
+++ b/.github/workflows/ci-cd-pipeline-bt-internal.yml
@@ -37,7 +37,7 @@ jobs:
     # applications started from the starter repo. If you want to run super scaffolding
     # test for your own app you can remove or comment out this next line.
     if: github.repository == 'bullet-train-co/bullet_train'
-    name: 🏗️ Super Scaffolding Tests
+    name: "🏗️ Core: Super Scaffolding Tests"
     uses: ./.github/workflows/_run_super_scaffolding_tests.yml
     secrets: inherit
     with:

--- a/.github/workflows/ci-cd-pipeline-bt-internal.yml
+++ b/.github/workflows/ci-cd-pipeline-bt-internal.yml
@@ -27,4 +27,4 @@ jobs:
     uses: ./.github/workflows/_run_tests.yml
     secrets: inherit
     with:
-      use_core_repo: true
+      use-core-repo: true

--- a/.github/workflows/ci-cd-pipeline.yml
+++ b/.github/workflows/ci-cd-pipeline.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   mini_test:
-    name: 🧪 MiniTest
+    name: 🧪 Minitest
     uses: ./.github/workflows/_run_tests.yml
     secrets: inherit
   standardrb:


### PR DESCRIPTION
This makes it so that we run tests against the `core` repo as part of our internal pipeline.

![CleanShot 2023-11-28 at 12 27 17](https://github.com/bullet-train-co/bullet_train/assets/58702/0f7a5f51-0a94-4475-8036-1fe0d0c470b2)

(CircleCI is giving us trouble (again!), so it might be time to migrate away.)