### PR TITLE
Pin pagy to verison 6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -110,6 +110,9 @@ end
 # BULLET TRAIN GEMS
 # This section is the list of Ruby gems included by default for Bullet Train.
 
+# TODO: Remove this after updating the core gems to 1.7.21
+gem "pagy", "< 7"
+
 # We use a constant here so that we can ensure that all of the bullet_train-*
 # packages are on the same version.
 BULLET_TRAIN_VERSION = "1.7.20"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -755,6 +755,7 @@ DEPENDENCIES
   magic_test
   minitest-reporters
   minitest-retry
+  pagy (< 7)
   pg (>= 0.18, < 2.0)
   postmark-rails
   pry


### PR DESCRIPTION
There are breaking changes in pagy versions 7 & 8 that we'll need to address. For now I'm pinning pagy to `< 7`. I've also done this in the `core` gems but I'm doing it here as well temporarily to be able to get some `depfu` updates in for the next version.