### PR TITLE
Update tailwind, switch to tailwindcss/nesting, move postcss-css-variables

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "postcss-nested": "^6.0.1",
     "stimulus-reveal": "^1.4.2",
     "stimulus-scroll-reveal": "^3.2.0",
-    "tailwindcss": "^3.4.1",
+    "tailwindcss": "^3.4.3",
     "yalc": "^1.0.0-pre.53"
   },
   "scripts": {

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -7,7 +7,7 @@ module.exports = {
   plugins: [
     require('postcss-import')(postcssImportConfig),
     require('postcss-extend-rule'),
-    require('postcss-nested'),
+    require('tailwindcss/nesting'),
     require('tailwindcss'),
     require('autoprefixer'),
   ]

--- a/postcss.mailer.config.js
+++ b/postcss.mailer.config.js
@@ -7,9 +7,9 @@ module.exports = {
   plugins: [
     require('postcss-import')(postcssImportConfig),
     require('postcss-extend-rule'),
-    require('postcss-nested'),
-    require('tailwindcss'),
     require('postcss-css-variables'),
+    require('tailwindcss/nesting'),
+    require('tailwindcss'),
     require('autoprefixer'),
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2272,10 +2272,10 @@ jackspeak@^2.3.5:
   optionalDependencies:
     "@pkgjs/parseargs" "^0.11.0"
 
-jiti@^1.19.1:
-  version "1.20.0"
-  resolved "https://registry.yarnpkg.com/jiti/-/jiti-1.20.0.tgz#2d823b5852ee8963585c8dd8b7992ffc1ae83b42"
-  integrity sha512-3TV69ZbrvV6U5DfQimop50jE9Dl6J8O1ja1dvBbMba/sZ3YBEQqJ2VZRoQPVnhlzjNtU1vaXRZVrVjU4qtm8yA==
+jiti@^1.21.0:
+  version "1.21.0"
+  resolved "https://registry.yarnpkg.com/jiti/-/jiti-1.21.0.tgz#7c97f8fe045724e136a397f7340475244156105d"
+  integrity sha512-gFqAIbuKyyso/3G2qhiO2OM6shY6EPP/R0+mkDbyspxKazh8BXDC5FiFsUjlczgdNz/vfra0da2y+aHrusLG/Q==
 
 jquery@>=1.10, jquery@^3.7.1:
   version "3.7.1"
@@ -3325,10 +3325,10 @@ swagger2openapi@^7.0.6:
     yaml "^1.10.0"
     yargs "^17.0.1"
 
-tailwindcss@^3.4.1:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-3.4.1.tgz#f512ca5d1dd4c9503c7d3d28a968f1ad8f5c839d"
-  integrity sha512-qAYmXRfk3ENzuPBakNK0SRrUDipP8NQnEY6772uDhflcQz5EhRdD7JNZxyrFHVQNCwULPBn6FNPp9brpO7ctcA==
+tailwindcss@^3.4.2:
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-3.4.3.tgz#be48f5283df77dfced705451319a5dffb8621519"
+  integrity sha512-U7sxQk/n397Bmx4JHbJx/iSOOv5G+II3f1kpLpY2QeUv5DcPdcTsYLlusZfq1NthHS1c1cZoyFmmkex1rzke0A==
   dependencies:
     "@alloc/quick-lru" "^5.2.0"
     arg "^5.0.2"
@@ -3338,7 +3338,7 @@ tailwindcss@^3.4.1:
     fast-glob "^3.3.0"
     glob-parent "^6.0.2"
     is-glob "^4.0.3"
-    jiti "^1.19.1"
+    jiti "^1.21.0"
     lilconfig "^2.1.0"
     micromatch "^4.0.5"
     normalize-path "^3.0.0"


### PR DESCRIPTION
Fixes #1416
Fixes #1074

As noted in #1416 there's been a change in `tailwindcss` around the `@apply` directive. In order to get it to work correctly for nested classes we need to use the `tailswindcss/nesting` plugin. We were already using `postcss-nested`, which is what `tailwindcss/nesting` uses under the hood. So this PR just switches them out.

It also moves the `postcss-css-variables` plugin to be higher in the plugin stack for the mailer stylesheet. [That plugin doesn't play nicely when it's below the nesting plugin.](https://github.com/MadLittleMods/postcss-css-variables/issues/135#issuecomment-1981442330)

Moving `postcss-css-variables` higher in the stack also seems to have fixed the problems described in #1074. When it's higher in the stack I see almost zero difference in build times between having it activated or not, and the resulting stylesheet is actually _smaller_ when it is activated (~120k vs ~140k).