### PR TITLE
[CI] Handle HIDE_THINGS differently in tests

### DIFF
--- a/test/concerns/fields/super_select_support_concern_test.rb
+++ b/test/concerns/fields/super_select_support_concern_test.rb
@@ -1,67 +1,74 @@
 require "test_helper"
 
-unless scaffolding_things_disabled?
-  class Fields::SuperSelectSupportConcernTest < ActiveSupport::TestCase
-    class FakeController < Account::ApplicationController
-      include Fields::SuperSelectSupport
+class Fields::SuperSelectSupportConcernTest < ActiveSupport::TestCase
+  class FakeController < Account::ApplicationController
+    include Fields::SuperSelectSupport
+  end
+
+  setup do
+    @controller = FakeController.new
+    @user = FactoryBot.create :onboarded_user
+    @team = @user.current_team
+
+    @original_hide_things = ENV['HIDE_THINGS']
+    ENV['HIDE_THINGS'] = 'false'
+    Rails.application.reload_routes!
+  end
+
+  teardown do
+    ENV['HIDE_THINGS'] = @original_hide_things
+    Rails.application.reload_routes!
+  end
+
+  test "should not create new model for authorized singular id" do
+    creative_concept = FactoryBot.create :creative_concept, team: @team
+    strong_params = {id: creative_concept.id.to_s}
+
+    strong_params[:id] = @controller.ensure_backing_models_on(@team.scaffolding_absolutely_abstract_creative_concepts, id: strong_params[:id]) do |scope, id|
+      scope.find_or_create_by(name: id)
     end
 
-    setup do
-      @controller = FakeController.new
-      @user = FactoryBot.create :onboarded_user
-      @team = @user.current_team
+    assert_equal strong_params[:id], creative_concept.id.to_s
+  end
+
+  test "should create new model for unauthorized singular numerical id" do
+    @other_user = FactoryBot.create :onboarded_user
+    @other_team = @other_user.current_team
+    unauthorized_creative_concept = FactoryBot.create :creative_concept, team: @other_team
+    strong_params = {id: unauthorized_creative_concept.id.to_s}
+
+    strong_params[:id] = @controller.ensure_backing_models_on(@team.scaffolding_absolutely_abstract_creative_concepts, id: strong_params[:id]) do |scope, id|
+      scope.find_or_create_by(name: id)
     end
 
-    test "should not create new model for authorized singular id" do
-      creative_concept = FactoryBot.create :creative_concept, team: @team
-      strong_params = {id: creative_concept.id.to_s}
+    assert_not_equal strong_params[:id], unauthorized_creative_concept.id.to_s
+  end
 
-      strong_params[:id] = @controller.ensure_backing_models_on(@team.scaffolding_absolutely_abstract_creative_concepts, id: strong_params[:id]) do |scope, id|
-        scope.find_or_create_by(name: id)
-      end
+  test "should create new model for unauthorized singular new_text as id" do
+    creative_concept = nil
+    strong_params = {id: "creative concept one"}
 
-      assert_equal strong_params[:id], creative_concept.id.to_s
+    strong_params[:id] = @controller.ensure_backing_models_on(@team.scaffolding_absolutely_abstract_creative_concepts, id: strong_params[:id]) do |scope, id|
+      creative_concept = scope.find_or_create_by(name: id)
+      creative_concept
     end
 
-    test "should create new model for unauthorized singular numerical id" do
-      @other_user = FactoryBot.create :onboarded_user
-      @other_team = @other_user.current_team
-      unauthorized_creative_concept = FactoryBot.create :creative_concept, team: @other_team
-      strong_params = {id: unauthorized_creative_concept.id.to_s}
+    assert_equal strong_params[:id], creative_concept.id.to_s
+    assert_equal @team.scaffolding_absolutely_abstract_creative_concepts.find(strong_params[:id])&.name, "creative concept one"
+  end
 
-      strong_params[:id] = @controller.ensure_backing_models_on(@team.scaffolding_absolutely_abstract_creative_concepts, id: strong_params[:id]) do |scope, id|
-        scope.find_or_create_by(name: id)
-      end
+  test "should handle a list with authorized id and new text string" do
+    known_creative_concept = FactoryBot.create :creative_concept, team: @team
+    new_creative_concept = nil
+    strong_params = {ids: [known_creative_concept.id.to_s, "creative concept one"]}
 
-      assert_not_equal strong_params[:id], unauthorized_creative_concept.id.to_s
+    strong_params[:ids] = @controller.ensure_backing_models_on(@team.scaffolding_absolutely_abstract_creative_concepts, ids: strong_params[:ids]) do |scope, id|
+      new_creative_concept = scope.find_or_create_by(name: id)
+      new_creative_concept
     end
 
-    test "should create new model for unauthorized singular new_text as id" do
-      creative_concept = nil
-      strong_params = {id: "creative concept one"}
-
-      strong_params[:id] = @controller.ensure_backing_models_on(@team.scaffolding_absolutely_abstract_creative_concepts, id: strong_params[:id]) do |scope, id|
-        creative_concept = scope.find_or_create_by(name: id)
-        creative_concept
-      end
-
-      assert_equal strong_params[:id], creative_concept.id.to_s
-      assert_equal @team.scaffolding_absolutely_abstract_creative_concepts.find(strong_params[:id])&.name, "creative concept one"
-    end
-
-    test "should handle a list with authorized id and new text string" do
-      known_creative_concept = FactoryBot.create :creative_concept, team: @team
-      new_creative_concept = nil
-      strong_params = {ids: [known_creative_concept.id.to_s, "creative concept one"]}
-
-      strong_params[:ids] = @controller.ensure_backing_models_on(@team.scaffolding_absolutely_abstract_creative_concepts, ids: strong_params[:ids]) do |scope, id|
-        new_creative_concept = scope.find_or_create_by(name: id)
-        new_creative_concept
-      end
-
-      assert strong_params[:ids].include?(known_creative_concept.id.to_s)
-      assert strong_params[:ids].include?(new_creative_concept.id.to_s)
-      assert_equal @team.scaffolding_absolutely_abstract_creative_concepts.find(new_creative_concept.id)&.name, "creative concept one"
-    end
+    assert strong_params[:ids].include?(known_creative_concept.id.to_s)
+    assert strong_params[:ids].include?(new_creative_concept.id.to_s)
+    assert_equal @team.scaffolding_absolutely_abstract_creative_concepts.find(new_creative_concept.id)&.name, "creative concept one"
   end
 end

--- a/test/concerns/fields/super_select_support_concern_test.rb
+++ b/test/concerns/fields/super_select_support_concern_test.rb
@@ -10,13 +10,13 @@ class Fields::SuperSelectSupportConcernTest < ActiveSupport::TestCase
     @user = FactoryBot.create :onboarded_user
     @team = @user.current_team
 
-    @original_hide_things = ENV['HIDE_THINGS']
-    ENV['HIDE_THINGS'] = 'false'
+    @original_hide_things = ENV["HIDE_THINGS"]
+    ENV["HIDE_THINGS"] = "false"
     Rails.application.reload_routes!
   end
 
   teardown do
-    ENV['HIDE_THINGS'] = @original_hide_things
+    ENV["HIDE_THINGS"] = @original_hide_things
     Rails.application.reload_routes!
   end
 

--- a/test/controllers/account/scaffolding/absolutely_abstract/creative_concepts_controller_test.rb
+++ b/test/controllers/account/scaffolding/absolutely_abstract/creative_concepts_controller_test.rb
@@ -3,55 +3,64 @@ require "test_helper"
 class Account::Scaffolding::AbsolutelyAbstract::CreativeConceptsControllerTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
 
-  unless scaffolding_things_disabled? # 🚅 skip when scaffolding.
-    def setup
-      super
-      @user = create(:onboarded_user)
-      sign_in @user
-      @team = @user.current_team
-      @creative_concept = create(:scaffolding_absolutely_abstract_creative_concept, team: @team)
+  def setup
+    super
+    @user = create(:onboarded_user)
+    sign_in @user
+    @team = @user.current_team
+    @creative_concept = create(:scaffolding_absolutely_abstract_creative_concept, team: @team)
+
+    @original_hide_things = ENV['HIDE_THINGS']
+    ENV['HIDE_THINGS'] = 'false'
+    Rails.application.reload_routes!
+  end
+
+  def teardown
+    super
+    ENV['HIDE_THINGS'] = @original_hide_things
+    Rails.application.reload_routes!
+  end
+
+
+  test "should get index" do
+    skip("Controller uses uses temporary redirect")
+    get account_team_scaffolding_absolutely_abstract_creative_concepts_url(@team)
+    assert_response :success
+  end
+
+  test "should get new" do
+    get new_account_team_scaffolding_absolutely_abstract_creative_concept_url(@team)
+    assert_response :success
+  end
+
+  test "should create creative_concept" do
+    assert_difference("Scaffolding::AbsolutelyAbstract::CreativeConcept.count") do
+      post account_team_scaffolding_absolutely_abstract_creative_concepts_url(@team), params: {scaffolding_absolutely_abstract_creative_concept: {name: @creative_concept.name}}
     end
 
-    test "should get index" do
-      skip("Controller uses uses temporary redirect")
-      get account_team_scaffolding_absolutely_abstract_creative_concepts_url(@team)
-      assert_response :success
+    assert_redirected_to account_scaffolding_absolutely_abstract_creative_concept_path(Scaffolding::AbsolutelyAbstract::CreativeConcept.last)
+  end
+
+  test "should show creative_concept" do
+    get account_scaffolding_absolutely_abstract_creative_concept_url(@creative_concept)
+    assert_response :success
+  end
+
+  test "should get edit" do
+    get edit_account_scaffolding_absolutely_abstract_creative_concept_url(@creative_concept)
+    assert_response :success
+  end
+
+  test "should update creative_concept" do
+    patch account_scaffolding_absolutely_abstract_creative_concept_url(@creative_concept), params: {scaffolding_absolutely_abstract_creative_concept: {name: @creative_concept.name}}
+    assert_redirected_to account_scaffolding_absolutely_abstract_creative_concept_url(@creative_concept)
+  end
+
+  test "should destroy creative_concept" do
+    assert_difference("Scaffolding::AbsolutelyAbstract::CreativeConcept.count", -1) do
+      delete account_scaffolding_absolutely_abstract_creative_concept_url(@creative_concept)
     end
 
-    test "should get new" do
-      get new_account_team_scaffolding_absolutely_abstract_creative_concept_url(@team)
-      assert_response :success
-    end
-
-    test "should create creative_concept" do
-      assert_difference("Scaffolding::AbsolutelyAbstract::CreativeConcept.count") do
-        post account_team_scaffolding_absolutely_abstract_creative_concepts_url(@team), params: {scaffolding_absolutely_abstract_creative_concept: {name: @creative_concept.name}}
-      end
-
-      assert_redirected_to account_scaffolding_absolutely_abstract_creative_concept_path(Scaffolding::AbsolutelyAbstract::CreativeConcept.last)
-    end
-
-    test "should show creative_concept" do
-      get account_scaffolding_absolutely_abstract_creative_concept_url(@creative_concept)
-      assert_response :success
-    end
-
-    test "should get edit" do
-      get edit_account_scaffolding_absolutely_abstract_creative_concept_url(@creative_concept)
-      assert_response :success
-    end
-
-    test "should update creative_concept" do
-      patch account_scaffolding_absolutely_abstract_creative_concept_url(@creative_concept), params: {scaffolding_absolutely_abstract_creative_concept: {name: @creative_concept.name}}
-      assert_redirected_to account_scaffolding_absolutely_abstract_creative_concept_url(@creative_concept)
-    end
-
-    test "should destroy creative_concept" do
-      assert_difference("Scaffolding::AbsolutelyAbstract::CreativeConcept.count", -1) do
-        delete account_scaffolding_absolutely_abstract_creative_concept_url(@creative_concept)
-      end
-
-      assert_redirected_to account_team_scaffolding_absolutely_abstract_creative_concepts_url(@team)
-    end
+    assert_redirected_to account_team_scaffolding_absolutely_abstract_creative_concepts_url(@team)
   end
 end

