### PR TITLE
Prevent scaffolding test from generating OpenAPI document unnecessarily

### DIFF
--- a/test/system/super_scaffolding/super_scaffolding_test.rb
+++ b/test/system/super_scaffolding/super_scaffolding_test.rb
@@ -286,7 +286,7 @@ class SuperScaffoldingSystemTest < ApplicationSystemTestCase
   end
 
   test "OpenAPI V3 document is still valid" do
-    puts(output = `yarn exec redocly lint http://127.0.0.1:3001/api/v1/openapi.yaml 1> /dev/stdout 2> /dev/stdout; rm openapi.yaml`)
+    puts(output = `yarn exec redocly lint http://127.0.0.1:3001/api/v1/openapi.yaml 1> /dev/stdout 2> /dev/stdout`)
     # redocly/openapi-core changed the format of their success message in version 1.2.0.
     # https://github.com/Redocly/redocly-cli/pull/1239
     # We use a robust regex here so that we can match both formats.

--- a/test/system/super_scaffolding/super_scaffolding_test.rb
+++ b/test/system/super_scaffolding/super_scaffolding_test.rb
@@ -286,7 +286,8 @@ class SuperScaffoldingSystemTest < ApplicationSystemTestCase
   end
 
   test "OpenAPI V3 document is still valid" do
-    puts(output = `yarn exec redocly lint http://127.0.0.1:3001/api/v1/openapi.yaml 1> /dev/stdout 2> /dev/stdout`)
+    visit "/" # Make sure the test server is running before linting the file.
+    puts(output = `yarn exec redocly lint http://127.0.0.1:3001/api/v1/openapi.yaml 1> /dev/stdout 2> /dev/stdout; rm openapi.yaml`)
     # redocly/openapi-core changed the format of their success message in version 1.2.0.
     # https://github.com/Redocly/redocly-cli/pull/1239
     # We use a robust regex here so that we can match both formats.

--- a/test/system/super_scaffolding/super_scaffolding_test.rb
+++ b/test/system/super_scaffolding/super_scaffolding_test.rb
@@ -286,7 +286,6 @@ class SuperScaffoldingSystemTest < ApplicationSystemTestCase
   end
 
   test "OpenAPI V3 document is still valid" do
-    visit "http://127.0.0.1:3001/api/v1/openapi.yaml"
     puts(output = `yarn exec redocly lint http://127.0.0.1:3001/api/v1/openapi.yaml 1> /dev/stdout 2> /dev/stdout; rm openapi.yaml`)
     # redocly/openapi-core changed the format of their success message in version 1.2.0.
     # https://github.com/Redocly/redocly-cli/pull/1239

--- a/test/system/super_scaffolding/super_scaffolding_test.rb
+++ b/test/system/super_scaffolding/super_scaffolding_test.rb
@@ -287,7 +287,7 @@ class SuperScaffoldingSystemTest < ApplicationSystemTestCase
 
   test "OpenAPI V3 document is still valid" do
     visit "/" # Make sure the test server is running before linting the file.
-    puts(output = `yarn exec redocly lint http://127.0.0.1:3001/api/v1/openapi.yaml 1> /dev/stdout 2> /dev/stdout; rm openapi.yaml`)
+    puts(output = `yarn exec redocly lint http://127.0.0.1:3001/api/v1/openapi.yaml 1> /dev/stdout 2> /dev/stdout`)
     # redocly/openapi-core changed the format of their success message in version 1.2.0.
     # https://github.com/Redocly/redocly-cli/pull/1239
     # We use a robust regex here so that we can match both formats.


### PR DESCRIPTION
Fixes #1315.

We were visiting the page here, but the actual `lint` command produces the documentation. You can verify this by simply running the tests, because the `puts` we have on the lint command outputs the results to the terminal.
