### PR TITLE
Better & cheaper initial experience on Heroku

### DIFF
--- a/app.json
+++ b/app.json
@@ -6,28 +6,27 @@
   "keywords": ["ruby", "rails"],
   "buildpacks": [
     { "url": "heroku/nodejs" },
+    { "url": "https://github.com/gaffneyc/heroku-buildpack-jemalloc.git" },
     { "url": "heroku/ruby" }
   ],
   "formation": {
     "web": {
       "quantity": 1,
-      "size": "standard-1x"
+      "size": "basic"
     },
     "worker": {
       "quantity": 1,
-      "size": "standard-1x"
+      "size": "basic"
     }
   },
   "addons": [
-    "heroku-postgresql:standard-0",
-    "heroku-redis:premium-0",
-    "memcachier:100",
-    "bucketeer:hobbyist",
+    "heroku-postgresql:essential-0",
+    "heroku-redis:mini",
+    "memcachier:dev",
     "cloudinary:starter",
     "scheduler:standard",
     "rails-autoscale:white",
-    "honeybadger:basic",
-    "sentry:f1"
+    "honeybadger:basic"
   ],
   "env": {
     "BASE_URL": {
@@ -46,6 +45,18 @@
       "description": "This ensures the Super Scaffolding templates don't show up in production.",
       "generator": "secret",
       "required": true
+    },
+    "RAILS_MAX_THREADS": {
+      "description": "The maximum number of threads that puma will fork. https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server#recommended-default-puma-process-and-thread-configuration",
+      "value": "5"
+    },
+    "WEB_CONCURRENCY": {
+      "description": "The number of workers per puma thread. We set it low to prevent OOM errors on new heroku apps. If you move to larger dynos you can increase this. https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server#recommended-default-puma-process-and-thread-configuration",
+      "value": "2"
+    },
+    "JEMALLOC_ENABLED": {
+      "description": "Activate the jemalloc buildpack. https://elements.heroku.com/buildpacks/gaffneyc/heroku-buildpack-jemalloc",
+      "value": true
     }
   }
 }


### PR DESCRIPTION
This PR does a few things to make the process of setting up an app on Heroku better and cheaper.

1. It adds a buildpack for `jemalloc` and sets the `JEMALLOC_ENABLED` ENV var. This helps with memory usage. Fixes: https://github.com/bullet-train-co/bullet_train/issues/1524
2. Makes the initial setup cheaper by using cheaper dynos and the entry level for a number of addons (in addition to removing the Bucketeer addon that seems questionably useful to begin with). This brings the monthly cost (as provisioned by `app.json`) down from ~$185/month to ~$22/month. Fixes: https://github.com/bullet-train-co/bullet_train/issues/1127
3. Removes the Sentry addon. This was redundant since Honeybadger was already included, and Sentry isn't supported in review apps on Heroku, so having it in `app.json` prevents the use of review apps entirely which is frustrating. Fixes: https://github.com/bullet-train-co/bullet_train/issues/1521
4. Sets `RAILS_MAX_THREADS` and `WEB_CONCURRENCY` to match the values [suggested by heroku](https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server#recommended-default-puma-process-and-thread-configuration). Fixes: https://github.com/bullet-train-co/bullet_train/issues/1523

Joint PR for udpating docs: https://github.com/bullet-train-co/bullet_train-core/pull/850