### PR TITLE
Remove global `window.$` jQuery definition (redux)

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -26,8 +26,6 @@ require("@icon/themify-icons/themify-icons.css")
 import { trixEditor } from "@bullet-train/fields"
 trixEditor()
 
-import "./electron"
-
 // ✅ YOUR APPLICATION'S INCLUDES
 // If you need to customize your application's includes, this is the place to do it. This helps avoid merge
 // conflicts in the future when Rails or Bullet Train update their own default includes.

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -3,7 +3,6 @@
 // includes should be specified at the end of the file, not in this section. This helps avoid merge conflicts in the
 // future should the framework defaults change.
 
-import "./support/jquery";
 import Rails from "@rails/ujs"
 import * as ActiveStorage from "@rails/activestorage"
 import "@hotwired/turbo-rails"

--- a/app/javascript/electron/index.js
+++ b/app/javascript/electron/index.js
@@ -1,5 +1,0 @@
-$(document).on('turbo:load', function() {
-  if (navigator.userAgent.toLocaleLowerCase().includes('electron')) {
-    $('body').addClass('electron')
-  }
-})

--- a/app/javascript/support/jquery.js
+++ b/app/javascript/support/jquery.js
@@ -1,3 +1,0 @@
-import jquery from "jquery";
-window.jQuery = jquery;
-window.$ = jquery;

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "dragula": "^3.7.3",
     "esbuild": "^0.20.2",
     "glob": "^10.3.10",
-    "jquery": "^3.7.0",
     "jstz": "^2.1.1",
     "postcss": "^8.4.38",
     "postcss-css-variables": "^0.19.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2276,7 +2276,7 @@ jiti@^1.19.1:
   resolved "https://registry.yarnpkg.com/jiti/-/jiti-1.20.0.tgz#2d823b5852ee8963585c8dd8b7992ffc1ae83b42"
   integrity sha512-3TV69ZbrvV6U5DfQimop50jE9Dl6J8O1ja1dvBbMba/sZ3YBEQqJ2VZRoQPVnhlzjNtU1vaXRZVrVjU4qtm8yA==
 
-jquery@>=1.10, jquery@^3.7.0:
+jquery@>=1.10:
   version "3.7.1"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.7.1.tgz#083ef98927c9a6a74d05a6af02806566d16274de"
   integrity sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==


### PR DESCRIPTION
This is a re-do of https://github.com/bullet-train-co/bullet_train/pull/1319

Copied from that PR:

As a first step to completely remove jQuery as a dependency, we can at least remove the global `window.$` definition.

Joint PRs:
- https://github.com/bullet-train-co/bullet_train-core/pull/765

## If you still require jQuery on `window.$`

If your application still needs `$` defined globally, you can do the following:

1. `yarn add jquery`
2. Add the following lines to your `app/javascript/application.js` file:

```js
import jquery from "jquery";
window.jQuery = jquery;
window.$ = jquery;
```