### PR TITLE
Set `config.raise_on_missing_callback_actions = true`

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -85,7 +85,7 @@ Rails.application.configure do
   # TODO: Eventually we should enable this by default. Currently enabling it causes problems.
   # Related issue: https://github.com/bullet-train-co/bullet_train-core/issues/926
   # Once that issue has been resolved we should remove this comment block and the following config line.
-  config.action_controller.raise_on_missing_callback_actions = false
+  config.action_controller.raise_on_missing_callback_actions = true
 
   # disable asset pipeline.
   config.assets.enabled = false

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -74,7 +74,7 @@ Rails.application.configure do
   # TODO: Eventually we should enable this by default. Currently enabling it causes problems.
   # Related issue: https://github.com/bullet-train-co/bullet_train-core/issues/926
   # Once that issue has been resolved we should remove this comment block and the following config line.
-  config.action_controller.raise_on_missing_callback_actions = false
+  config.action_controller.raise_on_missing_callback_actions = true
 
   # We only enable this for a specific test.
   config.action_view.annotate_rendered_view_with_filenames = ENV["ENABLE_VIEW_ANNOTATION"] || false


### PR DESCRIPTION
This is a new config in Rails 7.1 and the default is to have it set to `true` in `development` and `test` environments.