### PR TITLE
Remove fix needed in versions before Capybara v3.39.2 

### DIFF
--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -23,23 +23,6 @@ if Bundler.locked_gems.dependencies.has_key? "cuprite"
   end
   Capybara.default_driver = Capybara.javascript_driver = :bt_cuprite
 else # Selenium
-
-  # TODO: Ideally we shouldn't have to register this driver. Once a new version of
-  # capybara > 3.39.2 is released we should be able to remove this entire block.
-  # https://github.com/teamcapybara/capybara/pull/2726
-  Capybara.register_driver :selenium_chrome_headless do |app|
-    version = Capybara::Selenium::Driver.load_selenium
-    options_key = Capybara::Selenium::Driver::CAPS_VERSION.satisfied_by?(version) ? :capabilities : :options
-    browser_options = Selenium::WebDriver::Chrome::Options.new.tap do |opts|
-      opts.add_argument("--headless=new")
-      opts.add_argument("--disable-gpu") if Gem.win_platform?
-      # Workaround https://bugs.chromium.org/p/chromedriver/issues/detail?id=2650&q=load&sort=-id&colspec=ID%20Status%20Pri%20Owner%20Summary
-      opts.add_argument("--disable-site-isolation-trials")
-    end
-
-    Capybara::Selenium::Driver.new(app, **{:browser => :chrome, options_key => browser_options})
-  end
-
   Capybara.javascript_driver = ENV["MAGIC_TEST"].present? ? :selenium_chrome : :selenium_chrome_headless
   Capybara.default_driver = ENV["MAGIC_TEST"].present? ? :selenium_chrome : :selenium_chrome_headless
 end


### PR DESCRIPTION
We introduced a fix in https://github.com/bullet-train-co/bullet_train/pull/1243 to account for this issue in Capybara: https://github.com/teamcapybara/capybara/pull/2726.

Since we're now running on Capybara v3.40.0, we won't need this fix anymore.