### PR TITLE
Add default local stylesheet

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1,0 +1,13 @@
+/* The theme's stylesheet initializes tailwindcss and imports the theme's default styles.
+
+   The $ThemeStylesheet path is evaluated via a postcss resolver, which finds the theme's
+   main stylesheet within the theme's gem.
+   
+   To control the order of the tailwindcss imports further, you can eject the theme's
+   stylesheet locally using the following command, which will take precedence.
+   > rake bullet_train:themes:light:eject_css
+
+   Read more: https://bullettrain.co/docs/stylesheets
+*/
+@import "$ThemeStylesheet";
+@import "application.custom";

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -10,4 +10,8 @@
    Read more: https://bullettrain.co/docs/stylesheets
 */
 @import "$ThemeStylesheet";
-@import "application.custom";
+
+/* ✅ YOUR APPLICATION'S CSS */
+/* If you need to customize your application's CSS, this is the place to do it. This helps
+   avoid merge conflicts in the future when Rails or Bullet Train update their own CSS.
+*/

--- a/app/assets/stylesheets/application.custom.css
+++ b/app/assets/stylesheets/application.custom.css
@@ -1,0 +1,3 @@
+/* Include your application's CSS customizations in this file.
+   You can also use @apply to include Tailwind classes.
+*/

--- a/app/assets/stylesheets/application.custom.css
+++ b/app/assets/stylesheets/application.custom.css
@@ -1,3 +1,0 @@
-/* Include your application's CSS customizations in this file.
-   You can also use @apply to include Tailwind classes.
-*/

--- a/bin/theme
+++ b/bin/theme
@@ -28,6 +28,8 @@ when "tailwind-mailer-config"
   ["/tailwind.mailer.#{theme}.config.js", "/tailwind.#{theme}.config.js"]
 when "tailwind-stylesheet"
   ["/app/assets/stylesheets/#{theme}.tailwind.css", nil]
+when "stylesheets-dir"
+  ["/app/assets/stylesheets/#{theme}/", nil]
 when "javascript"
   ["/app/javascript/application.#{theme}.js", nil]
 when "postcss-import-config"

--- a/bin/theme
+++ b/bin/theme
@@ -53,4 +53,12 @@ end
 find_file(file_path)
 find_file(fallback_file_path) if fallback_file_path
 
-raise "Sorry, we couldn't find `#{file_path}` in any of the following paths: #{@candidate_paths.join(", ")}"
+if file_type == "postcss-import-config" && @candidate_paths.size == 1 && @candidate_paths.first == Dir.pwd
+  raise <<~ERROR
+    It looks like you're using an ejected theme and you don't have a `postcss-import-config.js` file in your project.
+    Use the following command to copy the default `postcss-import-config.js` file to your project:
+    > bin/resolve postcss-import-config.js --eject
+  ERROR
+else
+  raise "Sorry, we couldn't find `#{file_path}` in any of the following paths: #{@candidate_paths.join(", ")}"
+end

--- a/bin/theme
+++ b/bin/theme
@@ -30,6 +30,8 @@ when "tailwind-stylesheet"
   ["/app/assets/stylesheets/#{theme}.tailwind.css", nil]
 when "javascript"
   ["/app/javascript/application.#{theme}.js", nil]
