### PR TITLE
Run the PartialTest on a dedicated CI node

### DIFF
--- a/.github/workflows/_run_super_scaffolding_tests.yml
+++ b/.github/workflows/_run_super_scaffolding_tests.yml
@@ -23,8 +23,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # For super scaffolding tests we need to have exactly 8 runners.
-        ci_runners: [TestSite, Project, 'Project::Step', Insight, 'Personality::Disposition', 'Personality::Observation', TestFile, PartialTest]
+        # For super scaffolding tests we need to have exactly 5 runners.
+        ci_runners: ["TestSite, Project", "Project::Step, Insight", "Personality::Disposition, Personality::Observation", "TestFile, PartialTest", Webhook]
     services:
       postgres:
         image: postgres:11-alpine
@@ -131,7 +131,12 @@ jobs:
           CIRCLE_NODE_INDEX: ${{ strategy.job-index }}
 
       - name: 'Run Super Scaffolding Test'
-        run: bin/rails test test/system/super_scaffolding/ test/controllers/webhooks/incoming/some_provider_webhooks_controller_test.rb
+        run: bin/rails test test/system/super_scaffolding/
+        working-directory: tmp/starter
+
+      - name: 'Run Super Scaffolding Webhook Test'
+        run: bin/rails test test/controllers/webhooks/incoming/some_provider_webhooks_controller_test.rb
+        if: ${{ strategy.job-index == 5 }}
         working-directory: tmp/starter
 
       - name: Test Summary

--- a/.github/workflows/_run_super_scaffolding_tests.yml
+++ b/.github/workflows/_run_super_scaffolding_tests.yml
@@ -23,8 +23,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # For super scaffolding tests we need to have exactly 7 runners.
-        ci_runners: [TestSite, Project, 'Project::Step', Insight, 'Personality::Disposition', 'Personality::Observation', TestFile]
+        # For super scaffolding tests we need to have exactly 8 runners.
+        ci_runners: [TestSite, Project, 'Project::Step', Insight, 'Personality::Disposition', 'Personality::Observation', TestFile, PartialTest]
     services:
       postgres:
         image: postgres:11-alpine

--- a/test/bin/setup-super-scaffolding-system-test
+++ b/test/bin/setup-super-scaffolding-system-test
@@ -16,7 +16,7 @@ else
   echo "Skipping \`TestSite\` and \`TestPage\` on this CI node."
 fi
 
-if [ -z "${CIRCLE_NODE_INDEX}" ] || [ "${CIRCLE_NODE_INDEX}" == "1" ]; then
+if [ -z "${CIRCLE_NODE_INDEX}" ] || [ "${CIRCLE_NODE_INDEX}" == "0" ]; then
   rails g super_scaffold Project Team name:text_field description:trix_editor --navbar="ti-layout"
   rails g super_scaffold Projects::Deliverable Project,Team name:text_field description:trix_editor
 
@@ -35,21 +35,21 @@ else
   echo "Skipping \`Project\` and \`Projects::Deliverable\` on this CI node."
 fi
 
-if [ -z "${CIRCLE_NODE_INDEX}" ] || [ "${CIRCLE_NODE_INDEX}" == "2" ]; then
+if [ -z "${CIRCLE_NODE_INDEX}" ] || [ "${CIRCLE_NODE_INDEX}" == "1" ]; then
   rails g super_scaffold Projects::Step Team name:text_field description:trix_editor --navbar="ti-world"
   rails g super_scaffold Objective Projects::Step,Team name:text_field description:trix_editor
 else
   echo "Skipping \`Projects::Step\` and \`Objective\` on this CI node."
 fi
 
-if [ -z "${CIRCLE_NODE_INDEX}" ] || [ "${CIRCLE_NODE_INDEX}" == "3" ]; then
+if [ -z "${CIRCLE_NODE_INDEX}" ] || [ "${CIRCLE_NODE_INDEX}" == "1" ]; then
   rails g super_scaffold Insight Team name:text_field description:trix_editor --navbar="ti-world"
   rails g super_scaffold Personality::CharacterTrait Insight,Team name:text_field description:trix_editor
 else
   echo "Skipping \`Insight\` and \`Personality::CharacterTrait\` on this CI node."
 fi
 
-if [ -z "${CIRCLE_NODE_INDEX}" ] || [ "${CIRCLE_NODE_INDEX}" == "4" ]; then
+if [ -z "${CIRCLE_NODE_INDEX}" ] || [ "${CIRCLE_NODE_INDEX}" == "2" ]; then
   rails g super_scaffold Personality::Disposition Team name:text_field description:trix_editor --navbar="ti-world"
   rails g super_scaffold Personality::Note Personality::Disposition,Team name:text_field description:trix_editor
 
@@ -65,7 +65,7 @@ else
   echo "Skipping \`Personality::Disposition\` and \`Personality::Note\` on this CI node."
 fi
 
-if [ -z "${CIRCLE_NODE_INDEX}" ] || [ "${CIRCLE_NODE_INDEX}" == "5" ]; then
+if [ -z "${CIRCLE_NODE_INDEX}" ] || [ "${CIRCLE_NODE_INDEX}" == "2" ]; then
   rails g super_scaffold Personality::Observation Team name:text_field description:trix_editor --navbar="ti-world"
   rails g super_scaffold Personality::Reactions::Response Personality::Observation,Team name:text_field description:trix_editor
   if [[ "$OSTYPE" == "darwin"* ]]; then
