### PR TITLE
Run Action Models generators with `bin/super-scaffold`

### DIFF
--- a/bin/super-scaffold
+++ b/bin/super-scaffold
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 require "active_support/deprecation"
+require "colorize"
 
 ActiveSupport::Deprecation.new.warn(
   "`bin/super-scaffold` is deprecated. Please use `rails generate super_scaffold` instead.\n" \
@@ -26,7 +27,8 @@ if ARGV.first.match?(/^action-models/)
   if defined?(BulletTrain::ActionModels)
     scaffolding_type = ARGV.first.gsub(/-/, "_")
   else
-    puts "You must have Action Models installed if you want to use this generator."
+    puts ""
+    puts "You must have Action Models installed if you want to use this generator.".red
     puts "Please refer to the documentation for more information: https://bullettrain.co/docs/action-models"
     exit 1
   end

--- a/bin/super-scaffold
+++ b/bin/super-scaffold
@@ -22,6 +22,16 @@ else
   nil
 end
 
+if ARGV.first.match?(/^action-models/)
+  if defined?(BulletTrain::ActionModels)
+    scaffolding_type = ARGV.first.gsub(/-/, "_")
+  else
+    puts "You must have Action Models installed if you want to use this generator.".red
+    puts "Please refer to the documentation for more information: https://bullettrain.co/docs/action-models"
+    exit 1
+  end
+end
+
 if scaffolding_type
   exec "#{"spring" if ENV["SPRING"]} rails generate super_scaffold:#{scaffolding_type} #{ARGV.join(" ")}"
 else

--- a/bin/super-scaffold
+++ b/bin/super-scaffold
@@ -26,7 +26,7 @@ if ARGV.first.match?(/^action-models/)
   if defined?(BulletTrain::ActionModels)
     scaffolding_type = ARGV.first.gsub(/-/, "_")
   else
-    puts "You must have Action Models installed if you want to use this generator.".red
+    puts "You must have Action Models installed if you want to use this generator."
     puts "Please refer to the documentation for more information: https://bullettrain.co/docs/action-models"
     exit 1
   end


### PR DESCRIPTION
Since `bin/super-scaffold` is still available in the current version of Bullet Train, this fix allows developers to run commands like `bin/super-scaffold action-models:targets-many Archive Project Team` against the new generators in the following PR:
- https://github.com/bullet-train-co/bullet_train-core/pull/736
