### PR TITLE
Bundle capybara-lockstep to improve System Test stability.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -92,6 +92,10 @@ group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem "capybara", "~> 3.39"
 
+  # Synchronize Capybara commands with client-side JavaScript and AJAX requests to greatly improve
+  # system test stability. Only works on the Selenium Driver though.
+  # gem "capybara-lockstep"
+
   # Selenium is the default default Capybara driver for system tests that ships with
   # Rails. Cuprite is an alternative driver that uses Chrome's native DevTools protocol
   # and offers improved speed and reliability, but only works with Chrome. If you want

--- a/Gemfile
+++ b/Gemfile
@@ -94,7 +94,7 @@ group :test do
 
   # Synchronize Capybara commands with client-side JavaScript and AJAX requests to greatly improve
   # system test stability. Only works on the Selenium Driver though.
-  # gem "capybara-lockstep"
+  gem "capybara-lockstep"
 
   # Selenium is the default default Capybara driver for system tests that ships with
   # Rails. Cuprite is an alternative driver that uses Chrome's native DevTools protocol

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -246,6 +246,11 @@ GEM
     capybara-email (3.0.2)
       capybara (>= 2.4, < 4.0)
       mail
+    capybara-lockstep (2.1.0)
+      activesupport (>= 4.2)
+      capybara (>= 3.0)
+      ruby2_keywords
+      selenium-webdriver (>= 4.0)
     charlock_holmes (0.7.7)
     choice (0.2.0)
     chronic (0.10.2)
@@ -723,6 +728,7 @@ DEPENDENCIES
   bullet_train-themes-tailwind_css (= 1.6.24)
   capybara (~> 3.39)
   capybara-email
+  capybara-lockstep
   chronic
   colorize
   cssbundling-rails

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -26,4 +26,6 @@
 
 <%= render 'magic_test/support' if Rails.env.test? %>
 
+<%= capybara_lockstep if defined?(Capybara::Lockstep) %>
+
 <% # put your application-specific additions below to avoid merge conflicts later. %>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -82,6 +82,10 @@ Rails.application.configure do
   # TODO for some reason this doesn't seem to be doing anything.
   config.active_job.queue_adapter = :inline
 
+  if defined?(Capybara::Lockstep)
+    config.middleware.insert_before 0, Capybara::Lockstep::Middleware
+  end
+
   # ✅ YOUR APPLICATION'S CONFIGURATION
   # If you need to customize your application's configuration, this is the place to do it. This helps avoid merge
   # conflicts in the future when Rails or Bullet Train update their own default settings.

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -77,6 +77,8 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   include Warden::Test::Helpers
   include Waiting
 
+  # Capybara::Lockstep.debug = true # Uncomment to inspect and verify the integration in your app.
+
   def example_password
     @example_password ||= SecureRandom.hex
   end


### PR DESCRIPTION
https://github.com/makandra/capybara-lockstep

Seems like it costs 5 seconds, but the build fails in strange ways. So I'm opening this for posterity.

I also used `bundle open bullet_train-themes-light` to add the expected JS include in `app/views/themes/light/layouts/_head.html.erb`:

```diff
+<%= capybara_lockstep if defined?(Capybara::Lockstep) %>
<%= javascript_include_tag 'application', 'data-turbo-track': 'reload' %>
```

@gazayas @jagthedrummer I'll probably close this unless either of you feel like diving into the test failures, because I don't know what they mean 😊