### PR TITLE
Allow the app to boot if S3 is not configured

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -111,6 +111,9 @@ Rails.application.configure do
 
   if (ENV["AWS_ACCESS_KEY_ID"] || ENV["BUCKETEER_AWS_ACCESS_KEY_ID"]).present?
     config.active_storage.service = :amazon
+  else
+    puts "WARNING! : We didn't find an active_storage.service configured so we're falling back to the local store, but it's A VERY BAD IDEA to rely on it in product unless you know what your'e doing."
+    config.active_storage.service = :local
   end
 
   config.action_mailer.perform_deliveries = true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -112,7 +112,7 @@ Rails.application.configure do
   if (ENV["AWS_ACCESS_KEY_ID"] || ENV["BUCKETEER_AWS_ACCESS_KEY_ID"]).present?
     config.active_storage.service = :amazon
   else
-    puts "WARNING! : We didn't find an active_storage.service configured so we're falling back to the local store, but it's A VERY BAD IDEA to rely on it in product unless you know what your'e doing."
+    puts "WARNING! : We didn't find an active_storage.service configured so we're falling back to the local store, but it's A VERY BAD IDEA to rely on it in production unless you know what you're doing."
     config.active_storage.service = :local
   end
 


### PR DESCRIPTION
Fixes https://github.com/bullet-train-co/bullet_train/issues/1284

There may be better ways to handle this, but right now anyone who updates to a new version (or who starts a new project) is going to have trouble even booting their app in a production environment if they haven't configured S3.