### PR TITLE
Avoid more buggy FactoryBot versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,7 +65,8 @@ group :development, :test do
 
   # Generate test objects.
   # 6.3.0 and 6.4.0 have a bug https://github.com/thoughtbot/factory_bot_rails/issues/433
-  gem "factory_bot_rails", "~> 6.2", "!= 6.3.0", "!= 6.4.0"
+  # And now 6.4.1 and 6.4.2 break some things: https://github.com/bullet-train-co/bullet_train-core/issues/707
+  gem "factory_bot_rails", "~> 6.2", "!= 6.3.0", "!= 6.4.0", "!= 6.4.1", "!= 6.4.2"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -666,7 +666,7 @@ DEPENDENCIES
   debug
   devise
   devise-two-factor
-  factory_bot_rails (~> 6.2, != 6.4.0, != 6.3.0)
+  factory_bot_rails (~> 6.2, != 6.4.2, != 6.4.1, != 6.4.0, != 6.3.0)
   foreman
   honeybadger
   jbuilder


### PR DESCRIPTION
It seems that `factory_bot_rails` unexpectedly introduced a breaking change. https://github.com/thoughtbot/factory_bot/issues/1602

For now I'm just going to avoid that version while we decide what to do about it: https://github.com/bullet-train-co/bullet_train-core/issues/707