### PR TITLE
Add a source to the inline Gemfile for `bin/configure`

### DIFF
--- a/bin/configure-scripts/utils.rb
+++ b/bin/configure-scripts/utils.rb
@@ -3,6 +3,7 @@
 require "bundler/inline"
 
 gemfile do
+  source 'https://rubygems.org'
   gem "colorize"
   gem "activesupport", require: "active_support"
 end

--- a/bin/configure-scripts/utils.rb
+++ b/bin/configure-scripts/utils.rb
@@ -3,7 +3,7 @@
 require "bundler/inline"
 
 gemfile do
-  source 'https://rubygems.org'
+  source "https://rubygems.org"
   gem "colorize"
   gem "activesupport", require: "active_support"
 end


### PR DESCRIPTION
We were missing a `source` line which meant that the inline `Gemfile` couldn't install anything. So if you didn't already have the required gems installed it would fail.

Address the `colorizer` issue mentioned in https://github.com/bullet-train-co/bullet_train/issues/1606