### PR TITLE
Fix for crashes on MacOS related to ruby-pg

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -24,6 +24,10 @@ default: &default
 development:
   <<: *default
   database: untitled_application_development
+  # On MacOS some users are reporting crashes when first trying to access
+  # the database. This workaround was suggested in this issue on `ruby-pg`:
+  # https://github.com/ged/ruby-pg/issues/538
+  <% if RUBY_PLATFORM =~ /darwin/ %>gssencmode: disable<% end %>
 
   # The specified database role being used to connect to postgres.
   # To create additional roles in postgres see `$ createuser --help`.


### PR DESCRIPTION
Some users are reporting crashes on MacOS when first trying to access the database. There's an issue open on `ruby-pg` that describes this temporary workaround. https://github.com/ged/ruby-pg/issues/538

Hopefully fixes: https://github.com/bullet-train-co/bullet_train/issues/1379