### PR TITLE
Fix the "Deploy to Heroku" button

### DIFF
--- a/app.json
+++ b/app.json
@@ -43,8 +43,7 @@
     },
     "HIDE_THINGS": {
       "description": "This ensures the Super Scaffolding templates don't show up in production.",
-      "generator": "secret",
-      "required": true
+      "value": "true"
     },
     "RAILS_MAX_THREADS": {
       "description": "The maximum number of threads that puma will fork. https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server#recommended-default-puma-process-and-thread-configuration",
@@ -56,7 +55,7 @@
     },
     "JEMALLOC_ENABLED": {
       "description": "Activate the jemalloc buildpack. https://elements.heroku.com/buildpacks/gaffneyc/heroku-buildpack-jemalloc",
-      "value": true
+      "value": "true"
     }
   }
 }

--- a/bin/configure-scripts/deploy-buttons/heroku.md
+++ b/bin/configure-scripts/deploy-buttons/heroku.md
@@ -1,7 +1,7 @@
 
 ### Heroku
 
-[![Deploy to Heroku](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/bullet-train-co/bullet_train)
+[![Deploy to Heroku](https://www.herokucdn.com/deploy/button.svg)](https://www.heroku.com/deploy?template=https://github.com/bullet-train-co/bullet_train)
 
 Clicking this button will take you to the first step of a process that, when completed, will provision production-grade infrastructure and services for your Bullet Train application which will cost about **$140/month**.
 


### PR DESCRIPTION
The button needs to point at `www.heroku.com/deploy` not just `heroku.com/deploy` for it to even start to work.

Once you get past the first step it seems like having boolean literals in the `value` field causes problems (which are hard to debug because Heroku doesn't surface a useful error message).

Fixes: https://github.com/bullet-train-co/bullet_train/issues/1609