--- a/test/controllers/account/scaffolding/absolutely_abstract/creative_concepts_controller_test.rb
+++ b/test/controllers/account/scaffolding/absolutely_abstract/creative_concepts_controller_test.rb
@@ -10,17 +10,16 @@ class Account::Scaffolding::AbsolutelyAbstract::CreativeConceptsControllerTest <
     @team = @user.current_team
     @creative_concept = create(:scaffolding_absolutely_abstract_creative_concept, team: @team)
 
-    @original_hide_things = ENV['HIDE_THINGS']
-    ENV['HIDE_THINGS'] = 'false'
+    @original_hide_things = ENV["HIDE_THINGS"]
+    ENV["HIDE_THINGS"] = "false"
     Rails.application.reload_routes!
   end
 
   def teardown
     super
-    ENV['HIDE_THINGS'] = @original_hide_things
+    ENV["HIDE_THINGS"] = @original_hide_things
     Rails.application.reload_routes!
   end
-
 
   test "should get index" do
     skip("Controller uses uses temporary redirect")

--- a/test/controllers/account/scaffolding/completely_concrete/tangible_things_controller_test.rb
+++ b/test/controllers/account/scaffolding/completely_concrete/tangible_things_controller_test.rb
@@ -14,14 +14,14 @@ class Account::Scaffolding::CompletelyConcrete::TangibleThingsControllerTest < A
     # 🚅 stop any skipping we're doing now.
     # 🚅 super scaffolding will insert factory setup in place of this line.
 
-    @original_hide_things = ENV['HIDE_THINGS']
-    ENV['HIDE_THINGS'] = 'false'
+    @original_hide_things = ENV["HIDE_THINGS"]
+    ENV["HIDE_THINGS"] = "false"
     Rails.application.reload_routes!
   end
 
   def teardown
     super
-    ENV['HIDE_THINGS'] = @original_hide_things
+    ENV["HIDE_THINGS"] = @original_hide_things
     Rails.application.reload_routes!
   end
 

--- a/test/controllers/account/scaffolding/completely_concrete/tangible_things_controller_test.rb
+++ b/test/controllers/account/scaffolding/completely_concrete/tangible_things_controller_test.rb
@@ -3,90 +3,98 @@ require "test_helper"
 class Account::Scaffolding::CompletelyConcrete::TangibleThingsControllerTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
 
-  unless scaffolding_things_disabled? # 🚅 skip when scaffolding.
-    def setup
-      super
-      @user = create(:onboarded_user)
-      sign_in @user
-      @team = @user.current_team
-      # 🚅 skip this section when scaffolding.
-      @absolutely_abstract_creative_concept = create(:scaffolding_absolutely_abstract_creative_concept, team: @team)
-      @tangible_thing = create(:scaffolding_completely_concrete_tangible_thing, absolutely_abstract_creative_concept: @absolutely_abstract_creative_concept)
-      # 🚅 stop any skipping we're doing now.
-      # 🚅 super scaffolding will insert factory setup in place of this line.
-    end
+  def setup
+    super
+    @user = create(:onboarded_user)
+    sign_in @user
+    @team = @user.current_team
+    # 🚅 skip this section when scaffolding.
+    @absolutely_abstract_creative_concept = create(:scaffolding_absolutely_abstract_creative_concept, team: @team)
+    @tangible_thing = create(:scaffolding_completely_concrete_tangible_thing, absolutely_abstract_creative_concept: @absolutely_abstract_creative_concept)
+    # 🚅 stop any skipping we're doing now.
+    # 🚅 super scaffolding will insert factory setup in place of this line.
 
-    test "should get index" do
-      get url_for([:account, @absolutely_abstract_creative_concept, :completely_concrete_tangible_things])
-      assert_response :success
-    end
+    @original_hide_things = ENV['HIDE_THINGS']
+    ENV['HIDE_THINGS'] = 'false'
+    Rails.application.reload_routes!
+  end
 
-    test "should get new" do
-      get url_for([:new, :account, @absolutely_abstract_creative_concept, :completely_concrete_tangible_thing])
-      assert_response :success
-    end
+  def teardown
+    super
+    ENV['HIDE_THINGS'] = @original_hide_things
+    Rails.application.reload_routes!
+  end
 
-    test "should create tangible_thing" do
-      assert_difference("Scaffolding::CompletelyConcrete::TangibleThing.count") do
-        post url_for([:account, @absolutely_abstract_creative_concept, :completely_concrete_tangible_things]), params: {
-          scaffolding_completely_concrete_tangible_thing: {
-            # 🚅 skip this section when scaffolding.
-            text_field_value: "Alternative String Value",
-            button_value: @tangible_thing.button_value,
-            cloudinary_image_value: @tangible_thing.cloudinary_image_value,
-            date_field_value: @tangible_thing.date_field_value,
-            email_field_value: "another.email@test.com",
-            password_field_value: "Alternative String Value",
-            phone_field_value: "+19053871234",
-            super_select_value: @tangible_thing.super_select_value,
-            text_area_value: "Alternative String Value",
-            action_text_value: @tangible_thing.action_text_value,
-            # 🚅 stop any skipping we're doing now.
-            # 🚅 super scaffolding will insert new fields above this line.
-          }
-        }
-      end
+  test "should get index" do
+    get url_for([:account, @absolutely_abstract_creative_concept, :completely_concrete_tangible_things])
+    assert_response :success
+  end
 
-      assert_redirected_to url_for([:account, Scaffolding::CompletelyConcrete::TangibleThing.last])
-    end
+  test "should get new" do
+    get url_for([:new, :account, @absolutely_abstract_creative_concept, :completely_concrete_tangible_thing])
+    assert_response :success
+  end
 
