### PR TITLE
Use 'rails g super_scaffold:...' in action models tests

### DIFF
--- a/test/bin/setup-action-models-system-test
+++ b/test/bin/setup-action-models-system-test
@@ -8,9 +8,9 @@ fi
 export SPRING=true
 
 if [ -z "${CIRCLE_NODE_INDEX}" ] || [ "${CIRCLE_NODE_INDEX}" == "0" ]; then
-  bin/super-scaffold crud Project Team name:text_field --navbar="ti-world"
+  rails g super_scaffold Project Team name:text_field --navbar="ti-world"
   rails db:migrate
-  bin/super-scaffold action-model:targets-many Archive Project Team
+  rails g super_scaffold:action_models:targets_many Archive Project Team
 
   PERFORM_METHOD="  def perform_on_target(project)"
   TARGETS_MANY_ACTION='project.update(name: "#{project.name} archived")'
@@ -22,9 +22,9 @@ else
 fi
 
 if [ -z "${CIRCLE_NODE_INDEX}" ] || [ "${CIRCLE_NODE_INDEX}" == "1" ]; then
-  bin/super-scaffold crud Listing Team name:text_field --navbar="ti-world"
+  rails g super_scaffold Listing Team name:text_field --navbar="ti-world"
   rails db:migrate
-  bin/super-scaffold action-model:targets-one Publish Listing Team
+  rails g super_scaffold:action_models:targets_one Publish Listing Team
 
   test/bin/portable-string-replace app/models/projects/archive_action.rb "# This is where you implement the operation you want to perform on the action's target." "listing.update(name: \"#{listing.name} published\")"
 else
@@ -32,10 +32,10 @@ else
 fi
 
 if [ -z "${CIRCLE_NODE_INDEX}" ] || [ "${CIRCLE_NODE_INDEX}" == "3" ]; then
-  bin/super-scaffold crud Customer Team name:text_field --navbar="ti-user"
-  bin/super-scaffold crud Notification Customer,Team text:text_field read:boolean --navbar="ti-email"
+  rails g super_scaffold Customer Team name:text_field --navbar="ti-user"
+  rails g super_scaffold Notification Customer,Team text:text_field read:boolean --navbar="ti-email"
   rails db:migrate
-  bin/super-scaffold action-model:targets-one-parent MarkAllAsRead Notification Customer
+  rails g super_scaffold:action_models:targets_one_parent MarkAllAsRead Notification Customer
 
   test/bin/portable-string-replace app/models/notifications/mark_all_as_read_action.rb "# This is where you implement the operation you want to perform on the target." "customer.notifications.update(read: true)"
 else
@@ -43,17 +43,17 @@ else
 fi
 
 if [ -z "${CIRCLE_NODE_INDEX}" ] || [ "${CIRCLE_NODE_INDEX}" == "2" ]; then
-  bin/super-scaffold crud Article Team name:text_field --navbar="ti-world"
+  rails g super_scaffold Article Team name:text_field --navbar="ti-world"
   rails db:migrate
-  bin/super-scaffold action-model:performs-import CsvImport Article Team
+  rails g super_scaffold:action_models:performs_import CsvImport Article Team
 else
   echo "Skipping the \`performs-import\` action on this CI node."
 fi
 
 if [ -z "${CIRCLE_NODE_INDEX}" ] || [ "${CIRCLE_NODE_INDEX}" == "3" ]; then
-  bin/super-scaffold crud Visitor Team email:text_field first_name:text_field last_name:text_field --navbar="ti-world"
+  rails g super_scaffold Visitor Team email:text_field first_name:text_field last_name:text_field --navbar="ti-world"
   rails db:migrate
-  bin/super-scaffold action-model:performs-export CsvExport Visitor Team
+  rails g super_scaffold:action_models:performs_export CsvExport Visitor Team
 else
   echo "Skipping the \`performs-export\` action on this CI node."
 fi

--- a/test/system/action_models_test.rb
+++ b/test/system/action_models_test.rb
@@ -41,7 +41,7 @@ class ActionModelsSystemTest < ApplicationSystemTestCase
   if defined?(Projects::ArchiveAction)
     # This error message is displayed for all actions, not just `targets-many`.
     test "the proper error message is displayed for unneeded namespaces" do
-      output = `bin/super-scaffold action-model:targets-many Project::Publish Project Team`
+      output = `rails g super_scaffold:action_models:targets_many Project::Publish Project Team`
       assert output.include?("When creating an Action Model, you don't have to namespace the action")
     end
 


### PR DESCRIPTION
This makes it so that the action models tests/setup uses the new `rails g super_scaffold:action_models:...` syntax instead of the old `bin/super-scaffold` syntax.