+when "postcss-import-config"
+  ["/postcss-import-config.js", nil]
 else
   raise "Sorry, we couldn't recognize the file you're looking for: \"#{file_type}\""
 end

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "scripts": {
     "build": "THEME=\"light\" node esbuild.config.js",
     "build:css": "bin/link; THEME=\"light\" yarn build; yarn light:build:css; yarn light:build:mailer:css",
-    "light:build:css": "THEME=\"light\" NODE_PATH=./node_modules tailwindcss -c tailwind.config.js -i $(bundle exec bin/theme tailwind-stylesheet light) -o ./app/assets/builds/application.light.css --postcss ./postcss.config.js",
+    "light:build:css": "THEME=\"light\" NODE_PATH=./node_modules tailwindcss -c tailwind.config.js -i ./app/assets/stylesheets/application.css -o ./app/assets/builds/application.light.css --postcss ./postcss.config.js",
     "light:build:mailer:css": "NODE_PATH=./node_modules tailwindcss -c $(bundle exec bin/theme tailwind-mailer-config light) -i $(bundle exec bin/theme tailwind-stylesheet light) -o ./app/assets/builds/application.mailer.light.css --postcss ./postcss.mailer.config.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "scripts": {
     "build": "THEME=\"light\" node esbuild.config.js",
-    "build:css": "THEME=\"light\" yarn build; yarn light:build:css; yarn light:build:mailer:css",
+    "build:css": "bin/link; THEME=\"light\" yarn build; yarn light:build:css; yarn light:build:mailer:css",
     "light:build:css": "THEME=\"light\" NODE_PATH=./node_modules tailwindcss -c tailwind.config.js -i ./app/assets/stylesheets/application.css -o ./app/assets/builds/application.light.css --postcss ./postcss.config.js",
     "light:build:mailer:css": "THEME=\"light\" NODE_PATH=./node_modules tailwindcss -c $(bundle exec bin/theme tailwind-mailer-config light) -i $(bundle exec bin/theme tailwind-stylesheet light) -o ./app/assets/builds/application.mailer.light.css --postcss ./postcss.mailer.config.js"
   }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,6 @@
     "build": "THEME=\"light\" node esbuild.config.js",
     "build:css": "bin/link; THEME=\"light\" yarn build; yarn light:build:css; yarn light:build:mailer:css",
     "light:build:css": "THEME=\"light\" NODE_PATH=./node_modules tailwindcss -c tailwind.config.js -i ./app/assets/stylesheets/application.css -o ./app/assets/builds/application.light.css --postcss ./postcss.config.js",
-    "light:build:mailer:css": "NODE_PATH=./node_modules tailwindcss -c $(bundle exec bin/theme tailwind-mailer-config light) -i $(bundle exec bin/theme tailwind-stylesheet light) -o ./app/assets/builds/application.mailer.light.css --postcss ./postcss.mailer.config.js"
+    "light:build:mailer:css": "THEME=\"light\" NODE_PATH=./node_modules tailwindcss -c $(bundle exec bin/theme tailwind-mailer-config light) -i $(bundle exec bin/theme tailwind-stylesheet light) -o ./app/assets/builds/application.mailer.light.css --postcss ./postcss.mailer.config.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "scripts": {
     "build": "THEME=\"light\" node esbuild.config.js",
-    "build:css": "bin/link; THEME=\"light\" yarn build; yarn light:build:css; yarn light:build:mailer:css",
+    "build:css": "THEME=\"light\" yarn build; yarn light:build:css; yarn light:build:mailer:css",
     "light:build:css": "THEME=\"light\" NODE_PATH=./node_modules tailwindcss -c tailwind.config.js -i ./app/assets/stylesheets/application.css -o ./app/assets/builds/application.light.css --postcss ./postcss.config.js",
     "light:build:mailer:css": "THEME=\"light\" NODE_PATH=./node_modules tailwindcss -c $(bundle exec bin/theme tailwind-mailer-config light) -i $(bundle exec bin/theme tailwind-stylesheet light) -o ./app/assets/builds/application.mailer.light.css --postcss ./postcss.mailer.config.js"
   }

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,15 +1,20 @@
 const path = require('path');
 const { execSync } = require("child_process");
 
+const themeStylesheet = execSync(`bundle exec bin/theme tailwind-stylesheet ${process.env.THEME} 2> /dev/null`).toString().trim()
 const themeRoot = execSync(`bundle show bullet_train-themes-${process.env.THEME} 2> /dev/null`).toString().trim()