-    test "should show tangible_thing" do
-      get url_for([:account, @tangible_thing])
-      assert_response :success
-    end
-
-    test "should get edit" do
-      get url_for([:edit, :account, @tangible_thing])
-      assert_response :success
-    end
-
-    test "should update tangible_thing" do
-      patch url_for([:account, @tangible_thing]), params: {
+  test "should create tangible_thing" do
+    assert_difference("Scaffolding::CompletelyConcrete::TangibleThing.count") do
+      post url_for([:account, @absolutely_abstract_creative_concept, :completely_concrete_tangible_things]), params: {
         scaffolding_completely_concrete_tangible_thing: {
           # 🚅 skip this section when scaffolding.
-          text_field_value: @tangible_thing.text_field_value,
+          text_field_value: "Alternative String Value",
           button_value: @tangible_thing.button_value,
           cloudinary_image_value: @tangible_thing.cloudinary_image_value,
           date_field_value: @tangible_thing.date_field_value,
-          email_field_value: @tangible_thing.email_field_value,
-          password_field_value: @tangible_thing.password_field_value,
-          phone_field_value: @tangible_thing.phone_field_value,
+          email_field_value: "another.email@test.com",
+          password_field_value: "Alternative String Value",
+          phone_field_value: "+19053871234",
           super_select_value: @tangible_thing.super_select_value,
-          text_area_value: @tangible_thing.text_area_value,
+          text_area_value: "Alternative String Value",
           action_text_value: @tangible_thing.action_text_value,
           # 🚅 stop any skipping we're doing now.
-          # 🚅 super scaffolding will also insert new fields above this line.
+          # 🚅 super scaffolding will insert new fields above this line.
         }
       }
-      assert_redirected_to url_for([:account, @tangible_thing])
     end
 
-    test "should destroy tangible_thing" do
-      assert_difference("Scaffolding::CompletelyConcrete::TangibleThing.count", -1) do
-        delete url_for([:account, @tangible_thing])
-      end
+    assert_redirected_to url_for([:account, Scaffolding::CompletelyConcrete::TangibleThing.last])
+  end
 
-      assert_redirected_to url_for([:account, @absolutely_abstract_creative_concept, :completely_concrete_tangible_things])
+  test "should show tangible_thing" do
+    get url_for([:account, @tangible_thing])
+    assert_response :success
+  end
+
+  test "should get edit" do
+    get url_for([:edit, :account, @tangible_thing])
+    assert_response :success
+  end
+
+  test "should update tangible_thing" do
+    patch url_for([:account, @tangible_thing]), params: {
+      scaffolding_completely_concrete_tangible_thing: {
+        # 🚅 skip this section when scaffolding.
+        text_field_value: @tangible_thing.text_field_value,
+        button_value: @tangible_thing.button_value,
+        cloudinary_image_value: @tangible_thing.cloudinary_image_value,
+        date_field_value: @tangible_thing.date_field_value,
+        email_field_value: @tangible_thing.email_field_value,
+        password_field_value: @tangible_thing.password_field_value,
+        phone_field_value: @tangible_thing.phone_field_value,
+        super_select_value: @tangible_thing.super_select_value,
+        text_area_value: @tangible_thing.text_area_value,
+        action_text_value: @tangible_thing.action_text_value,
+        # 🚅 stop any skipping we're doing now.
+        # 🚅 super scaffolding will also insert new fields above this line.
+      }
+    }
+    assert_redirected_to url_for([:account, @tangible_thing])
+  end
+
+  test "should destroy tangible_thing" do
+    assert_difference("Scaffolding::CompletelyConcrete::TangibleThing.count", -1) do
+      delete url_for([:account, @tangible_thing])
     end
+
+    assert_redirected_to url_for([:account, @absolutely_abstract_creative_concept, :completely_concrete_tangible_things])
   end
 end

--- a/test/controllers/api/v1/scaffolding/completely_concrete/tangible_things_controller_test.rb
+++ b/test/controllers/api/v1/scaffolding/completely_concrete/tangible_things_controller_test.rb
@@ -20,14 +20,14 @@ class Api::V1::Scaffolding::CompletelyConcrete::TangibleThingsControllerTest < A
     @tangible_thing.save
     @another_tangible_thing.save
 
-    @original_hide_things = ENV['HIDE_THINGS']
-    ENV['HIDE_THINGS'] = 'false'
+    @original_hide_things = ENV["HIDE_THINGS"]
+    ENV["HIDE_THINGS"] = "false"
     Rails.application.reload_routes!
   end
 
   def teardown
     super
-    ENV['HIDE_THINGS'] = @original_hide_things
+    ENV["HIDE_THINGS"] = @original_hide_things
     Rails.application.reload_routes!
   end
 
@@ -101,27 +101,27 @@ class Api::V1::Scaffolding::CompletelyConcrete::TangibleThingsControllerTest < A
     # Also ensure we can't do that same action as another user.
     post "/api/v1/scaffolding/absolutely_abstract/creative_concepts/#{@absolutely_abstract_creative_concept.id}/completely_concrete/tangible_things",
       params: params.merge({access_token: another_access_token})
-      assert_response :not_found
+    assert_response :not_found
   end
 
   test "update" do
     # Post an attribute update ensure nothing is seriously broken.
     put "/api/v1/scaffolding/completely_concrete/tangible_things/#{@tangible_thing.id}", params: {
       access_token: access_token,
-        scaffolding_completely_concrete_tangible_thing: {
-          # 🚅 skip this section when scaffolding.
-          text_field_value: "Alternative String Value",
-          button_value: @tangible_thing.button_value,
-          cloudinary_image_value: @tangible_thing.cloudinary_image_value,
-          date_field_value: @tangible_thing.date_field_value,
-          email_field_value: "another.email@test.com",
-          password_field_value: "Alternative String Value",
-          phone_field_value: "+19053871234",
-          super_select_value: @tangible_thing.super_select_value,
-          text_area_value: "Alternative String Value",
-          # 🚅 stop any skipping we're doing now.
-          # 🚅 super scaffolding will also insert new fields above this line.
-        }
+      scaffolding_completely_concrete_tangible_thing: {
+        # 🚅 skip this section when scaffolding.
+        text_field_value: "Alternative String Value",
+        button_value: @tangible_thing.button_value,
+        cloudinary_image_value: @tangible_thing.cloudinary_image_value,
+        date_field_value: @tangible_thing.date_field_value,
+        email_field_value: "another.email@test.com",
+        password_field_value: "Alternative String Value",
+        phone_field_value: "+19053871234",
+        super_select_value: @tangible_thing.super_select_value,
+        text_area_value: "Alternative String Value",
+        # 🚅 stop any skipping we're doing now.
+        # 🚅 super scaffolding will also insert new fields above this line.
+      }
     }
 
     assert_response :success

--- a/test/controllers/api/v1/scaffolding/completely_concrete/tangible_things_controller_test.rb
+++ b/test/controllers/api/v1/scaffolding/completely_concrete/tangible_things_controller_test.rb
@@ -1,104 +1,113 @@
 require "controllers/api/v1/test"
 
 class Api::V1::Scaffolding::CompletelyConcrete::TangibleThingsControllerTest < Api::Test
-  unless scaffolding_things_disabled? # 🚅 skip when scaffolding.
-    def setup
-      # See `test/controllers/api/test.rb` for common set up for API tests.
-      super
+  def setup
+    # See `test/controllers/api/test.rb` for common set up for API tests.
+    super
 
-      # 🚅 skip this section when scaffolding.
-      @absolutely_abstract_creative_concept = create(:scaffolding_absolutely_abstract_creative_concept, team: @team)
-      @tangible_thing = create(:scaffolding_completely_concrete_tangible_thing, absolutely_abstract_creative_concept: @absolutely_abstract_creative_concept)
-      @tangible_thing.file_field_value = Rack::Test::UploadedFile.new("test/support/foo.txt")
-      @tangible_thing.save
-      # 🚅 stop any skipping we're doing now.
-      # 🚅 super scaffolding will insert factory setup in place of this line.
-      @other_tangible_things = create_list(:scaffolding_completely_concrete_tangible_thing, 3)
+    # 🚅 skip this section when scaffolding.
+    @absolutely_abstract_creative_concept = create(:scaffolding_absolutely_abstract_creative_concept, team: @team)
+    @tangible_thing = create(:scaffolding_completely_concrete_tangible_thing, absolutely_abstract_creative_concept: @absolutely_abstract_creative_concept)
+    @tangible_thing.file_field_value = Rack::Test::UploadedFile.new("test/support/foo.txt")
+    @tangible_thing.save
+    # 🚅 stop any skipping we're doing now.
+    # 🚅 super scaffolding will insert factory setup in place of this line.
+    @other_tangible_things = create_list(:scaffolding_completely_concrete_tangible_thing, 3)
 
-      @another_tangible_thing = create(:scaffolding_completely_concrete_tangible_thing, absolutely_abstract_creative_concept: @absolutely_abstract_creative_concept)
+    @another_tangible_thing = create(:scaffolding_completely_concrete_tangible_thing, absolutely_abstract_creative_concept: @absolutely_abstract_creative_concept)
 
-      # 🚅 super scaffolding will insert file-related logic above this line.
-      @tangible_thing.save
-      @another_tangible_thing.save
-    end
+    # 🚅 super scaffolding will insert file-related logic above this line.
+    @tangible_thing.save
+    @another_tangible_thing.save
 
-    # This assertion is written in such a way that new attributes won't cause the tests to start failing, but removing
-    # data we were previously providing to users _will_ break the test suite.
-    def assert_proper_object_serialization(tangible_thing_data)
-      # Fetch the tangible_thing in question and prepare to compare it's attributes.
-      tangible_thing = Scaffolding::CompletelyConcrete::TangibleThing.find(tangible_thing_data["id"])
+    @original_hide_things = ENV['HIDE_THINGS']
+    ENV['HIDE_THINGS'] = 'false'
+    Rails.application.reload_routes!
+  end
 
-      # 🚅 skip this section when scaffolding.
-      assert_equal tangible_thing_data["text_field_value"], tangible_thing.text_field_value
-      assert_equal tangible_thing_data["button_value"], tangible_thing.button_value
-      assert_equal tangible_thing_data["cloudinary_image_value"], tangible_thing.cloudinary_image_value
-      assert_equal Date.parse(tangible_thing_data["date_field_value"]), tangible_thing.date_field_value
-      assert_equal DateTime.parse(tangible_thing_data["date_and_time_field_value"]), tangible_thing.date_and_time_field_value
-      assert_equal tangible_thing_data["email_field_value"], tangible_thing.email_field_value
-      assert_equal tangible_thing_data["password_field_value"], tangible_thing.password_field_value
-      assert_equal tangible_thing_data["phone_field_value"], tangible_thing.phone_field_value
-      assert_equal_or_nil tangible_thing_data["option_value"], tangible_thing.option_value
+  def teardown
+    super
+    ENV['HIDE_THINGS'] = @original_hide_things
+    Rails.application.reload_routes!
+  end
 
-      assert_equal tangible_thing_data["super_select_value"], tangible_thing.super_select_value
-      # assert_equal tangible_thing_data["text_area_value"], tangible_thing.text_area_value
-      # 🚅 stop any skipping we're doing now.
-      # 🚅 super scaffolding will insert new fields above this line.
+  # This assertion is written in such a way that new attributes won't cause the tests to start failing, but removing
+  # data we were previously providing to users _will_ break the test suite.
+  def assert_proper_object_serialization(tangible_thing_data)
+    # Fetch the tangible_thing in question and prepare to compare it's attributes.
+    tangible_thing = Scaffolding::CompletelyConcrete::TangibleThing.find(tangible_thing_data["id"])
 
-      assert_equal tangible_thing_data["absolutely_abstract_creative_concept_id"], tangible_thing.absolutely_abstract_creative_concept_id
-    end
+    # 🚅 skip this section when scaffolding.
+    assert_equal tangible_thing_data["text_field_value"], tangible_thing.text_field_value
+    assert_equal tangible_thing_data["button_value"], tangible_thing.button_value
+    assert_equal tangible_thing_data["cloudinary_image_value"], tangible_thing.cloudinary_image_value
+    assert_equal Date.parse(tangible_thing_data["date_field_value"]), tangible_thing.date_field_value
+    assert_equal DateTime.parse(tangible_thing_data["date_and_time_field_value"]), tangible_thing.date_and_time_field_value
+    assert_equal tangible_thing_data["email_field_value"], tangible_thing.email_field_value
+    assert_equal tangible_thing_data["password_field_value"], tangible_thing.password_field_value
+    assert_equal tangible_thing_data["phone_field_value"], tangible_thing.phone_field_value
+    assert_equal_or_nil tangible_thing_data["option_value"], tangible_thing.option_value
 
-    test "index" do
-      # Fetch and ensure nothing is seriously broken.
-      get "/api/v1/scaffolding/absolutely_abstract/creative_concepts/#{@absolutely_abstract_creative_concept.id}/completely_concrete/tangible_things", params: {access_token: access_token}
-      assert_response :success
+    assert_equal tangible_thing_data["super_select_value"], tangible_thing.super_select_value
+    # assert_equal tangible_thing_data["text_area_value"], tangible_thing.text_area_value
+    # 🚅 stop any skipping we're doing now.
+    # 🚅 super scaffolding will insert new fields above this line.
 
-      # Make sure it's returning our resources.
-      tangible_thing_ids_returned = response.parsed_body.map { |tangible_thing| tangible_thing["id"] }
-      assert_includes(tangible_thing_ids_returned, @tangible_thing.id)
+    assert_equal tangible_thing_data["absolutely_abstract_creative_concept_id"], tangible_thing.absolutely_abstract_creative_concept_id
+  end
 
-      # But not returning other people's resources.
-      assert_not_includes(tangible_thing_ids_returned, @other_tangible_things[0].id)
+  test "index" do
+    # Fetch and ensure nothing is seriously broken.
+    get "/api/v1/scaffolding/absolutely_abstract/creative_concepts/#{@absolutely_abstract_creative_concept.id}/completely_concrete/tangible_things", params: {access_token: access_token}
+    assert_response :success
 
-      # And that the object structure is correct.
-      assert_proper_object_serialization response.parsed_body.first
-    end
+    # Make sure it's returning our resources.
+    tangible_thing_ids_returned = response.parsed_body.map { |tangible_thing| tangible_thing["id"] }
+    assert_includes(tangible_thing_ids_returned, @tangible_thing.id)
 
-    test "show" do
-      # Fetch and ensure nothing is seriously broken.
-      get "/api/v1/scaffolding/completely_concrete/tangible_things/#{@tangible_thing.id}", params: {access_token: access_token}
-      assert_response :success
+    # But not returning other people's resources.
+    assert_not_includes(tangible_thing_ids_returned, @other_tangible_things[0].id)
 
-      # Ensure all the required data is returned properly.
-      assert_proper_object_serialization response.parsed_body
+    # And that the object structure is correct.
+    assert_proper_object_serialization response.parsed_body.first
+  end
 
-      # Also ensure we can't do that same action as another user.
-      get "/api/v1/scaffolding/completely_concrete/tangible_things/#{@tangible_thing.id}", params: {access_token: another_access_token}
+  test "show" do
+    # Fetch and ensure nothing is seriously broken.
+    get "/api/v1/scaffolding/completely_concrete/tangible_things/#{@tangible_thing.id}", params: {access_token: access_token}
+    assert_response :success
+
+    # Ensure all the required data is returned properly.
+    assert_proper_object_serialization response.parsed_body
+
+    # Also ensure we can't do that same action as another user.
+    get "/api/v1/scaffolding/completely_concrete/tangible_things/#{@tangible_thing.id}", params: {access_token: another_access_token}
+    assert_response :not_found
+  end
+
+  test "create" do
+    # Use the serializer to generate a payload, but strip some attributes out.
+    params = {access_token: access_token}
+    tangible_thing_data = JSON.parse(build(:scaffolding_completely_concrete_tangible_thing, absolutely_abstract_creative_concept: nil).api_attributes.to_json)
+    tangible_thing_data.except!("id", "absolutely_abstract_creative_concept_id", "created_at", "updated_at")
+    params[:scaffolding_completely_concrete_tangible_thing] = tangible_thing_data
+
+    post "/api/v1/scaffolding/absolutely_abstract/creative_concepts/#{@absolutely_abstract_creative_concept.id}/completely_concrete/tangible_things", params: params
+    assert_response :success
+
+    # # Ensure all the required data is returned properly.
+    assert_proper_object_serialization response.parsed_body
+
+    # Also ensure we can't do that same action as another user.
+    post "/api/v1/scaffolding/absolutely_abstract/creative_concepts/#{@absolutely_abstract_creative_concept.id}/completely_concrete/tangible_things",
+      params: params.merge({access_token: another_access_token})
       assert_response :not_found
-    end
+  end
 
-    test "create" do
-      # Use the serializer to generate a payload, but strip some attributes out.
-      params = {access_token: access_token}
-      tangible_thing_data = JSON.parse(build(:scaffolding_completely_concrete_tangible_thing, absolutely_abstract_creative_concept: nil).api_attributes.to_json)
-      tangible_thing_data.except!("id", "absolutely_abstract_creative_concept_id", "created_at", "updated_at")
-      params[:scaffolding_completely_concrete_tangible_thing] = tangible_thing_data
-
-      post "/api/v1/scaffolding/absolutely_abstract/creative_concepts/#{@absolutely_abstract_creative_concept.id}/completely_concrete/tangible_things", params: params
-      assert_response :success
-
-      # # Ensure all the required data is returned properly.
-      assert_proper_object_serialization response.parsed_body
-
-      # Also ensure we can't do that same action as another user.
-      post "/api/v1/scaffolding/absolutely_abstract/creative_concepts/#{@absolutely_abstract_creative_concept.id}/completely_concrete/tangible_things",
-        params: params.merge({access_token: another_access_token})
-      assert_response :not_found
-    end
-
-    test "update" do
-      # Post an attribute update ensure nothing is seriously broken.
-      put "/api/v1/scaffolding/completely_concrete/tangible_things/#{@tangible_thing.id}", params: {
-        access_token: access_token,
+  test "update" do
+    # Post an attribute update ensure nothing is seriously broken.
+    put "/api/v1/scaffolding/completely_concrete/tangible_things/#{@tangible_thing.id}", params: {
+      access_token: access_token,
         scaffolding_completely_concrete_tangible_thing: {
           # 🚅 skip this section when scaffolding.
           text_field_value: "Alternative String Value",
@@ -113,39 +122,38 @@ class Api::V1::Scaffolding::CompletelyConcrete::TangibleThingsControllerTest < A
           # 🚅 stop any skipping we're doing now.
           # 🚅 super scaffolding will also insert new fields above this line.
         }
-      }
+    }
 
+    assert_response :success
+
+    # Ensure all the required data is returned properly.
+    assert_proper_object_serialization response.parsed_body
+
+    # But we have to manually assert the value was properly updated.
+    @tangible_thing.reload
+    # 🚅 skip this section when scaffolding.
+    assert_equal @tangible_thing.text_field_value, "Alternative String Value"
+    assert_equal @tangible_thing.email_field_value, "another.email@test.com"
+    assert_equal @tangible_thing.password_field_value, "Alternative String Value"
+    assert_equal @tangible_thing.phone_field_value, "+19053871234"
+    assert_equal @tangible_thing.text_area_value, "Alternative String Value"
+    # 🚅 stop any skipping we're doing now.
+    # 🚅 super scaffolding will additionally insert new fields above this line.
+
+    # Also ensure we can't do that same action as another user.
+    put "/api/v1/scaffolding/completely_concrete/tangible_things/#{@tangible_thing.id}", params: {access_token: another_access_token}
+    assert_response :not_found
+  end
+
+  test "destroy" do
+    # Delete and ensure it actually went away.
+    assert_difference("Scaffolding::CompletelyConcrete::TangibleThing.count", -1) do
+      delete "/api/v1/scaffolding/completely_concrete/tangible_things/#{@tangible_thing.id}", params: {access_token: access_token}
       assert_response :success
-
-      # Ensure all the required data is returned properly.
-      assert_proper_object_serialization response.parsed_body
-
-      # But we have to manually assert the value was properly updated.
-      @tangible_thing.reload
-      # 🚅 skip this section when scaffolding.
-      assert_equal @tangible_thing.text_field_value, "Alternative String Value"
-      assert_equal @tangible_thing.email_field_value, "another.email@test.com"
-      assert_equal @tangible_thing.password_field_value, "Alternative String Value"
-      assert_equal @tangible_thing.phone_field_value, "+19053871234"
-      assert_equal @tangible_thing.text_area_value, "Alternative String Value"
-      # 🚅 stop any skipping we're doing now.
-      # 🚅 super scaffolding will additionally insert new fields above this line.
-
-      # Also ensure we can't do that same action as another user.
-      put "/api/v1/scaffolding/completely_concrete/tangible_things/#{@tangible_thing.id}", params: {access_token: another_access_token}
-      assert_response :not_found
     end
 
-    test "destroy" do
-      # Delete and ensure it actually went away.
-      assert_difference("Scaffolding::CompletelyConcrete::TangibleThing.count", -1) do
-        delete "/api/v1/scaffolding/completely_concrete/tangible_things/#{@tangible_thing.id}", params: {access_token: access_token}
-        assert_response :success
-      end
-
-      # Also ensure we can't do that same action as another user.
-      delete "/api/v1/scaffolding/completely_concrete/tangible_things/#{@another_tangible_thing.id}", params: {access_token: another_access_token}
-      assert_response :not_found
-    end
-  end # 🚅 skip when scaffolding.
+    # Also ensure we can't do that same action as another user.
+    delete "/api/v1/scaffolding/completely_concrete/tangible_things/#{@another_tangible_thing.id}", params: {access_token: another_access_token}
+    assert_response :not_found
+  end
 end

--- a/test/system/account_test.rb
+++ b/test/system/account_test.rb
@@ -5,7 +5,6 @@ class AccountTest < ApplicationSystemTestCase
     super
     @jane = create :onboarded_user, first_name: "Jane", last_name: "Smith"
     login_as(@jane, scope: :user)
-    puts "@jane = #{@jane.as_json}"
     visit root_path
     if billing_enabled?
       unless freemium_enabled?

--- a/test/system/account_test.rb
+++ b/test/system/account_test.rb
@@ -5,6 +5,7 @@ class AccountTest < ApplicationSystemTestCase
     super
     @jane = create :onboarded_user, first_name: "Jane", last_name: "Smith"
     login_as(@jane, scope: :user)
+    puts "@jane = #{@jane.as_json}"
     visit root_path
     if billing_enabled?
       unless freemium_enabled?

--- a/test/system/dates_helper_test.rb
+++ b/test/system/dates_helper_test.rb
@@ -1,81 +1,92 @@
 require "application_system_test_case"
 
 class DatesHelperTest < ApplicationSystemTestCase
-  unless scaffolding_things_disabled?
-    device_test "Time is displayed correctly" do
-      be_invited_to_sign_up
-      visit root_path
+  def setup
+    super
+    @original_hide_things = ENV['HIDE_THINGS']
+    ENV['HIDE_THINGS'] = 'false'
+    Rails.application.reload_routes!
+  end
 
-      # Sign up and log in
-      new_registration_page_for(display_details)
-      fill_in "Your Email Address", with: "bullettrain@gmail.com"
-      fill_in "Set Password", with: example_password
-      fill_in "Confirm Password", with: example_password
-      click_on "Sign Up"
-      fill_in "First Name", with: "Testy"
-      fill_in "Last Name", with: "McTesterson"
-      fill_in "Your Team Name", with: "The Testing Team"
-      select "(GMT+00:00) UTC", from: "Your Time Zone"
-      click_on "Next"
-      click_on "Skip" if bulk_invitations_enabled?
+  def teardown
+    super
+    ENV['HIDE_THINGS'] = @original_hide_things
+    Rails.application.reload_routes!
+  end
 
-      if billing_enabled?
-        unless freemium_enabled?
-          complete_pricing_page
-        end
+  device_test "Time is displayed correctly" do
+    be_invited_to_sign_up
+    visit root_path
+
+    # Sign up and log in
+    new_registration_page_for(display_details)
+    fill_in "Your Email Address", with: "bullettrain@gmail.com"
+    fill_in "Set Password", with: example_password
+    fill_in "Confirm Password", with: example_password
+    click_on "Sign Up"
+    fill_in "First Name", with: "Testy"
+    fill_in "Last Name", with: "McTesterson"
+    fill_in "Your Team Name", with: "The Testing Team"
+    select "(GMT+00:00) UTC", from: "Your Time Zone"
+    click_on "Next"
+    click_on "Skip" if bulk_invitations_enabled?
+
+    if billing_enabled?
+      unless freemium_enabled?
+        complete_pricing_page
       end
-
-      # Create a Tangible Thing
-      click_on "Creative Concepts"
-      click_on "Add New Creative Concept"
-      fill_in "Name", with: "Test Concept"
-      fill_in "Description", with: "Test Description"
-      click_on "Create Creative Concept"
-      click_on "Add New Tangible Thing"
-      fill_in "Text Field Value", with: "Test Tangible Thing"
-      click_on "Create Tangible Thing"
-      assert page.has_text? "Tangible Thing was successfully created."
-
-      time = Scaffolding::CompletelyConcrete::TangibleThing.first.created_at
-
-      # Go to the Tangible Thing's index page.
-      click_on "Back"
-
-      # Assert today's date is displayed correctly.
-      assert_text "Today at #{time.strftime("%l:%M %p").strip}"
-
-      # Assert yesterday's date is displayed correctly.
-      travel_to time + 1.day
-      visit current_url # Refresh the page
-      assert_text "Yesterday at #{time.strftime("%l:%M %p").strip}"
-
-      # Assert the month and day is shown for anything before then.
-      travel_to time + 2.days
-      visit current_url
-
-      # We have to assert these two things separately so it doesn't fail on the last day of the year when the year is present.
-      assert_text time.strftime("%B %-d").strip.to_s
-      assert_text "at #{time.strftime("%l:%M %p").strip}"
-
-      # Create a new record in a different time zone.
-      Time.zone = "Tokyo"
-
-      # No need to check the strings on the page if the record
-      # is successfully created and the times below are different.
-      visit account_team_path(Team.find_by(name: "The Testing Team"))
-      click_on "Test Concept"
-      click_on "Add New Tangible Thing"
-      fill_in "Text Field Value", with: "Another Test Tangible Thing"
-      click_on "Create Tangible Thing"
-      assert page.has_text? "Tangible Thing was successfully created."
-
-      # Compare by hours instead of seconds/minutes for accuracy.
-      tokyo_time = Scaffolding::CompletelyConcrete::TangibleThing.find_by(text_field_value: "Another Test Tangible Thing").created_at
-      refute time.strftime("%l").to_i == tokyo_time.strftime("%l").to_i
-
-      # Even if we push UTC time forward by an hour,
-      # it should still be behind Tokyo time.
-      assert tokyo_time > (time + 1.hour)
     end
+
+    # Create a Tangible Thing
+    click_on "Creative Concepts"
+    click_on "Add New Creative Concept"
+    fill_in "Name", with: "Test Concept"
+    fill_in "Description", with: "Test Description"
+    click_on "Create Creative Concept"
+    click_on "Add New Tangible Thing"
+    fill_in "Text Field Value", with: "Test Tangible Thing"
+    click_on "Create Tangible Thing"
+    assert page.has_text? "Tangible Thing was successfully created."
+
+    time = Scaffolding::CompletelyConcrete::TangibleThing.first.created_at
+
+    # Go to the Tangible Thing's index page.
+    click_on "Back"
+
+    # Assert today's date is displayed correctly.
+    assert_text "Today at #{time.strftime("%l:%M %p").strip}"
+
+    # Assert yesterday's date is displayed correctly.
+    travel_to time + 1.day
+    visit current_url # Refresh the page
+    assert_text "Yesterday at #{time.strftime("%l:%M %p").strip}"
+
+    # Assert the month and day is shown for anything before then.
+    travel_to time + 2.days
+    visit current_url
+
+    # We have to assert these two things separately so it doesn't fail on the last day of the year when the year is present.
+    assert_text time.strftime("%B %-d").strip.to_s
+    assert_text "at #{time.strftime("%l:%M %p").strip}"
+
+    # Create a new record in a different time zone.
+    Time.zone = "Tokyo"
+
+    # No need to check the strings on the page if the record
+    # is successfully created and the times below are different.
+    visit account_team_path(Team.find_by(name: "The Testing Team"))
+    click_on "Test Concept"
+    click_on "Add New Tangible Thing"
+    fill_in "Text Field Value", with: "Another Test Tangible Thing"
+    click_on "Create Tangible Thing"
+    assert page.has_text? "Tangible Thing was successfully created."
+
+    # Compare by hours instead of seconds/minutes for accuracy.
+    tokyo_time = Scaffolding::CompletelyConcrete::TangibleThing.find_by(text_field_value: "Another Test Tangible Thing").created_at
+    refute time.strftime("%l").to_i == tokyo_time.strftime("%l").to_i
+
+    # Even if we push UTC time forward by an hour,
+    # it should still be behind Tokyo time.
+    assert tokyo_time > (time + 1.hour)
   end
 end

--- a/test/system/dates_helper_test.rb
+++ b/test/system/dates_helper_test.rb
@@ -3,14 +3,14 @@ require "application_system_test_case"
 class DatesHelperTest < ApplicationSystemTestCase
   def setup
     super
-    @original_hide_things = ENV['HIDE_THINGS']
-    ENV['HIDE_THINGS'] = 'false'
+    @original_hide_things = ENV["HIDE_THINGS"]
+    ENV["HIDE_THINGS"] = "false"
     Rails.application.reload_routes!
   end
 
   def teardown
     super
-    ENV['HIDE_THINGS'] = @original_hide_things
+    ENV["HIDE_THINGS"] = @original_hide_things
     Rails.application.reload_routes!
   end
 

--- a/test/system/fields_test.rb
+++ b/test/system/fields_test.rb
@@ -1,17 +1,16 @@
 require "application_system_test_case"
 
-
 class AccountTest < ApplicationSystemTestCase
   def setup
     super
-    @original_hide_things = ENV['HIDE_THINGS']
-    ENV['HIDE_THINGS'] = 'false'
+    @original_hide_things = ENV["HIDE_THINGS"]
+    ENV["HIDE_THINGS"] = "false"
     Rails.application.reload_routes!
   end
 
   def teardown
     super
-    ENV['HIDE_THINGS'] = @original_hide_things
+    ENV["HIDE_THINGS"] = @original_hide_things
     Rails.application.reload_routes!
   end
 

--- a/test/system/fields_test.rb
+++ b/test/system/fields_test.rb
@@ -1,6 +1,6 @@
 require "application_system_test_case"
 
-class AccountTest < ApplicationSystemTestCase
+class FieldsTest < ApplicationSystemTestCase
   def setup
     super
     @original_hide_things = ENV["HIDE_THINGS"]

--- a/test/system/fields_test.rb
+++ b/test/system/fields_test.rb
@@ -1,79 +1,91 @@
 require "application_system_test_case"
 
-unless scaffolding_things_disabled?
-  class AccountTest < ApplicationSystemTestCase
-    device_test "simulate restoring behavior of form fields on page restore" do
-      # TODO: This is an ugly hack to ensure the default device_test user isn't logged in.
-      # This is happening when the entire device_test suite is run.
-      visit account_team_path(Team.first) if Team.first
-      if page.text.match?("Your Team’s Dashboard")
-        sign_out_for(display_details)
+
+class AccountTest < ApplicationSystemTestCase
+  def setup
+    super
+    @original_hide_things = ENV['HIDE_THINGS']
+    ENV['HIDE_THINGS'] = 'false'
+    Rails.application.reload_routes!
+  end
+
+  def teardown
+    super
+    ENV['HIDE_THINGS'] = @original_hide_things
+    Rails.application.reload_routes!
+  end
+
+  device_test "simulate restoring behavior of form fields on page restore" do
+    # TODO: This is an ugly hack to ensure the default device_test user isn't logged in.
+    # This is happening when the entire device_test suite is run.
+    visit account_team_path(Team.first) if Team.first
+    if page.text.match?("Your Team’s Dashboard")
+      sign_out_for(display_details)
+    end
+
+    new_session_page_for(display_details)
+    invitation_only? ? be_invited_to_sign_up : click_on("Don't have an account?")
+    assert_text("Create Your Account")
+    fill_in "Your Email Address", with: "me@acme.com"
+    fill_in "Set Password", with: example_password
+    fill_in "Confirm Password", with: example_password
+    click_on "Sign Up"
+    fill_in "Your First Name", with: "John"
+    fill_in "Your Last Name", with: "Doe"
+    fill_in "Your Team Name", with: "My Super Team"
+    page.select "Brisbane", from: "Your Time Zone"
+    click_on "Next"
+    click_on "Skip" if bulk_invitations_enabled?
+
+    if billing_enabled?
+      unless freemium_enabled?
+        complete_pricing_page
       end
+    end
 
-      new_session_page_for(display_details)
-      invitation_only? ? be_invited_to_sign_up : click_on("Don't have an account?")
-      assert_text("Create Your Account")
-      fill_in "Your Email Address", with: "me@acme.com"
-      fill_in "Set Password", with: example_password
-      fill_in "Confirm Password", with: example_password
-      click_on "Sign Up"
-      fill_in "Your First Name", with: "John"
-      fill_in "Your Last Name", with: "Doe"
-      fill_in "Your Team Name", with: "My Super Team"
-      page.select "Brisbane", from: "Your Time Zone"
-      click_on "Next"
-      click_on "Skip" if bulk_invitations_enabled?
+    click_on "Add New Creative Concept"
+    fill_in "Name", with: "My Generic Creative Concept"
+    fill_in "Description", with: "Dummy description for my creative concept"
+    click_on "Create Creative Concept"
 
-      if billing_enabled?
-        unless freemium_enabled?
-          complete_pricing_page
-        end
-      end
+    click_on "Add New Tangible Thing"
 
-      click_on "Add New Creative Concept"
-      fill_in "Name", with: "My Generic Creative Concept"
-      fill_in "Description", with: "Dummy description for my creative concept"
-      click_on "Create Creative Concept"
+    select2_select "Multiple Super Select Values", ["Five", "Six"]
+    super_select = find_stimulus_controller_for_label "Multiple Super Select Values", "fields--super-select"
+    assert_no_js_errors do
+      disconnect_stimulus_controller_on super_select
+      reconnect_stimulus_controller_on super_select
+      improperly_disconnect_and_reconnect_stimulus_controller_on super_select
+      select2_select "Multiple Super Select Values", ["Four"]
+      assert super_select.has_css?(".select2-container--default", count: 1)
+    end
 
-      click_on "Add New Tangible Thing"
+    button = find_stimulus_controller_for_label "Button Value", "fields--button-toggle"
+    click_on "One"
+    assert_no_js_errors do
+      disconnect_stimulus_controller_on button
+      reconnect_stimulus_controller_on button
+      assert button.find('input[type="radio"]', visible: false)["checked"]
+      improperly_disconnect_and_reconnect_stimulus_controller_on button # the radio button won't be checked because we're using innerHTML
+    end
 
-      select2_select "Multiple Super Select Values", ["Five", "Six"]
-      super_select = find_stimulus_controller_for_label "Multiple Super Select Values", "fields--super-select"
-      assert_no_js_errors do
-        disconnect_stimulus_controller_on super_select
-        reconnect_stimulus_controller_on super_select
-        improperly_disconnect_and_reconnect_stimulus_controller_on super_select
-        select2_select "Multiple Super Select Values", ["Four"]
-        assert super_select.has_css?(".select2-container--default", count: 1)
-      end
+    phone_field_wrapper = find_stimulus_controller_for_label "Phone Field Value", "fields--phone", wrapper: true
+    phone_field = phone_field_wrapper.first("input")
+    "+1 613".chars.each do |digit|
+      phone_field.send_keys(digit)
+    end
+    assert_no_js_errors do
+      disconnect_stimulus_controller_on phone_field_wrapper
+      reconnect_stimulus_controller_on phone_field_wrapper
+      improperly_disconnect_and_reconnect_stimulus_controller_on phone_field_wrapper
+      assert phone_field_wrapper.first(".iti__selected-flag")["title"] == "Canada: +1"
+    end
 
-      button = find_stimulus_controller_for_label "Button Value", "fields--button-toggle"
-      click_on "One"
-      assert_no_js_errors do
-        disconnect_stimulus_controller_on button
-        reconnect_stimulus_controller_on button
-        assert button.find('input[type="radio"]', visible: false)["checked"]
-        improperly_disconnect_and_reconnect_stimulus_controller_on button # the radio button won't be checked because we're using innerHTML
-      end
-
-      phone_field_wrapper = find_stimulus_controller_for_label "Phone Field Value", "fields--phone", wrapper: true
-      phone_field = phone_field_wrapper.first("input")
-      "+1 613".chars.each do |digit|
-        phone_field.send_keys(digit)
-      end
-      assert_no_js_errors do
-        disconnect_stimulus_controller_on phone_field_wrapper
-        reconnect_stimulus_controller_on phone_field_wrapper
-        improperly_disconnect_and_reconnect_stimulus_controller_on phone_field_wrapper
-        assert phone_field_wrapper.first(".iti__selected-flag")["title"] == "Canada: +1"
-      end
-
-      date_field = find_stimulus_controller_for_label "Date Field Value", "fields--date"
-      assert_no_js_errors do
-        disconnect_stimulus_controller_on date_field
-        reconnect_stimulus_controller_on date_field
-        improperly_disconnect_and_reconnect_stimulus_controller_on date_field
-      end
+    date_field = find_stimulus_controller_for_label "Date Field Value", "fields--date"
+    assert_no_js_errors do
+      disconnect_stimulus_controller_on date_field
+      reconnect_stimulus_controller_on date_field
+      improperly_disconnect_and_reconnect_stimulus_controller_on date_field
     end
   end
 end

--- a/test/system/pagination_test.rb
+++ b/test/system/pagination_test.rb
@@ -6,14 +6,14 @@ class PaginationTest < ApplicationSystemTestCase
     @jane = create :onboarded_user, first_name: "Jane", last_name: "Smith"
     @team = @jane.current_team
 
-    @original_hide_things = ENV['HIDE_THINGS']
-    ENV['HIDE_THINGS'] = 'false'
+    @original_hide_things = ENV["HIDE_THINGS"]
+    ENV["HIDE_THINGS"] = "false"
     Rails.application.reload_routes!
   end
 
   def teardown
     super
-    ENV['HIDE_THINGS'] = @original_hide_things
+    ENV["HIDE_THINGS"] = @original_hide_things
     Rails.application.reload_routes!
   end
 

--- a/test/system/pagination_test.rb
+++ b/test/system/pagination_test.rb
@@ -5,34 +5,42 @@ class PaginationTest < ApplicationSystemTestCase
     super
     @jane = create :onboarded_user, first_name: "Jane", last_name: "Smith"
     @team = @jane.current_team
+
+    @original_hide_things = ENV['HIDE_THINGS']
+    ENV['HIDE_THINGS'] = 'false'
+    Rails.application.reload_routes!
   end
 
-  unless scaffolding_things_disabled?
-    device_test "pagination works properly" do
-      login_as(@jane, scope: :user)
+  def teardown
+    super
+    ENV['HIDE_THINGS'] = @original_hide_things
+    Rails.application.reload_routes!
+  end
 
-      creative_concept = @team.scaffolding_absolutely_abstract_creative_concepts.create(name: "Test Name")
+  device_test "pagination works properly" do
+    login_as(@jane, scope: :user)
 
-      # Pagy::DEFAULT[:items] denotes the max of records that exist on one page.
-      (Pagy::DEFAULT[:items] + 1).times do |n|
-        creative_concept.completely_concrete_tangible_things.create(text_field_value: "Test #{n + 1}")
-      end
+    creative_concept = @team.scaffolding_absolutely_abstract_creative_concepts.create(name: "Test Name")
 
-      visit root_path
-      if billing_enabled?
-        unless freemium_enabled?
-          complete_pricing_page
-          sleep 2
-        end
-      end
-
-      visit account_scaffolding_absolutely_abstract_creative_concept_path(creative_concept)
-
-      assert_text("Test 1")
-      refute_text("Test #{Pagy::DEFAULT[:items] + 1}")
-
-      click_on "Next"
-      assert_text("Test #{Pagy::DEFAULT[:items] + 1}")
+    # Pagy::DEFAULT[:items] denotes the max of records that exist on one page.
+    (Pagy::DEFAULT[:items] + 1).times do |n|
+      creative_concept.completely_concrete_tangible_things.create(text_field_value: "Test #{n + 1}")
     end
+
+    visit root_path
+    if billing_enabled?
+      unless freemium_enabled?
+        complete_pricing_page
+        sleep 2
+      end
+    end
+
+    visit account_scaffolding_absolutely_abstract_creative_concept_path(creative_concept)
+
+    assert_text("Test 1")
+    refute_text("Test #{Pagy::DEFAULT[:items] + 1}")
+
+    click_on "Next"
+    assert_text("Test #{Pagy::DEFAULT[:items] + 1}")
   end
 end

--- a/test/system/reactivity_system_test.rb
+++ b/test/system/reactivity_system_test.rb
@@ -1,106 +1,117 @@
 require "application_system_test_case"
 
-unless scaffolding_things_disabled?
-  class ReactivitySystemTest < ApplicationSystemTestCase
-    device_test "create a new tangible thing and update it" do
-      visit user_session_path
+class ReactivitySystemTest < ApplicationSystemTestCase
+  def setup
+    super
+    @original_hide_things = ENV['HIDE_THINGS']
+    ENV['HIDE_THINGS'] = 'false'
+    Rails.application.reload_routes!
+  end
 
-      invitation_only? ? be_invited_to_sign_up : click_on("Don't have an account?")
-      assert_text("Create Your Account")
-      fill_in "Your Email Address", with: "me@acme.com"
-      fill_in "Set Password", with: example_password
-      fill_in "Confirm Password", with: example_password
-      click_on "Sign Up"
-      fill_in "Your First Name", with: "John"
-      fill_in "Your Last Name", with: "Doe"
-      fill_in "Your Team Name", with: "My Super Team"
-      page.select "Brisbane", from: "Your Time Zone"
-      click_on "Next"
-      click_on "Skip" if bulk_invitations_enabled?
+  def teardown
+    super
+    ENV['HIDE_THINGS'] = @original_hide_things
+    Rails.application.reload_routes!
+  end
 
-      if billing_enabled?
-        unless freemium_enabled?
-          complete_pricing_page
-        end
+  device_test "create a new tangible thing and update it" do
+    visit user_session_path
+
+    invitation_only? ? be_invited_to_sign_up : click_on("Don't have an account?")
+    assert_text("Create Your Account")
+    fill_in "Your Email Address", with: "me@acme.com"
+    fill_in "Set Password", with: example_password
+    fill_in "Confirm Password", with: example_password
+    click_on "Sign Up"
+    fill_in "Your First Name", with: "John"
+    fill_in "Your Last Name", with: "Doe"
+    fill_in "Your Team Name", with: "My Super Team"
+    page.select "Brisbane", from: "Your Time Zone"
+    click_on "Next"
+    click_on "Skip" if bulk_invitations_enabled?
+
+    if billing_enabled?
+      unless freemium_enabled?
+        complete_pricing_page
       end
+    end
 
-      # We should be on the account dashboard with no Creative Concepts listed.
+    # We should be on the account dashboard with no Creative Concepts listed.
+    assert_text "My Super Team’s Dashboard"
+    assert_text "If you're wondering what this"
+
+    # Open a new window. We'll bounce back and forth between these two to ensure updates are happening in both places.
+    current_url = page.current_url
+    second_window = open_new_window
+
+    # We're going to do some activity and assertions within the new window.
+    within_window second_window do
+      visit current_url
       assert_text "My Super Team’s Dashboard"
+
+      # Ensure we're on a page with no Creative Concepts listed.
+      # (This sets us up to confirm that an entire table manifests out of nowhere.)
       assert_text "If you're wondering what this"
+    end
 
-      # Open a new window. We'll bounce back and forth between these two to ensure updates are happening in both places.
-      current_url = page.current_url
-      second_window = open_new_window
+    # We're now back on the regular window to take additional actions.
+    click_on "Add New Creative Concept"
 
-      # We're going to do some activity and assertions within the new window.
-      within_window second_window do
-        visit current_url
-        assert_text "My Super Team’s Dashboard"
+    fill_in "Name", with: "My Generic Creative Concept"
+    fill_in "Description", with: "Dummy description for my creative concept"
+    click_on "Create Creative Concept"
 
-        # Ensure we're on a page with no Creative Concepts listed.
-        # (This sets us up to confirm that an entire table manifests out of nowhere.)
-        assert_text "If you're wondering what this"
-      end
+    assert_text "Creative Concept was successfully created."
 
-      # We're now back on the regular window to take additional actions.
-      click_on "Add New Creative Concept"
+    within_window second_window do
+      # Ensure we're still on the same page.
+      assert_text "My Super Team’s Dashboard"
 
-      fill_in "Name", with: "My Generic Creative Concept"
-      fill_in "Description", with: "Dummy description for my creative concept"
-      click_on "Create Creative Concept"
+      # But now the new Creative Concept should be present on the page.
+      assert_text "My Generic Creative Concept"
 
-      assert_text "Creative Concept was successfully created."
+      # Since we're already here, and the other window is already on the show page, let's edit from here so we can
+      # ensure the show page is properly wired up as well.
+      click_on "Edit"
 
-      within_window second_window do
-        # Ensure we're still on the same page.
-        assert_text "My Super Team’s Dashboard"
+      fill_in "Name", with: "My Updated Creative Concept"
+      click_on "Update Creative Concept"
 
-        # But now the new Creative Concept should be present on the page.
-        assert_text "My Generic Creative Concept"
+      assert_text "Creative Concept was successfully updated."
+    end
 
-        # Since we're already here, and the other window is already on the show page, let's edit from here so we can
-        # ensure the show page is properly wired up as well.
-        click_on "Edit"
+    # Ensure this first tab hasn't been refreshed by ensuring it still has that original flash message on it.
+    assert_text "Creative Concept was successfully created."
 
-        fill_in "Name", with: "My Updated Creative Concept"
-        click_on "Update Creative Concept"
+    # But also ensure the Creative Concept presentation has been updated.
+    assert_text "My Updated Creative Concept"
 
-        assert_text "Creative Concept was successfully updated."
-      end
-
-      # Ensure this first tab hasn't been refreshed by ensuring it still has that original flash message on it.
-      assert_text "Creative Concept was successfully created."
-
-      # But also ensure the Creative Concept presentation has been updated.
-      assert_text "My Updated Creative Concept"
-
-      # Now for the final device_test, we need one of the tabs to be looking at the index.
-      within_window second_window do
-        click_on "Back"
-
-        # Confirm that we're still looking at a populated list of Creative Concepts.
-        assert_text "If you're wondering what this"
-      end
-
-      # Now that someone is looking at the index, let's destroy the Creative Concept.
-
-      # click_on "Remove Creative Concept"
-
-      # ☝️ This actually causes the device_test to fail because the page we're looking at receives the dirty signal before
-      # the browser is redirected and tries to reload the very page we're looking on, which is then a 404. We'll have
-      # to try and figure this scenario out. So for now, we'll do it like this, from the index page:
-
+    # Now for the final device_test, we need one of the tabs to be looking at the index.
+    within_window second_window do
       click_on "Back"
-      accept_alert { click_on "Delete" }
 
-      assert_text "Creative Concept was successfully destroyed."
+      # Confirm that we're still looking at a populated list of Creative Concepts.
       assert_text "If you're wondering what this"
+    end
 
-      # Now for the final device_test, we need one of the tabs to be looking at the index.
-      within_window second_window do
-        # Confirm that we're no longer looking at a populated list of Creative Concepts.
-        assert_text "If you're wondering what this"
-      end
+    # Now that someone is looking at the index, let's destroy the Creative Concept.
+
+    # click_on "Remove Creative Concept"
+
+    # ☝️ This actually causes the device_test to fail because the page we're looking at receives the dirty signal before
+    # the browser is redirected and tries to reload the very page we're looking on, which is then a 404. We'll have
+    # to try and figure this scenario out. So for now, we'll do it like this, from the index page:
+
+    click_on "Back"
+    accept_alert { click_on "Delete" }
+
+    assert_text "Creative Concept was successfully destroyed."
+    assert_text "If you're wondering what this"
+
+    # Now for the final device_test, we need one of the tabs to be looking at the index.
+    within_window second_window do
+      # Confirm that we're no longer looking at a populated list of Creative Concepts.
+      assert_text "If you're wondering what this"
     end
   end
 end

--- a/test/system/reactivity_system_test.rb
+++ b/test/system/reactivity_system_test.rb
@@ -3,14 +3,14 @@ require "application_system_test_case"
 class ReactivitySystemTest < ApplicationSystemTestCase
   def setup
     super
-    @original_hide_things = ENV['HIDE_THINGS']
-    ENV['HIDE_THINGS'] = 'false'
+    @original_hide_things = ENV["HIDE_THINGS"]
+    ENV["HIDE_THINGS"] = "false"
     Rails.application.reload_routes!
   end
 
   def teardown
     super
-    ENV['HIDE_THINGS'] = @original_hide_things
+    ENV["HIDE_THINGS"] = @original_hide_things
     Rails.application.reload_routes!
   end
 

--- a/test/system/tangible_thing_test.rb
+++ b/test/system/tangible_thing_test.rb
@@ -3,14 +3,14 @@ require "application_system_test_case"
 class TangibleThingTest < ApplicationSystemTestCase
   def setup
     super
-    @original_hide_things = ENV['HIDE_THINGS']
-    ENV['HIDE_THINGS'] = 'false'
+    @original_hide_things = ENV["HIDE_THINGS"]
+    ENV["HIDE_THINGS"] = "false"
     Rails.application.reload_routes!
   end
 
   def teardown
     super
-    ENV['HIDE_THINGS'] = @original_hide_things
+    ENV["HIDE_THINGS"] = @original_hide_things
     Rails.application.reload_routes!
   end
 

--- a/test/system/tangible_thing_test.rb
+++ b/test/system/tangible_thing_test.rb
@@ -1,119 +1,130 @@
 require "application_system_test_case"
 
-unless scaffolding_things_disabled?
-  class TangibleThingTest < ApplicationSystemTestCase
-    device_test "create a new tangible thing and update it" do
-      visit user_session_path
+class TangibleThingTest < ApplicationSystemTestCase
+  def setup
+    super
+    @original_hide_things = ENV['HIDE_THINGS']
+    ENV['HIDE_THINGS'] = 'false'
+    Rails.application.reload_routes!
+  end
 
-      invitation_only? ? be_invited_to_sign_up : click_on("Don't have an account?")
-      assert_text("Create Your Account")
-      fill_in "Your Email Address", with: "me@acme.com"
-      fill_in "Set Password", with: example_password
-      fill_in "Confirm Password", with: example_password
-      click_on "Sign Up"
-      fill_in "Your First Name", with: "John"
-      fill_in "Your Last Name", with: "Doe"
-      fill_in "Your Team Name", with: "My Super Team"
-      page.select "Brisbane", from: "Your Time Zone"
-      click_on "Next"
-      click_on "Skip" if bulk_invitations_enabled?
+  def teardown
+    super
+    ENV['HIDE_THINGS'] = @original_hide_things
+    Rails.application.reload_routes!
+  end
 
-      if billing_enabled?
-        unless freemium_enabled?
-          complete_pricing_page
-        end
+  device_test "create a new tangible thing and update it" do
+    visit user_session_path
+
+    invitation_only? ? be_invited_to_sign_up : click_on("Don't have an account?")
+    assert_text("Create Your Account")
+    fill_in "Your Email Address", with: "me@acme.com"
+    fill_in "Set Password", with: example_password
+    fill_in "Confirm Password", with: example_password
+    click_on "Sign Up"
+    fill_in "Your First Name", with: "John"
+    fill_in "Your Last Name", with: "Doe"
+    fill_in "Your Team Name", with: "My Super Team"
+    page.select "Brisbane", from: "Your Time Zone"
+    click_on "Next"
+    click_on "Skip" if bulk_invitations_enabled?
+
+    if billing_enabled?
+      unless freemium_enabled?
+        complete_pricing_page
       end
-
-      visit edit_account_user_path(User.find_by!(email: "me@acme.com"))
-      page.select "Tokyo", from: "Your Time Zone"
-      click_on "Update Profile"
-      visit account_teams_path(Team.find_by!(name: "My Super Team"))
-
-      click_on "Add New Creative Concept"
-      fill_in "Name", with: "My Generic Creative Concept"
-      fill_in "Description", with: "Dummy description for my creative concept"
-      click_on "Create Creative Concept"
-
-      click_on "Add New Tangible Thing"
-      fill_in "Text Field Value", with: "My value for this text field"
-      click_on "Yes"
-      click_on "Two" # this should never make it to the database, because of what comes next.
-      click_on "Three"
-      click_on "Four"
-      click_on "Five"
-      page.all('input[id^="scaffolding_completely_concrete_tangible_thing_date_field_value"]').each do |el|
-        el.click
-      end
-      find(".daterangepicker").click_on("Apply")
-      page.all('input[id^="scaffolding_completely_concrete_tangible_thing_date_and_time_field_value"]').each do |el|
-        el.click
-      end
-      find(".daterangepicker").click_on("Apply")
-      fill_in "Email Field Value", with: "me@acme.com"
-      fill_in "Password Field Value", with: "secure-password"
-      fill_in "Phone Field Value", with: "(201) 551-8321"
-
-      assert_text "State / Province"
-      select "Japan", from: "Country"
-      assert_text "Prefecture"
-      select "United States", from: "Country"
-      assert_text "State"
-
-      fill_in "Address", with: "123 Main St."
-      fill_in "City", with: "New York"
-      select "New York", from: "State"
-      fill_in "Zip code", with: "10001"
-
-      select "One", from: "Super Select Value"
-      select2_select "Multiple Super Select Values", ["Five", "Six"]
-      fill_in "Text Area Value", with: "Long text for this text area field"
-
-      click_on "Create Tangible Thing"
-      assert_text "Tangible Thing was successfully created."
-
-      # Creating a Tangible Thing redirects to its show page.
-      assert_text "Tangible Thing Details"
-
-      assert_text "My value for this text field"
-      assert_text "Yes"
-      assert page.has_no_content? "Two"
-      assert_text "Three"
-      assert_text "Four and Five"
-      assert_text "me@acme.com"
-      assert_text "secure-password"
-      assert_text "+1 201-551-8321"
-      assert_text "One"
-      assert_text "Five and Six"
-      assert_text "Long text for this text area field"
-      assert_text "123 Main St."
-      assert_text "New York"
-      assert_text "UNITED STATES"
-      assert_text "10001"
-
-      click_on "Edit Tangible Thing"
-
-      fill_in "Text Field Value", with: "My new value for this text field"
-      click_on "No"
-      click_on "One"
-      fill_in "Date Field Value", with: "02/17/2021"
-      fill_in "Date and Time Field Value", with: "08/15/2023 8:00 PM"
-
-      fill_in "Email Field Value", with: "not-me@acme.com"
-      fill_in "Password Field Value", with: "insecure-password"
-      fill_in "Phone Field Value", with: "(231) 832-5512"
-      page.select "Two", from: "Super Select Value"
-      fill_in "Text Area Value", with: "New long text for this text area field"
-
-      click_on "Update Tangible Thing"
-
-      assert_text "My new value for this text field"
-      assert_text "No"
-      assert_text "One"
-      assert_text "not-me@acme.com"
-      assert_text "insecure-password"
-      assert_text "+1 231-832-5512"
-      assert_text "Two"
-      assert_text "New long text for this text area field"
     end
+
+    visit edit_account_user_path(User.find_by!(email: "me@acme.com"))
+    page.select "Tokyo", from: "Your Time Zone"
+    click_on "Update Profile"
+    visit account_teams_path(Team.find_by!(name: "My Super Team"))
+
+    click_on "Add New Creative Concept"
+    fill_in "Name", with: "My Generic Creative Concept"
+    fill_in "Description", with: "Dummy description for my creative concept"
+    click_on "Create Creative Concept"
+
+    click_on "Add New Tangible Thing"
+    fill_in "Text Field Value", with: "My value for this text field"
+    click_on "Yes"
+    click_on "Two" # this should never make it to the database, because of what comes next.
+    click_on "Three"
+    click_on "Four"
+    click_on "Five"
+    page.all('input[id^="scaffolding_completely_concrete_tangible_thing_date_field_value"]').each do |el|
+      el.click
+    end
+    find(".daterangepicker").click_on("Apply")
+    page.all('input[id^="scaffolding_completely_concrete_tangible_thing_date_and_time_field_value"]').each do |el|
+      el.click
+    end
+    find(".daterangepicker").click_on("Apply")
+    fill_in "Email Field Value", with: "me@acme.com"
+    fill_in "Password Field Value", with: "secure-password"
+    fill_in "Phone Field Value", with: "(201) 551-8321"
+
+    assert_text "State / Province"
+    select "Japan", from: "Country"
+    assert_text "Prefecture"
+    select "United States", from: "Country"
+    assert_text "State"
+
+    fill_in "Address", with: "123 Main St."
+    fill_in "City", with: "New York"
+    select "New York", from: "State"
+    fill_in "Zip code", with: "10001"
+
+    select "One", from: "Super Select Value"
+    select2_select "Multiple Super Select Values", ["Five", "Six"]
+    fill_in "Text Area Value", with: "Long text for this text area field"
+
+    click_on "Create Tangible Thing"
+    assert_text "Tangible Thing was successfully created."
+
+    # Creating a Tangible Thing redirects to its show page.
+    assert_text "Tangible Thing Details"
+
+    assert_text "My value for this text field"
+    assert_text "Yes"
+    assert page.has_no_content? "Two"
+    assert_text "Three"
+    assert_text "Four and Five"
+    assert_text "me@acme.com"
+    assert_text "secure-password"
+    assert_text "+1 201-551-8321"
+    assert_text "One"
+    assert_text "Five and Six"
+    assert_text "Long text for this text area field"
+    assert_text "123 Main St."
+    assert_text "New York"
+    assert_text "UNITED STATES"
+    assert_text "10001"
+
+    click_on "Edit Tangible Thing"
+
+    fill_in "Text Field Value", with: "My new value for this text field"
+    click_on "No"
+    click_on "One"
+    fill_in "Date Field Value", with: "02/17/2021"
+    fill_in "Date and Time Field Value", with: "08/15/2023 8:00 PM"
+
+    fill_in "Email Field Value", with: "not-me@acme.com"
+    fill_in "Password Field Value", with: "insecure-password"
+    fill_in "Phone Field Value", with: "(231) 832-5512"
+    page.select "Two", from: "Super Select Value"
+    fill_in "Text Area Value", with: "New long text for this text area field"
+
+    click_on "Update Tangible Thing"
+
+    assert_text "My new value for this text field"
+    assert_text "No"
+    assert_text "One"
+    assert_text "not-me@acme.com"
+    assert_text "insecure-password"
+    assert_text "+1 231-832-5512"
+    assert_text "Two"
+    assert_text "New long text for this text area field"
   end
 end

--- a/test/system/webhooks_system_test.rb
+++ b/test/system/webhooks_system_test.rb
@@ -10,14 +10,14 @@ class WebhooksSystemTest < ApplicationSystemTestCase
     Rails.configuration.outgoing_webhooks[:allowed_hostnames] = [URI.parse(Capybara.app_host).host]
     Rails.configuration.outgoing_webhooks[:blocked_hostnames] = []
 
-    @original_hide_things = ENV['HIDE_THINGS']
-    ENV['HIDE_THINGS'] = 'false'
+    @original_hide_things = ENV["HIDE_THINGS"]
+    ENV["HIDE_THINGS"] = "false"
     Rails.application.reload_routes!
   end
 
   def teardown
     super
-    ENV['HIDE_THINGS'] = @original_hide_things
+    ENV["HIDE_THINGS"] = @original_hide_things
     Rails.application.reload_routes!
   end
 
@@ -222,5 +222,4 @@ class WebhooksSystemTest < ApplicationSystemTestCase
 
     assert_text("Delivery Attempt Details")
   end
-
 end

--- a/test/system/webhooks_system_test.rb
+++ b/test/system/webhooks_system_test.rb
@@ -9,210 +9,218 @@ class WebhooksSystemTest < ApplicationSystemTestCase
 
     Rails.configuration.outgoing_webhooks[:allowed_hostnames] = [URI.parse(Capybara.app_host).host]
     Rails.configuration.outgoing_webhooks[:blocked_hostnames] = []
+
+    @original_hide_things = ENV['HIDE_THINGS']
+    ENV['HIDE_THINGS'] = 'false'
+    Rails.application.reload_routes!
   end
 
-  unless scaffolding_things_disabled?
-    device_test "team member registers for webhooks and then receives them" do
-      login_as(@user, scope: :user)
+  def teardown
+    super
+    ENV['HIDE_THINGS'] = @original_hide_things
+    Rails.application.reload_routes!
+  end
 
-      visit root_path
-      if billing_enabled?
-        unless freemium_enabled?
-          complete_pricing_page
-          sleep 2
-        end
+  device_test "team member registers for webhooks and then receives them" do
+    login_as(@user, scope: :user)
+
+    visit root_path
+    if billing_enabled?
+      unless freemium_enabled?
+        complete_pricing_page
+        sleep 2
       end
+    end
 
-      visit account_dashboard_path
+    visit account_dashboard_path
 
-      # create the endpoint.
-      if disable_developer_menu?
-        visit account_team_webhooks_outgoing_endpoints_path(@user.current_team)
-      else
-        within_developers_menu_for(display_details) do
-          click_on "Webhooks"
-        end
+    # create the endpoint.
+    if disable_developer_menu?
+      visit account_team_webhooks_outgoing_endpoints_path(@user.current_team)
+    else
+      within_developers_menu_for(display_details) do
+        click_on "Webhooks"
       end
-      click_on "Add New Endpoint"
-      fill_in "Name", with: "Some Bullet Train App"
-      fill_in "URL", with: "#{Capybara.app_host}/webhooks/incoming/bullet_train_webhooks"
-      select2_select "Event Types", ["thing.create", "thing.update"]
-      click_on "Create Endpoint"
-      assert_text("Endpoint was successfully created.")
+    end
+    click_on "Add New Endpoint"
+    fill_in "Name", with: "Some Bullet Train App"
+    fill_in "URL", with: "#{Capybara.app_host}/webhooks/incoming/bullet_train_webhooks"
+    select2_select "Event Types", ["thing.create", "thing.update"]
+    click_on "Create Endpoint"
+    assert_text("Endpoint was successfully created.")
 
-      # trigger the webhook event.
-      within_primary_menu_for(display_details) do
-        click_on "Creative Concepts"
-      end
+    # trigger the webhook event.
+    within_primary_menu_for(display_details) do
+      click_on "Creative Concepts"
+    end
 
-      assert_text "Your Team’s Creative Concepts"
+    assert_text "Your Team’s Creative Concepts"
 
-      click_on "Add New Creative Concept"
-      assert_text "New Creative Concept Details"
+    click_on "Add New Creative Concept"
+    assert_text "New Creative Concept Details"
 
-      assert_difference "Webhooks::Outgoing::Event.count", 0, "an outbound webhook event should not be issued" do
-        fill_in "Name", with: "Testing"
-        click_on "Create Creative Concept"
-        assert_text "Creative Concept was successfully created"
-
-        perform_enqueued_jobs
-      end
-
-      assert_difference "Webhooks::Outgoing::Delivery.count", 1, "an outbound webhook delivery should be issued" do
-        click_on "Add New Tangible Thing"
-        assert_text "New Tangible Thing Details"
-        fill_in "Text Field Value", with: "Some Thing"
-        click_on "Create Tangible Thing"
-        assert_text "Tangible Thing was successfully created"
-
-        perform_enqueued_jobs
-      end
-
-      # Go to index page.
-      click_on "Back"
-
-      assert_difference "Webhooks::Incoming::BulletTrainWebhook.count", 1, "an inbound webhook should be received" do
-        click_on "Add New Tangible Thing"
-        fill_in "Text Field Value", with: "Some Other Thing"
-        click_on "Create Tangible Thing"
-        assert_text "Tangible Thing was successfully created"
-
-        perform_enqueued_jobs
-      end
-
-      assert_difference "Webhooks::Outgoing::Delivery.count", 1, "an outbound webhook should be issued" do
-        assert_text "Tangible Thing Details"
-        click_on "Edit Tangible Thing"
-        assert_text "Edit Tangible Thing Details"
-        fill_in "Text Field Value", with: "Some Updated Thing"
-        click_on "Update Tangible Thing"
-        assert_text "Tangible Thing was successfully updated"
-
-        perform_enqueued_jobs
-      end
-
-      assert_difference "Webhooks::Incoming::BulletTrainWebhook.count", 1, "an inbound webhook should be received" do
-        click_on "Edit Tangible Thing"
-        fill_in "Text Field Value", with: "One Last Updated Thing"
-        click_on "Update Tangible Thing"
-        assert_text "Tangible Thing was successfully updated"
-
-        perform_enqueued_jobs
-      end
-
-      click_on "Back"
-
-      assert_difference "Webhooks::Outgoing::Delivery.count", 0, "an outbound webhook should not be issued" do
-        within("table tr:first-child[data-id]") do
-          accept_alert { click_on "Delete" }
-        end
-        assert_text("Tangible Thing was successfully destroyed.")
-
-        perform_enqueued_jobs
-      end
-
-      sign_out_for(display_details)
-
-      # create a thing as another user and confirm no webhooks are issued to the original user.
-      login_as(@another_user, scope: :user)
-      visit root_path
-      if billing_enabled?
-        unless freemium_enabled?
-          complete_pricing_page
-          sleep 2
-        end
-      end
-
-      visit account_dashboard_path
-
-      # trigger the webhook event.
-      within_primary_menu_for(display_details) do
-        click_on "Creative Concepts"
-      end
-
-      assert_text "Your Team’s Creative Concepts"
-
-      click_on "Add New Creative Concept"
-      assert_text "New Creative Concept Details"
-
+    assert_difference "Webhooks::Outgoing::Event.count", 0, "an outbound webhook event should not be issued" do
       fill_in "Name", with: "Testing"
       click_on "Create Creative Concept"
       assert_text "Creative Concept was successfully created"
 
-      # make sure that when a user takes an action that would trigger a webhook event that another user's has an
-      # endpoint configured to receive, that the webhooks don't bleed across teams.
-      assert_difference "Webhooks::Outgoing::Delivery.count", 0, "an outbound webhook should not be issued" do
-        click_on "Add New Tangible Thing"
-        fill_in "Text Field Value", with: "Some Thing"
-        click_on "Create Tangible Thing"
-        assert_text("Tangible Thing was successfully created.")
-
-        perform_enqueued_jobs
-      end
-
-      # create the endpoint.
-      if disable_developer_menu?
-        visit account_team_webhooks_outgoing_endpoints_path(@another_user.current_team)
-      else
-        within_developers_menu_for(display_details) do
-          click_on "Webhooks"
-        end
-      end
-      click_on "Add New Endpoint"
-      fill_in "Name", with: "Some Bullet Train App"
-      fill_in "URL", with: "#{Capybara.app_host}/webhooks/incoming/bullet_train_webhooks"
-      click_on "Create Endpoint"
-      assert_text("Endpoint was successfully created.")
-
-      # trigger the webhook event.
-      within_primary_menu_for(display_details) do
-        click_on "Creative Concepts"
-      end
-
-      assert_text "Your Team’s Creative Concepts"
-
-      click_on "Testing"
-      assert_text "Creative Concept Details"
-
-      assert_difference "Webhooks::Incoming::BulletTrainWebhook.count", 1, "an inbound webhook should be received" do
-        assert_difference "Webhooks::Outgoing::Delivery.count", 1, "an outbound webhook should be issued" do
-          within("table tr:first-child[data-id]") do
-            accept_alert { click_on "Delete" }
-          end
-          assert_text("Tangible Thing was successfully destroyed.")
-          perform_enqueued_jobs
-        end
-
-        perform_enqueued_jobs
-      end
-
-      if disable_developer_menu?
-        visit account_team_webhooks_outgoing_endpoints_path(@another_user.current_team)
-      else
-        within_developers_menu_for(display_details) do
-          click_on "Webhooks"
-        end
-      end
-
-      within("table tr:first-child[data-id]") do
-        find("td:first-child a").click
-      end
-
-      assert_text("Webhooks Endpoint Details")
-
-      within("table tr:first-child[data-id]") do
-        find("td:first-child a").click
-      end
-
-      assert_text("Webhook Delivery Details")
-
-      # View a delivery attempt.
-      within("table tr:first-child[data-id]") do
-        find("td:first-child a").click
-      end
-
-      assert_text("Delivery Attempt Details")
+      perform_enqueued_jobs
     end
 
+    assert_difference "Webhooks::Outgoing::Delivery.count", 1, "an outbound webhook delivery should be issued" do
+      click_on "Add New Tangible Thing"
+      assert_text "New Tangible Thing Details"
+      fill_in "Text Field Value", with: "Some Thing"
+      click_on "Create Tangible Thing"
+      assert_text "Tangible Thing was successfully created"
+
+      perform_enqueued_jobs
+    end
+
+    # Go to index page.
+    click_on "Back"
+
+    assert_difference "Webhooks::Incoming::BulletTrainWebhook.count", 1, "an inbound webhook should be received" do
+      click_on "Add New Tangible Thing"
+      fill_in "Text Field Value", with: "Some Other Thing"
+      click_on "Create Tangible Thing"
+      assert_text "Tangible Thing was successfully created"
+
+      perform_enqueued_jobs
+    end
+
+    assert_difference "Webhooks::Outgoing::Delivery.count", 1, "an outbound webhook should be issued" do
+      assert_text "Tangible Thing Details"
+      click_on "Edit Tangible Thing"
+      assert_text "Edit Tangible Thing Details"
+      fill_in "Text Field Value", with: "Some Updated Thing"
+      click_on "Update Tangible Thing"
+      assert_text "Tangible Thing was successfully updated"
+
+      perform_enqueued_jobs
+    end
+
+    assert_difference "Webhooks::Incoming::BulletTrainWebhook.count", 1, "an inbound webhook should be received" do
+      click_on "Edit Tangible Thing"
+      fill_in "Text Field Value", with: "One Last Updated Thing"
+      click_on "Update Tangible Thing"
+      assert_text "Tangible Thing was successfully updated"
+
+      perform_enqueued_jobs
+    end
+
+    click_on "Back"
+
+    assert_difference "Webhooks::Outgoing::Delivery.count", 0, "an outbound webhook should not be issued" do
+      within("table tr:first-child[data-id]") do
+        accept_alert { click_on "Delete" }
+      end
+      assert_text("Tangible Thing was successfully destroyed.")
+
+      perform_enqueued_jobs
+    end
+
+    sign_out_for(display_details)
+
+    # create a thing as another user and confirm no webhooks are issued to the original user.
+    login_as(@another_user, scope: :user)
+    visit root_path
+    if billing_enabled?
+      unless freemium_enabled?
+        complete_pricing_page
+        sleep 2
+      end
+    end
+
+    visit account_dashboard_path
+
+    # trigger the webhook event.
+    within_primary_menu_for(display_details) do
+      click_on "Creative Concepts"
+    end
+
+    assert_text "Your Team’s Creative Concepts"
+
+    click_on "Add New Creative Concept"
+    assert_text "New Creative Concept Details"
+
+    fill_in "Name", with: "Testing"
+    click_on "Create Creative Concept"
+    assert_text "Creative Concept was successfully created"
+
+    # make sure that when a user takes an action that would trigger a webhook event that another user's has an
+    # endpoint configured to receive, that the webhooks don't bleed across teams.
+    assert_difference "Webhooks::Outgoing::Delivery.count", 0, "an outbound webhook should not be issued" do
+      click_on "Add New Tangible Thing"
+      fill_in "Text Field Value", with: "Some Thing"
+      click_on "Create Tangible Thing"
+      assert_text("Tangible Thing was successfully created.")
+
+      perform_enqueued_jobs
+    end
+
+    # create the endpoint.
+    if disable_developer_menu?
+      visit account_team_webhooks_outgoing_endpoints_path(@another_user.current_team)
+    else
+      within_developers_menu_for(display_details) do
+        click_on "Webhooks"
+      end
+    end
+    click_on "Add New Endpoint"
+    fill_in "Name", with: "Some Bullet Train App"
+    fill_in "URL", with: "#{Capybara.app_host}/webhooks/incoming/bullet_train_webhooks"
+    click_on "Create Endpoint"
+    assert_text("Endpoint was successfully created.")
+
+    # trigger the webhook event.
+    within_primary_menu_for(display_details) do
+      click_on "Creative Concepts"
+    end
+
+    assert_text "Your Team’s Creative Concepts"
+
+    click_on "Testing"
+    assert_text "Creative Concept Details"
+
+    assert_difference "Webhooks::Incoming::BulletTrainWebhook.count", 1, "an inbound webhook should be received" do
+      assert_difference "Webhooks::Outgoing::Delivery.count", 1, "an outbound webhook should be issued" do
+        within("table tr:first-child[data-id]") do
+          accept_alert { click_on "Delete" }
+        end
+        assert_text("Tangible Thing was successfully destroyed.")
+        perform_enqueued_jobs
+      end
+
+      perform_enqueued_jobs
+    end
+
+    if disable_developer_menu?
+      visit account_team_webhooks_outgoing_endpoints_path(@another_user.current_team)
+    else
+      within_developers_menu_for(display_details) do
+        click_on "Webhooks"
+      end
+    end
+
+    within("table tr:first-child[data-id]") do
+      find("td:first-child a").click
+    end
+
+    assert_text("Webhooks Endpoint Details")
+
+    within("table tr:first-child[data-id]") do
+      find("td:first-child a").click
+    end
+
+    assert_text("Webhook Delivery Details")
+
+    # View a delivery attempt.
+    within("table tr:first-child[data-id]") do
+      find("td:first-child a").click
+    end
+
+    assert_text("Delivery Attempt Details")
   end
+
 end


### PR DESCRIPTION
Fixes: https://github.com/bullet-train-co/bullet_train/issues/1174

Joint PR: https://github.com/bullet-train-co/bullet_train-core/pull/701

This PR makes it so that we don't have to run the test suite twice with both possible values of `HIDE_THINGS`. Instead of skipping tests if `HIDE_THINGS` is set to `true`, this makes it so that we set `HIDE_THINGS` to `false` before running those tests, and then we restore `HIDE_THINGS` to it's previous value.

The only functional potentially user-facing change is in the joint PR.