### PR TITLE
Update bundler dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,7 +124,7 @@ GEM
     bindex (0.8.1)
     binding_of_caller (1.0.0)
       debug_inspector (>= 0.0.1)
-    bootsnap (1.17.1)
+    bootsnap (1.18.3)
       msgpack (~> 1.2)
     builder (3.2.4)
     bullet_train (1.6.36)
@@ -297,8 +297,7 @@ GEM
     domain_name (0.6.20240107)
     doorkeeper (5.6.9)
       railties (>= 5)
-    drb (2.2.0)
-      ruby2_keywords
+    drb (2.2.1)
     dry-initializer (3.1.1)
     email_reply_parser (0.5.11)
     erubi (1.12.0)
@@ -310,7 +309,7 @@ GEM
       charlock_holmes
       email_reply_parser (~> 0.5.9)
       mail
-    factory_bot (6.4.5)
+    factory_bot (6.4.6)
       activesupport (>= 5.0.0)
     factory_bot_rails (6.4.3)
       factory_bot (~> 6.4)
@@ -340,7 +339,7 @@ GEM
     httparty (0.21.0)
       mini_mime (>= 1.0.0)
       multi_xml (>= 0.5.2)
-    i18n (1.14.1)
+    i18n (1.14.4)
       concurrent-ruby (~> 1.0)
     image_processing (1.12.2)
       mini_magick (>= 4.9.5, < 5)


### PR DESCRIPTION
For some reason `depfu` [is having trouble getting us up to date](https://github.com/bullet-train-co/bullet_train/pull/1313).

This is a fresh attempt to apply those updates to `main`.

```
bundle update bootsnap factory_bot
```