### PR TITLE
Run super scaffolding tests via directory

### DIFF
--- a/.github/workflows/_run_super_scaffolding_tests.yml
+++ b/.github/workflows/_run_super_scaffolding_tests.yml
@@ -128,7 +128,7 @@ jobs:
           CIRCLE_NODE_INDEX: ${{ strategy.job-index }}
 
       - name: 'Run Super Scaffolding Test'
-        run: bundle exec rails test test/system/super_scaffolding/super_scaffolding_test.rb test/system/super_scaffolding/partial_test.rb test/controllers/webhooks/incoming/some_provider_webhooks_controller_test.rb
+        run: bin/rails test test/system/super_scaffolding/ test/controllers/webhooks/incoming/some_provider_webhooks_controller_test.rb
         working-directory: tmp/starter
 
       - name: Test Summary


### PR DESCRIPTION
Follow-up to #1311

With the new directory we can ensure any new super scaffolding test file is automatically run, so we don't forget.