### PR TITLE
De-flakify the TangibleThing system test (hopefully...)

### DIFF
--- a/test/system/dates_helper_test.rb
+++ b/test/system/dates_helper_test.rb
@@ -74,7 +74,8 @@ class DatesHelperTest < ApplicationSystemTestCase
 
     # No need to check the strings on the page if the record
     # is successfully created and the times below are different.
-    visit account_team_path(Team.find_by(name: "The Testing Team"))
+    team_path = account_team_path(Team.find_by(name: "The Testing Team"))
+    visit team_path
     click_on "Test Concept"
     click_on "Add New Tangible Thing"
     fill_in "Text Field Value", with: "Another Test Tangible Thing"

--- a/test/system/tangible_thing_test.rb
+++ b/test/system/tangible_thing_test.rb
@@ -41,7 +41,8 @@ class TangibleThingTest < ApplicationSystemTestCase
     assert_text "Update Your Profile"
     page.select "Tokyo", from: "Your Time Zone"
     click_on "Update Profile"
-    visit account_teams_path(Team.find_by!(name: "My Super Team"))
+    team_path = account_teams_path(Team.find_by!(name: "My Super Team"))
+    visit team_path
     assert_text "My Super Team’s Dashboard"
 
     click_on "Add New Creative Concept"

--- a/test/system/tangible_thing_test.rb
+++ b/test/system/tangible_thing_test.rb
@@ -37,7 +37,7 @@ class TangibleThingTest < ApplicationSystemTestCase
     end
 
     edit_user_path = edit_account_user_path(User.find_by!(email: "me@acme.com"))
-    visit edit_account_user_path(edit_user_path)
+    visit edit_user_path
     assert_text "Update Your Profile"
     page.select "Tokyo", from: "Your Time Zone"
     click_on "Update Profile"

--- a/test/system/tangible_thing_test.rb
+++ b/test/system/tangible_thing_test.rb
@@ -36,7 +36,8 @@ class TangibleThingTest < ApplicationSystemTestCase
       end
     end
 
-    visit edit_account_user_path(User.find_by!(email: "me@acme.com"))
+    edit_user_path = edit_account_user_path(User.find_by!(email: "me@acme.com"))
+    visit edit_account_user_path(edit_user_path)
     assert_text "Update Your Profile"
     page.select "Tokyo", from: "Your Time Zone"
     click_on "Update Profile"

--- a/test/system/teams_test.rb
+++ b/test/system/teams_test.rb
@@ -154,7 +154,8 @@ class TeamsTest < ApplicationSystemTestCase
     assert_text "Team was successfully created."
     User.find_by(first_name: "Jane").teams.size
 
-    visit edit_account_team_path(Team.find_by(name: "Another Team"))
+    edit_team_path = edit_account_team_path(Team.find_by(name: "Another Team"))
+    visit edit_team_path
     assert_text "Edit Team Details"
 
     assert_difference "Team.count", -1 do
@@ -167,7 +168,8 @@ class TeamsTest < ApplicationSystemTestCase
     be_invited_to_sign_up
     login_as(@jane, scope: :user)
 
-    visit edit_account_team_path(Team.find_by(name: "Your Team"))
+    edit_team_path = edit_account_team_path(Team.find_by(name: "Your Team"))
+    visit edit_team_path
     assert_text "Edit Team Details"
 
     assert_no_difference "Team.count" do
@@ -188,13 +190,15 @@ class TeamsTest < ApplicationSystemTestCase
     User.find_by(first_name: "Jane").teams.size
 
     # Create a new Membership on the original Team by sending an Invitation
-    visit new_account_team_invitation_path(Team.find_by(name: "Your Team"))
+    team_invitation_path = new_account_team_invitation_path(Team.find_by(name: "Your Team"))
+    visit team_invitation_path
     fill_in "Email", with: "someone@bullettrain.co"
     click_on "Create Invitation"
     assert_text("Invitation was successfully created.")
 
     # Delete the Team.
-    visit edit_account_team_path(Team.find_by(name: "Your Team"))
+    edit_team_path = edit_account_team_path(Team.find_by(name: "Your Team"))
+    visit edit_team_path
     assert_text "Edit Team Details"
     assert_difference "Team.count", -1 do
       accept_alert { click_on "Delete Team" }


### PR DESCRIPTION
Closes #1244.

Since we're using `User.find_by!` and it's not raising an error when the test fails, it seems to be an issue with the loading time for `visit`.

Granted, Capybara's max default wait time is `15` which seems to be set during `assert_text`, but it seems that `visit` hasn't finished loading before we get there so it gets applied to the onboarding step instead.

It might be due to the time it takes to look up the value in the database so I separated the logic here, but things are still passing for me locally so I plan on working on the branch here for a bit.

For what it's worth, this is the only file where we apply `find_by!` to link resolution in `visit` (one more for `Team` below), so I'm led to believe that's where the problem is.