### PR TITLE
Fix for new versions of Chrome/webdriver

### DIFF
--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -23,6 +23,23 @@ if Bundler.locked_gems.dependencies.has_key? "cuprite"
   end
   Capybara.default_driver = Capybara.javascript_driver = :bt_cuprite
 else # Selenium
+
+  # TODO: Ideally we shouldn't have to register this driver. Once a new version of
+  # capybara > 3.39.2 is released we should be able to remove this entire block.
+  # https://github.com/teamcapybara/capybara/pull/2726
+  Capybara.register_driver :selenium_chrome_headless do |app|
+    version = Capybara::Selenium::Driver.load_selenium
+    options_key = Capybara::Selenium::Driver::CAPS_VERSION.satisfied_by?(version) ? :capabilities : :options
+    browser_options = Selenium::WebDriver::Chrome::Options.new.tap do |opts|
+      opts.add_argument('--headless=new')
+      opts.add_argument('--disable-gpu') if Gem.win_platform?
+      # Workaround https://bugs.chromium.org/p/chromedriver/issues/detail?id=2650&q=load&sort=-id&colspec=ID%20Status%20Pri%20Owner%20Summary
+      opts.add_argument('--disable-site-isolation-trials')
+    end
+
+    Capybara::Selenium::Driver.new(app, **{ :browser => :chrome, options_key => browser_options })
+  end
+
   Capybara.javascript_driver = ENV["MAGIC_TEST"].present? ? :selenium_chrome : :selenium_chrome_headless
   Capybara.default_driver = ENV["MAGIC_TEST"].present? ? :selenium_chrome : :selenium_chrome_headless
 end

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -31,13 +31,13 @@ else # Selenium
     version = Capybara::Selenium::Driver.load_selenium
     options_key = Capybara::Selenium::Driver::CAPS_VERSION.satisfied_by?(version) ? :capabilities : :options
     browser_options = Selenium::WebDriver::Chrome::Options.new.tap do |opts|
-      opts.add_argument('--headless=new')
-      opts.add_argument('--disable-gpu') if Gem.win_platform?
+      opts.add_argument("--headless=new")
+      opts.add_argument("--disable-gpu") if Gem.win_platform?
       # Workaround https://bugs.chromium.org/p/chromedriver/issues/detail?id=2650&q=load&sort=-id&colspec=ID%20Status%20Pri%20Owner%20Summary
-      opts.add_argument('--disable-site-isolation-trials')
+      opts.add_argument("--disable-site-isolation-trials")
     end
 
-    Capybara::Selenium::Driver.new(app, **{ :browser => :chrome, options_key => browser_options })
+    Capybara::Selenium::Driver.new(app, **{:browser => :chrome, options_key => browser_options})
   end
 
   Capybara.javascript_driver = ENV["MAGIC_TEST"].present? ? :selenium_chrome : :selenium_chrome_headless

--- a/test/system/fields_test.rb
+++ b/test/system/fields_test.rb
@@ -6,6 +6,10 @@ class FieldsTest < ApplicationSystemTestCase
     @original_hide_things = ENV["HIDE_THINGS"]
     ENV["HIDE_THINGS"] = "false"
     Rails.application.reload_routes!
+
+    # TODO: Capybara.current_driver is returning :selenium,
+    # when it should be either :selenium_chrome or :selenium_chrome_headless.
+    Capybara.current_driver = Capybara.default_driver
   end
 
   def teardown

--- a/test/system/fields_test.rb
+++ b/test/system/fields_test.rb
@@ -6,10 +6,6 @@ class FieldsTest < ApplicationSystemTestCase
     @original_hide_things = ENV["HIDE_THINGS"]
     ENV["HIDE_THINGS"] = "false"
     Rails.application.reload_routes!
-
-    # TODO: Capybara.current_driver is returning :selenium,
-    # when it should be either :selenium_chrome or :selenium_chrome_headless.
-    Capybara.current_driver = Capybara.default_driver
   end
 
   def teardown


### PR DESCRIPTION
See this issue on Capybara for additional details:
https://github.com/teamcapybara/capybara/pull/2726

This PR just registers a new version of `:selenium_chrome_headless`
instead of using the one registered in the `capybara` gem. The new one
just mirrors the fix that's already been applied to the gem, but not yet
released to rubygems.org. Once a new version of `capybara` is out, we
can remove the custom driver.