### PR TITLE
Calculate new repository link from ssh path in configure script

### DIFF
--- a/bin/configure-scripts/deploy_button_heroku.rb
+++ b/bin/configure-scripts/deploy_button_heroku.rb
@@ -9,7 +9,11 @@ button_file = "#{__dir__}/deploy-buttons/heroku.md"
 add_button = ask_boolean "Would you like to add a 'Deploy to Heroku' button to your project.", "y"
 if add_button
   puts "Adding a 'Deploy to Heroku' button.".green
-  new_repo_link = ask "What is the https variant of your repo URL? (Something like: https://github.com/your-org/your-repo)"
+  new_repo_link = if SETUP_GITHUB
+    HTTP_PATH
+  else
+    ask "What is the https variant of your repo URL? (Something like: https://github.com/your-org/your-repo)"
+  end
 
   File.open("README.md", "a") do |readme|
     button = File.read(button_file)

--- a/bin/configure-scripts/deploy_button_render.rb
+++ b/bin/configure-scripts/deploy_button_render.rb
@@ -9,7 +9,11 @@ button_file = "#{__dir__}/deploy-buttons/render.md"
 add_button = ask_boolean "Would you like to add a 'Deploy to Render' button to your project.", "y"
 if add_button
   puts "Adding a 'Deploy to Render' button.".green
-  new_repo_link = ask "What is the https variant of your repo URL? (Something like: https://github.com/your-org/your-repo)"
+  new_repo_link = if SETUP_GITHUB
+    HTTP_PATH
+  else
+    ask "What is the https variant of your repo URL? (Something like: https://github.com/your-org/your-repo)"
+  end
 
   File.open("README.md", "a") do |readme|
     button = File.read(button_file)

--- a/bin/configure-scripts/setup_github.rb
+++ b/bin/configure-scripts/setup_github.rb
@@ -8,10 +8,10 @@ puts "Next, let's push your application to GitHub."
 puts "If you would like to use another service like Gitlab to manage your repository,"
 puts "you can opt out of this step and set up the repository manually."
 puts "(If you're not sure, we suggest going with GitHub)"
-setup_github = ask_boolean "Continue setting up with GitHub?", "y"
+SETUP_GITHUB = ask_boolean "Continue setting up with GitHub?", "y"
 
-puts "setup_github = #{setup_github}"
-if setup_github
+puts "SETUP_GITHUB = #{SETUP_GITHUB}"
+if SETUP_GITHUB
   if `git remote | grep origin`.strip.length > 0
     puts "Repository already has a `origin` remote.".yellow
   else

--- a/bin/configure-scripts/setup_github.rb
+++ b/bin/configure-scripts/setup_github.rb
@@ -35,7 +35,7 @@ if SETUP_GITHUB
       return
     else
       # We use this variable in the `deploy_button_heroku.rb` and `deploy_button_render.rb` scripts.
-      HTTP_PATH = "https://github.com/#{ssh_path.gsub(/(.*:)(.*)(\.git$)/, "#{$2}")}"
+      HTTP_PATH = "https://github.com/#{ssh_path.gsub(/.*:/, "")}".delete_suffix(".git")
     end
     puts "Setting repository's `origin` remote to `#{ssh_path}`.".green
     puts `git remote add origin #{ssh_path}`.chomp

--- a/bin/configure-scripts/setup_github.rb
+++ b/bin/configure-scripts/setup_github.rb
@@ -8,6 +8,8 @@ puts "Next, let's push your application to GitHub."
 puts "If you would like to use another service like Gitlab to manage your repository,"
 puts "you can opt out of this step and set up the repository manually."
 puts "(If you're not sure, we suggest going with GitHub)"
+
+# We use this variable in the `deploy_button_heroku.rb` and `deploy_button_render.rb` scripts.
 SETUP_GITHUB = ask_boolean "Continue setting up with GitHub?", "y"
 
 puts "SETUP_GITHUB = #{SETUP_GITHUB}"
@@ -31,6 +33,9 @@ if SETUP_GITHUB
     if ssh_path == "skip"
       puts "Bailing out of GitHub setup.".yellow
       return
+    else
+      # We use this variable in the `deploy_button_heroku.rb` and `deploy_button_render.rb` scripts.
+      HTTP_PATH = "https://github.com/#{ssh_path.gsub(/(.*:)(.*)(\.git$)/, "#{$2}")}"
     end
     puts "Setting repository's `origin` remote to `#{ssh_path}`.".green
     puts `git remote add origin #{ssh_path}`.chomp


### PR DESCRIPTION
Closes #1607.

I figured we didn't want to entirely get rid of the `ask` methods here in case developers decide not to setup their project with GitHub. I tested the configure script against a personal repository of mine so it should work, but you can pull it down with this branch if you want to check it out:

```
> git clone -b refactor-github-details git@github.com:bullet-train-co/bullet_train.git bt_test
```