@@ -77,7 +77,7 @@ else
   echo "Skipping \`Personality::Observation\` and \`Personality::Reactions::Response\` on this CI node."
 fi
 
-if [ -z "${CIRCLE_NODE_INDEX}" ] || [ "${CIRCLE_NODE_INDEX}" == "6" ]; then
+if [ -z "${CIRCLE_NODE_INDEX}" ] || [ "${CIRCLE_NODE_INDEX}" == "3" ]; then
   rails g super_scaffold TestFile Team name:text_field foo:file_field bars:file_field{multiple} --navbar="ti-tag"
   rails g super_scaffold ColorPicker Team color_picker_value:color_picker --navbar="ti-tag"
 else
@@ -85,7 +85,7 @@ else
 fi
 
 
-if [ -z "${CIRCLE_NODE_INDEX}" ] || [ "${CIRCLE_NODE_INDEX}" == "7" ]; then
+if [ -z "${CIRCLE_NODE_INDEX}" ] || [ "${CIRCLE_NODE_INDEX}" == "3" ]; then
   # TODO: Generate these in parallel.
   rails g super_scaffold PartialTest Team \
     text_field_test:text_field \
@@ -110,8 +110,10 @@ fi
 
 
 # The test for this webhook is run inline in .github/workflows/_run_super_scaffolding_tests.yml
-# TODO: We should figure out a way to do this differently so that we don't run this generator
-# and the associated test on _every single_ CI node that runs super scaffolding system tests.
-rails g super_scaffold:incoming_webhooks SomeProvider
+if [ -z "${CIRCLE_NODE_INDEX}" ] || [ "${CIRCLE_NODE_INDEX}" == "4" ]; then
+  rails g super_scaffold:incoming_webhooks SomeProvider
+else
+  echo "Skipping \`Webhok\` on this CI node."
+fi
 
 bundle exec spring rake db:schema:load db:migrate db:test:prepare

--- a/test/bin/setup-super-scaffolding-system-test
+++ b/test/bin/setup-super-scaffolding-system-test
@@ -84,26 +84,34 @@ else
   echo "Skipping \`TestFile\` and \`ColorPicker\` on this CI node."
 fi
 
-# TODO: Generate these in parallel.
-rails g super_scaffold PartialTest Team \
-  text_field_test:text_field \
-  boolean_test:boolean \
-  single_button_test:buttons \
-  multiple_buttons_test:buttons{multiple} \
-  date_test:date_field\
-  date_time_test:date_and_time_field \
-  file_test:file_field \
-  option_test:options \
-  multiple_options_test:options{multiple} \
-  password_test:password_field \
-  phone_field_test:phone_field \
-  super_select_test:super_select \
-  multiple_super_select_test:super_select{multiple} \
-  number_field_test:number_field \
-  text_area_test:text_area \
-  address_test:address_field --navbar="ti-layout"
+
+if [ -z "${CIRCLE_NODE_INDEX}" ] || [ "${CIRCLE_NODE_INDEX}" == "7" ]; then
+  # TODO: Generate these in parallel.
+  rails g super_scaffold PartialTest Team \
+    text_field_test:text_field \
+    boolean_test:boolean \
+    single_button_test:buttons \
+    multiple_buttons_test:buttons{multiple} \
+    date_test:date_field\
+    date_time_test:date_and_time_field \
+    file_test:file_field \
+    option_test:options \
+    multiple_options_test:options{multiple} \
+    password_test:password_field \
+    phone_field_test:phone_field \
+    super_select_test:super_select \
+    multiple_super_select_test:super_select{multiple} \
+    number_field_test:number_field \
+    text_area_test:text_area \
+    address_test:address_field --navbar="ti-layout"
+else
+  echo "Skipping \`PartialTest\` on this CI node."
+fi
+
 
 # The test for this webhook is run inline in .circleci/config.yml.
-rails g super_scaffold:incoming_webhooks SomeProvider
+# TODO: If we're going to run this setup we should write a test around it.
+# For now I'm just disabling it.
+# rails g super_scaffold:incoming_webhooks SomeProvider
 
 bundle exec spring rake db:schema:load db:migrate db:test:prepare

--- a/test/bin/setup-super-scaffolding-system-test
+++ b/test/bin/setup-super-scaffolding-system-test
@@ -109,9 +109,9 @@ else
 fi
 
 
-# The test for this webhook is run inline in .circleci/config.yml.
-# TODO: If we're going to run this setup we should write a test around it.
-# For now I'm just disabling it.
-# rails g super_scaffold:incoming_webhooks SomeProvider
+# The test for this webhook is run inline in .github/workflows/_run_super_scaffolding_tests.yml
+# TODO: We should figure out a way to do this differently so that we don't run this generator
+# and the associated test on _every single_ CI node that runs super scaffolding system tests.
+rails g super_scaffold:incoming_webhooks SomeProvider
 
 bundle exec spring rake db:schema:load db:migrate db:test:prepare


### PR DESCRIPTION
Previously every node that ran _any_ super scaffolding test would also run the super scaffolding test for `PartialTest`.

This PR makes it so that we run that test on a dedicated node, and all the other nodes won't run it.

It also consolidates some super scaffolding tests onto the same CI node so that instead of running them across 9 nodes we run on 5.