### PR TITLE
Don't pin GitHub actions to a specific version of ruby

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -22,7 +22,6 @@ jobs:
     - uses: "ruby/setup-ruby@v1"
       with:
         bundler-cache: true
-        ruby-version: 3.3
 
     - uses: "actions/setup-node@v3"
       with:

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -22,7 +22,7 @@ jobs:
     - uses: "ruby/setup-ruby@v1"
       with:
         bundler-cache: true
-        ruby-version: 3.2
+        ruby-version: 3.3
 
     - uses: "actions/setup-node@v3"
       with:


### PR DESCRIPTION
The `setup-ruby` action will use the version specified in the `.ruby-version` file.