### PR TITLE
[Release process] Use a PAT to generate the upgrade PR

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -50,6 +50,7 @@ jobs:
         delete-branch: true
         title: "BT-Core version bump: ${{ inputs.versionBump }} - ${{ steps.bump-core.outputs.NEW_VERSION_NUMBER }}"
         add-paths: "Gemfile, Gemfile.lock, package.json, yarn.lock"
+        token: ${{ secrets.UPGRADE_PR_PAT }}
         body: |
           Version bump of the `core` ruby gems and npm packages to version `${{ steps.bump-core.outputs.NEW_VERSION_NUMBER }}`
 


### PR DESCRIPTION
In order to get the CI workflow to run after we create the upgrade PR we need to create the PR using a PAT. (Weird GitHub Actions rules... 🤷)