### PR TITLE
Check for Redis in `bin/configure` via redis-cli

### DIFF
--- a/bin/configure
+++ b/bin/configure
@@ -114,11 +114,12 @@ when "linux"
     exit
   end
 
-  if system_packages.include?("redis") && system_packages.include?("redis-server")
-    version_information = `redis-server --version`
-    redis_version = version_information.split("\s")[2]
+  # TODO: system_packages should include `redis`.
+  # https://github.com/bullet-train-co/bullet_train/issues/1330
+  begin
+    redis_version = `redis-cli --version`.chomp.split("\s").last
     puts "Redis #{redis_version} is installed.".green
-  else
+  rescue
     puts "You don't have Redis installed. Please see the installation instructions at https://redis.io/docs/getting-started/installation/install-redis-on-linux/ .".red
     exit
   end


### PR DESCRIPTION
Closes #1330.

As the comment states, the command we use to retrieve system packages should return `redis` and/or `redis-server`:

```
> dpkg -l | grep '^ii' | grep redis
ii  redis                                      6:7.2.4-1rl1~focal1                        all          Persistent key-value database with network interface (metapackage)
ii  redis-server                               6:7.2.4-1rl1~focal1                        amd64        Persistent key-value database with network interface
ii  redis-tools                                6:7.2.4-1rl1~focal1                        amd64        Persistent key-value database with network interface (client)
```

I'm using Ubuntu 22.04 as well, so I'm not entirely sure why the problem in #1330 is happening.

```
> lsb_release -a
No LSB modules are available.
Distributor ID:	Ubuntu
Description:	Ubuntu 22.04.3 LTS
Release:	22.04
Codename:	jammy
```

Regardless, the [Redis documentation](https://redis.io/docs/install/install-redis/) shows on their install page that you can check if Redis is installed via the CLI.

```
$ redis-cli ping
PONG
```

If this is a good way to check if Redis is installed (especially considering that you can install Redis without installing `redis-server`), then I'm fine with using this check instead to show the developer they have Redis installed.

The only question that remains is if Bullet Train requires `redis-server`. In bin/setup, we have the following line, so users can at least know by this that they'll need `redis-server` too:

https://github.com/bullet-train-co/bullet_train/blob/108acf3502a242d9437d32de71e23d365f66c44b/bin/setup#L76