### PR TITLE
Allow the deploy button scripts to be run in isolation

### DIFF
--- a/bin/configure-scripts/deploy_button_heroku.rb
+++ b/bin/configure-scripts/deploy_button_heroku.rb
@@ -9,7 +9,7 @@ button_file = "#{__dir__}/deploy-buttons/heroku.md"
 add_button = ask_boolean "Would you like to add a 'Deploy to Heroku' button to your project.", "y"
 if add_button
   puts "Adding a 'Deploy to Heroku' button.".green
-  new_repo_link = if SETUP_GITHUB
+  new_repo_link = if defined?(SETUP_GITHUB)
     HTTP_PATH
   else
     ask "What is the https variant of your repo URL? (Something like: https://github.com/your-org/your-repo)"

--- a/bin/configure-scripts/deploy_button_render.rb
+++ b/bin/configure-scripts/deploy_button_render.rb
@@ -9,7 +9,7 @@ button_file = "#{__dir__}/deploy-buttons/render.md"
 add_button = ask_boolean "Would you like to add a 'Deploy to Render' button to your project.", "y"
 if add_button
   puts "Adding a 'Deploy to Render' button.".green
-  new_repo_link = if SETUP_GITHUB
+  new_repo_link = if defined?(SETUP_GITHUB)
     HTTP_PATH
   else
     ask "What is the https variant of your repo URL? (Something like: https://github.com/your-org/your-repo)"


### PR DESCRIPTION
This makes it so that you can run either of these scripts independently of `bin/configure`:

* `./bin/configure-scripts/deploy_button_heroku.rb`
* `./bin/configure-scripts/deploy_button_render.rb`