### PR TITLE
Add comment in GitHub Actions concerning `RAILS_MASTER_KEY`

### DIFF
--- a/.github/workflows/_database_schema_check.yml
+++ b/.github/workflows/_database_schema_check.yml
@@ -26,6 +26,8 @@ jobs:
           --health-retries 5
     env:
       RAILS_ENV: test
+      # Manually export your local RAILS_MASTER_KEY if using the credentials system.
+      # RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
       DATABASE_URL: "postgres://rails:password@localhost:5432/rails_test"
       BUNDLE_JOBS: 2
       BUNDLE_RETRY: 3

--- a/.github/workflows/_run_super_scaffolding_tests.yml
+++ b/.github/workflows/_run_super_scaffolding_tests.yml
@@ -52,6 +52,8 @@ jobs:
           --health-retries 5
     env:
       RAILS_ENV: test
+      # Manually export your local RAILS_MASTER_KEY if using the credentials system.
+      # RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
       DATABASE_URL: "postgres://rails:password@localhost:5432/rails_test"
       BUNDLE_JOBS: 2
       BUNDLE_RETRY: 3

--- a/.github/workflows/_run_tests.yml
+++ b/.github/workflows/_run_tests.yml
@@ -54,6 +54,8 @@ jobs:
           --health-retries 5
     env:
       RAILS_ENV: test
+      # Manually export your local RAILS_MASTER_KEY if using the credentials system.
+      # RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
       DATABASE_URL: "postgres://rails:password@localhost:5432/rails_test"
       BUNDLE_JOBS: 2
       BUNDLE_RETRY: 3

--- a/.github/workflows/_standardrb.yml
+++ b/.github/workflows/_standardrb.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       RAILS_ENV: test
+      # Manually export your local RAILS_MASTER_KEY if using the credentials system.
+      # RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
       BUNDLE_JOBS: 2
       BUNDLE_RETRY: 3
     steps:


### PR DESCRIPTION
Closes #1168.

I didn't add this to every environment, such as the PostgreSQL database setup in the following, but I can go ahead and add comments there too if necessary:

https://github.com/bullet-train-co/bullet_train/blob/8925e85a56f33df151df9623b120ef03a87d0994/.github/workflows/_database_schema_check.yml#L13-L20

@cc/ @olbrich
