### PR TITLE
Adjust instructions for tweaking logo height

### DIFF
--- a/config/initializers/logo.rb
+++ b/config/initializers/logo.rb
@@ -3,4 +3,5 @@
 # You may want to play with this setting after replacing the default Bullet Train starter kit logo with something else.
 # For example, if your logo is more squarish in aspect ratio, you probably want to increase this. However, remember you
 # must `rails restart` the server in order to see this setting take effect locally.
+# See also: `config/initializers/theme.rb` for settings affecting the logo in the main menu.
 BulletTrain::Themes.logo_height = 54

--- a/config/initializers/theme.rb
+++ b/config/initializers/theme.rb
@@ -6,5 +6,5 @@ BulletTrain::Themes::Light.color = :blue
 # The orientation of the navbar.
 # BulletTrain::Themes::Light.navigation = :left
 #
-# The logo shown in the navbar.
+# The logo shown in the navbar. To tweak further, run `bin/resolve shared/menu/logo --eject`
 # BulletTrain::Themes::Light.show_logo_in_account = true


### PR DESCRIPTION
Fixes https://github.com/bullet-train-co/bullet_train-core/issues/708

Adjusts comments in initializers to help tweak logo height.