### PR TITLE
Prevent Knapsack Pro from failing if the KNAPSACK_PRO_CI_NODE_INDEX env var is missing

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,7 +16,7 @@ I18n.default_locale = :en
 # of setup for things like the plans available for subscriptions and which outgoing webhooks are available to users.
 require File.expand_path("../../db/seeds", __FILE__)
 
-if ENV['KNAPSACK_PRO_CI_NODE_INDEX'].present?
+if ENV["KNAPSACK_PRO_CI_NODE_INDEX"].present?
   require "knapsack_pro"
   knapsack_pro_adapter = KnapsackPro::Adapters::MinitestAdapter.bind
   knapsack_pro_adapter.set_test_helper_path(__FILE__)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,9 +16,14 @@ I18n.default_locale = :en
 # of setup for things like the plans available for subscriptions and which outgoing webhooks are available to users.
 require File.expand_path("../../db/seeds", __FILE__)
 
-require "knapsack_pro"
-knapsack_pro_adapter = KnapsackPro::Adapters::MinitestAdapter.bind
-knapsack_pro_adapter.set_test_helper_path(__FILE__)
+if ENV['KNAPSACK_PRO_CI_NODE_INDEX'].present?
+  require "knapsack_pro"
+  knapsack_pro_adapter = KnapsackPro::Adapters::MinitestAdapter.bind
+  knapsack_pro_adapter.set_test_helper_path(__FILE__)
+else
+  puts "Not requiring Knapsack Pro.".yellow
+  puts "If you'd like to use Knapsack Pro make sure that you've set the environment variable KNAPSACK_PRO_CI_NODE_INDEX".yellow
+end
 
 require "sidekiq/testing"
 Sidekiq::Testing.inline!


### PR DESCRIPTION
Starting with verison `7.5.0` Knapsack Pro has begun to raise an error if it's missing the environment variables that tell it how to split tests. <https://github.com/KnapsackPro/knapsack_pro-ruby/blob/master/CHANGELOG.md#750>

That change has prevented `depfu` from being able to upgrade us to `7.5.0`. <https://github.com/bullet-train-co/bullet_train/pull/1493/checks?sha=563a3f0035beb0d929d33f2973a308d715222fec>

This makes it so that we don't automatically require Knapsack Pro if those env vars are missing.

(For "internal" purposes we don't use Knapsack at all, instead we use a crude splitting method to distribute tests across multiple runners on GitHub Actions. We also ship that same GHA workflow when people start a new repo.)