### PR TITLE
Fix Trix Attachments

### DIFF
--- a/app/views/active_storage/blobs/_blob.html.erb
+++ b/app/views/active_storage/blobs/_blob.html.erb
@@ -1,0 +1,14 @@
+<figure class="attachment attachment--<%= blob.representable? ? "preview" : "file" %> attachment--<%= blob.filename.extension %>">
+  <% if blob.representable? %>
+    <%= image_tag blob.representation(resize_to_limit: local_assigns[:in_gallery] ? [ 800, 600 ] : [ 1024, 768 ]) %>
+  <% end %>
+
+  <figcaption class="attachment__caption">
+    <% if caption = blob.try(:caption) %>
+      <%= caption %>
+    <% else %>
+      <span class="attachment__name"><%= blob.filename %></span>
+      <span class="attachment__size"><%= number_to_human_size blob.byte_size %></span>
+    <% end %>
+  </figcaption>
+</figure>

--- a/app/views/layouts/action_text/contents/_content.html.erb
+++ b/app/views/layouts/action_text/contents/_content.html.erb
@@ -1,0 +1,3 @@
+<div class="trix-content">
+  <%= yield -%>
+</div>

--- a/config/initializers/action_text_bug_fix.rb
+++ b/config/initializers/action_text_bug_fix.rb
@@ -7,10 +7,9 @@ module ActionText
   class Content
     def render_attachments(**options, &block)
       content = fragment.replace(ActionText::Attachment.tag_name) do |node|
-        if node.key?("content") && node["content"].present?
-          node["content"] = sanitize_content_attachment(node["content"])
-        elsif node.key?("content")
-          node.remove_attribute("content")
+        if node.key?("content")
+          sanitized_content = sanitize_content_attachment(node.remove_attribute("content").to_s)
+          node["content"] = sanitized_content if sanitized_content.present?
         end
         block.call(attachment_for_node(node, **options))
       end

--- a/config/initializers/action_text_bug_fix.rb
+++ b/config/initializers/action_text_bug_fix.rb
@@ -1,0 +1,20 @@
+# TODO: Remove this monkey patch initializer when the following issue has been resolved in rails core:
+# https://github.com/rails/rails/issues/52233
+
+require "action_text/content"
+
+module ActionText
+  class Content
+    def render_attachments(**options, &block)
+      content = fragment.replace(ActionText::Attachment.tag_name) do |node|
+        if node.key?("content") && node["content"].present?
+          node["content"] = sanitize_content_attachment(node["content"])
+        elsif node.key?("content")
+          node.remove_attribute("content")
+        end
+        block.call(attachment_for_node(node, **options))
+      end
+      self.class.new(content, canonicalize: false)
+    end
+  end
+end


### PR DESCRIPTION
Joint PR: https://github.com/bullet-train-co/bullet_train-core/pull/875

The two new files in `app/views` were generated by running `rails action_text:install`.

The `action_text:install` step also generated a few other files which we have in the `core` gems. So I haven't duplicated those here.

For instance it generates `app/assets/stylesheets/actiontext.css` but in the `core` repo we already have `bullet_train-themes-light/app/assets/stylesheets/light/actiontext.css`.

Things seem to work OK without these files, and I'm not _entirely_ sure that we really need them, but it seems like it would be a good idea to have them _somewhere_ since rails seems to expect them to be present. And since `rails action_text:install` will generate some duplicate files it seems like it might cause some confusion if people go looking for files that rails expects to be there, but they can't find them, and then run that install step.

So, I'm totally open to being persuaded that we don't need these if anyone has an argument in that direction.

The new file in `config/initializers` is a monkey patch for a broken `ActionText::Content` method. I'll open an issue about watching for the fix to land in `rails` and then removing the monkey patch.

Fixes https://github.com/bullet-train-co/bullet_train/issues/1580