### PR TITLE
Fix the version bump action

### DIFF
--- a/bin/bump-core
+++ b/bin/bump-core
@@ -51,6 +51,7 @@ class CoreBumpCLI < Thor
     end
 
     def yarn_upgrade(version_number)
+      puts `yarn --version`
       yarn_package_string = npm_packages.map{|pkg| "#{pkg}@#{version_number}"}.join(" ")
       puts `yarn upgrade #{yarn_package_string}`
     end

--- a/bin/bump-core
+++ b/bin/bump-core
@@ -52,6 +52,8 @@ class CoreBumpCLI < Thor
 
     def yarn_upgrade(version_number)
       puts `yarn --version`
+      puts "-------------------"
+      puts `yarn install`
       yarn_package_string = npm_packages.map{|pkg| "#{pkg}@#{version_number}"}.join(" ")
       puts `yarn upgrade #{yarn_package_string}`
     end

--- a/bin/bump-core
+++ b/bin/bump-core
@@ -55,7 +55,7 @@ class CoreBumpCLI < Thor
       puts "-------------------"
       puts `yarn install`
       yarn_package_string = npm_packages.map{|pkg| "#{pkg}@#{version_number}"}.join(" ")
-      puts `yarn upgrade #{yarn_package_string}`
+      puts `yarn up #{yarn_package_string}`
     end
 
     def write_to_github_output_file(version_number)


### PR DESCRIPTION
Apparently we need to `yarn install` before we can upgrade, and now `yarn upgrade` has apparently be renamed to `yarn up`.