### PR TITLE
Update the descirption of the "deploy to heroku" button

### DIFF
--- a/bin/configure-scripts/deploy-buttons/heroku.md
+++ b/bin/configure-scripts/deploy-buttons/heroku.md
@@ -3,7 +3,7 @@
 
 [![Deploy to Heroku](https://www.herokucdn.com/deploy/button.svg)](https://www.heroku.com/deploy?template=https://github.com/bullet-train-co/bullet_train)
 
-Clicking this button will take you to the first step of a process that, when completed, will provision production-grade infrastructure and services for your Bullet Train application which will cost about **$140/month**.
+Clicking this button will take you to the first step of a process that, when completed, will provision demo-grade infrastructure and services for your Bullet Train application which will cost about **$22/month**.
 
 Once that process has completed, be sure to complete the other steps from the [Deploying to Heroku](https://bullettrain.co/docs/heroku) documentation.
 


### PR DESCRIPTION
We used to provision higher production-ready tiers of the addons and when we updated `app.json` to provision demo-ready tiers we forgot to update the estimated cost of the addons.