-const themeStylesheets = path.resolve(themeRoot, 'app/assets/stylesheets/');
+const themeStylesheetsDir = path.resolve(themeRoot, 'app/assets/stylesheets/');
 
 module.exports = {
   plugins: [
     require('postcss-import')({
       resolve: (id, basedir, importOptions) => {
-        if (id.startsWith('$THEMESTYLESHEETS')) {
-          id = id.replace('$THEMESTYLESHEETS', themeStylesheets);
+        if (id.startsWith('$ThemeStylesheetsDir')) {
+          initial_id = id;
+          id = id.replace('$ThemeStylesheetsDir', themeStylesheetsDir);
+          console.log(initial_id, "$ThemeStylesheetsDir", themeStylesheetsDir, id)
+        } else if (id.startsWith('$ThemeStylesheet')) {
+          id = id.replace('$ThemeStylesheet', themeStylesheet);
         }
         return id;
       }

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,19 @@
+const path = require('path');
+const { execSync } = require("child_process");
+
+const themeRoot = execSync(`bundle show bullet_train-themes-${process.env.THEME} 2> /dev/null`).toString().trim()
+const themeStylesheets = path.resolve(themeRoot, 'app/assets/stylesheets/');
+
 module.exports = {
   plugins: [
-    require('postcss-import'),
+    require('postcss-import')({
+      resolve: (id, basedir, importOptions) => {
+        if (id.startsWith('$THEMESTYLESHEETS')) {
+          id = id.replace('$THEMESTYLESHEETS', themeStylesheets);
+        }
+        return id;
+      }
+    }),
     require('postcss-extend-rule'),
     require('postcss-nested'),
     require('tailwindcss'),

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,24 +1,11 @@
-const path = require('path');
 const { execSync } = require("child_process");
 
-const themeStylesheet = execSync(`bundle exec bin/theme tailwind-stylesheet ${process.env.THEME} 2> /dev/null`).toString().trim()
-const themeRoot = execSync(`bundle show bullet_train-themes-${process.env.THEME} 2> /dev/null`).toString().trim()
-const themeStylesheetsDir = path.resolve(themeRoot, 'app/assets/stylesheets/');
+const postcssImportConfigFile = execSync(`bundle exec bin/theme postcss-import-config ${process.env.THEME}`).toString().trim()
+const postcssImportConfig = require(postcssImportConfigFile)
 
 module.exports = {
   plugins: [
-    require('postcss-import')({
-      resolve: (id, basedir, importOptions) => {
-        if (id.startsWith('$ThemeStylesheetsDir')) {
-          initial_id = id;
-          id = id.replace('$ThemeStylesheetsDir', themeStylesheetsDir);
-          console.log(initial_id, "$ThemeStylesheetsDir", themeStylesheetsDir, id)
-        } else if (id.startsWith('$ThemeStylesheet')) {
-          id = id.replace('$ThemeStylesheet', themeStylesheet);
-        }
-        return id;
-      }
-    }),
+    require('postcss-import')(postcssImportConfig),
     require('postcss-extend-rule'),
     require('postcss-nested'),
     require('tailwindcss'),

--- a/postcss.mailer.config.js
+++ b/postcss.mailer.config.js
@@ -1,6 +1,11 @@
+const { execSync } = require("child_process");
+
+const postcssImportConfigFile = execSync(`bundle exec bin/theme postcss-import-config ${process.env.THEME}`).toString().trim()
+const postcssImportConfig = require(postcssImportConfigFile)
+
 module.exports = {
   plugins: [
-    require('postcss-import'),
+    require('postcss-import')(postcssImportConfig),
     require('postcss-extend-rule'),
     require('postcss-nested'),
     require('tailwindcss'),


### PR DESCRIPTION
Resolves #567.
Replaces #1247.

Introduces a new local stylesheet:

`app/assets/stylesheets/application.css` loads `$ThemeStylesheet`, an alias that postcss-import resolves to the current theme's stylesheet, responsible for initializing tailwind. It also loads...

Both `postcss.config.js` and `postcss.mailer.config.js` are updated with a `postcssImportConfig`, which resolves the new `$ThemeStylesheet` alias. This allows us to continue not requiring to publish an npm package for each theme.

Joint PR:
* https://github.com/bullet-train-co/bullet_train-core/pull/741