### PR TITLE
Disable raise_on_missing_callback_actions in development

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -82,6 +82,11 @@ Rails.application.configure do
   # if you want to change a default value specified here. Instead, simply re-specify the value in the section that
   # follows this section.
 
+  # TODO: Eventually we should enable this by default. Currently enabling it causes problems.
+  # Related issue: https://github.com/bullet-train-co/bullet_train-core/issues/926
+  # Once that issue has been resolved we should remove this comment block and the following config line.
+  config.action_controller.raise_on_missing_callback_actions = false
+
   # disable asset pipeline.
   config.assets.enabled = false
 


### PR DESCRIPTION
Because of https://github.com/bullet-train-co/bullet_train-core/issues/926