### PR TITLE
Use `setup do` instead of `def setup` in tests

### DIFF
--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -75,13 +75,13 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
     @another_example_password ||= SecureRandom.hex
   end
 
-  def setup
+  setup do
     ENV["BASE_URL"] = "http://localhost:3001"
     Capybara.use_default_driver
     Capybara.reset_sessions!
   end
 
-  def teardown
+  teardown do
     Capybara.use_default_driver
     Capybara.reset_sessions!
   end

--- a/test/controllers/account/scaffolding/absolutely_abstract/creative_concepts_controller_test.rb
+++ b/test/controllers/account/scaffolding/absolutely_abstract/creative_concepts_controller_test.rb
@@ -3,8 +3,7 @@ require "test_helper"
 class Account::Scaffolding::AbsolutelyAbstract::CreativeConceptsControllerTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
 
-  def setup
-    super
+  setup do
     @user = create(:onboarded_user)
     sign_in @user
     @team = @user.current_team
@@ -15,8 +14,7 @@ class Account::Scaffolding::AbsolutelyAbstract::CreativeConceptsControllerTest <
     Rails.application.reload_routes!
   end
 
-  def teardown
-    super
+  teardown do
     ENV["HIDE_THINGS"] = @original_hide_things
     Rails.application.reload_routes!
   end

--- a/test/controllers/account/scaffolding/completely_concrete/tangible_things_controller_test.rb
+++ b/test/controllers/account/scaffolding/completely_concrete/tangible_things_controller_test.rb
@@ -3,8 +3,7 @@ require "test_helper"
 class Account::Scaffolding::CompletelyConcrete::TangibleThingsControllerTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
 
-  def setup
-    super
+  setup do
     @user = create(:onboarded_user)
     sign_in @user
     @team = @user.current_team
@@ -19,8 +18,7 @@ class Account::Scaffolding::CompletelyConcrete::TangibleThingsControllerTest < A
     Rails.application.reload_routes!
   end
 
-  def teardown
-    super
+  teardown do
     ENV["HIDE_THINGS"] = @original_hide_things
     Rails.application.reload_routes!
   end

--- a/test/controllers/account/teams_controller_test.rb
+++ b/test/controllers/account/teams_controller_test.rb
@@ -3,8 +3,7 @@ require "test_helper"
 class Account::TeamsControllerTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
 
-  def setup
-    super
+  setup do
     @user = FactoryBot.create(:onboarded_user)
     sign_in @user
     @team = @user.current_team

--- a/test/controllers/api/test.rb
+++ b/test/controllers/api/test.rb
@@ -25,9 +25,7 @@ class Api::Test < ActionDispatch::IntegrationTest
     response.parsed_body["access_token"]
   end
 
-  def setup
-    super
-
+  setup do
     @user = create(:onboarded_user)
     @team = @user.current_team
     @platform_application = create(:platform_application, team: @team)

--- a/test/controllers/api/v1/platform/access_tokens_controller_test.rb
+++ b/test/controllers/api/v1/platform/access_tokens_controller_test.rb
@@ -1,9 +1,8 @@
 require "controllers/api/v1/test"
 
 class Api::V1::Platform::AccessTokensControllerTest < Api::Test
-  def setup
+  setup do
     # See `test/controllers/api/test.rb` for common set up for API tests.
-    super
 
     @application = create(:platform_application, team: @team)
     @access_token = build(:platform_access_token, application: @application)

--- a/test/controllers/api/v1/platform/applications_controller_test.rb
+++ b/test/controllers/api/v1/platform/applications_controller_test.rb
@@ -3,9 +3,8 @@ require "controllers/api/v1/test"
 class Api::V1::Platform::ApplicationsControllerTest < Api::Test
   include Devise::Test::IntegrationHelpers
 
-  def setup
+  setup do
     # See `test/controllers/api/test.rb` for common set up for API tests.
-    super
     sign_in @user
   end
 

--- a/test/controllers/api/v1/scaffolding/completely_concrete/tangible_things_controller_test.rb
+++ b/test/controllers/api/v1/scaffolding/completely_concrete/tangible_things_controller_test.rb
@@ -1,9 +1,8 @@
 require "controllers/api/v1/test"
 
 class Api::V1::Scaffolding::CompletelyConcrete::TangibleThingsControllerTest < Api::Test
-  def setup
+  setup do
     # See `test/controllers/api/test.rb` for common set up for API tests.
-    super
 
     # 🚅 skip this section when scaffolding.
     @absolutely_abstract_creative_concept = create(:scaffolding_absolutely_abstract_creative_concept, team: @team)
@@ -25,8 +24,7 @@ class Api::V1::Scaffolding::CompletelyConcrete::TangibleThingsControllerTest < A
     Rails.application.reload_routes!
   end
 
-  def teardown
-    super
+  teardown do
     ENV["HIDE_THINGS"] = @original_hide_things
     Rails.application.reload_routes!
   end

--- a/test/controllers/api/v1/teams_controller_test.rb
+++ b/test/controllers/api/v1/teams_controller_test.rb
@@ -1,9 +1,8 @@
 require "controllers/api/v1/test"
 
 class Api::V1::TeamsControllerTest < Api::Test
-  def setup
+  setup do
     # See `test/controllers/api/test.rb` for common set up for API tests.
-    super
 
     @teams = create_list(:team, 3)
     # 🚅 super scaffolding will insert file-related logic above this line.

--- a/test/controllers/api/v1/users_controller_test.rb
+++ b/test/controllers/api/v1/users_controller_test.rb
@@ -1,9 +1,8 @@
 require "controllers/api/v1/test"
 
 class Api::V1::UsersControllerTest < Api::Test
-  def setup
+  setup do
     # See `test/controllers/api/test.rb` for common set up for API tests.
-    super
 
     @users = create_list(:user, 3)
     # 🚅 super scaffolding will insert file-related logic above this line.

--- a/test/controllers/application/localization_test.rb
+++ b/test/controllers/application/localization_test.rb
@@ -21,7 +21,7 @@ class ApplicationControllerTest < ActionController::TestCase
     @user = create(:onboarded_user)
   end
 
-  def teardown
+  teardown do
     I18n.available_locales = @actual_locales
   end
 

--- a/test/models/ability_test.rb
+++ b/test/models/ability_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 module AbilityTest
   class TeamMemberScenarios < ActiveSupport::TestCase
-    def setup
+    setup do
       @user = FactoryBot.create :onboarded_user
       @another_user = FactoryBot.create :onboarded_user
       @membership = FactoryBot.create :membership, user: @user, team: @user.current_team
@@ -29,7 +29,7 @@ module AbilityTest
   end
 
   class NonTeamMemberScenarios < ActiveSupport::TestCase
-    def setup
+    setup do
       @user = FactoryBot.create :user
       @another_user = FactoryBot.create :user
       @team = FactoryBot.create :team
@@ -54,7 +54,7 @@ module AbilityTest
   end
 
   class TeamAdminScenarios < ActiveSupport::TestCase
-    def setup
+    setup do
       @admin = FactoryBot.create :onboarded_user
       @another_user = FactoryBot.create :onboarded_user
       @membership = FactoryBot.create :membership, user: @admin, team: @admin.current_team, role_ids: [Role.admin.id]

--- a/test/models/invitation_test.rb
+++ b/test/models/invitation_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 
 class InvitationTest < ActiveSupport::TestCase
-  def setup
+  setup do
     @user = create(:onboarded_user)
     @membership = Membership.new(team: @user.current_team)
     @invitation = Invitation.create(team: @user.current_team, email: "test@user.com", from_membership: @user.memberships.first, membership: @membership)

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 
 class UserTest < ActiveSupport::TestCase
-  def setup
+  setup do
     @user = User.new(email: "jane@bullettrain.co")
   end
 

--- a/test/models/webhooks/incoming/stripe_webhook_test.rb
+++ b/test/models/webhooks/incoming/stripe_webhook_test.rb
@@ -41,7 +41,7 @@ if defined?(BulletTrain::Billing::Stripe)
     end
 
     class SubscriptionValidOrderTests < Webhooks::Incoming::StripeWebhookTest
-      def setup
+      setup do
         team = create :team
         stripe_subscription = create :billing_stripe_subscription, team: team
         @generic_subscription = create :billing_subscription, provider_subscription: stripe_subscription, status: nil
@@ -64,7 +64,7 @@ if defined?(BulletTrain::Billing::Stripe)
     # we want to make sure that we don't erroneously set the subscription status
     # back to 'pending' becasue that's confusing for everyone especially customers.
     class SubscriptionInvalidOrderTests < Webhooks::Incoming::StripeWebhookTest
-      def setup
+      setup do
         team = create :team
         stripe_subscription = create :billing_stripe_subscription, team: team
         @generic_subscription = create :billing_subscription, provider_subscription: stripe_subscription, status: nil

--- a/test/system/account_test.rb
+++ b/test/system/account_test.rb
@@ -1,8 +1,7 @@
 require "application_system_test_case"
 
 class AccountTest < ApplicationSystemTestCase
-  def setup
-    super
+  setup do
     @jane = create :onboarded_user, first_name: "Jane", last_name: "Smith"
     login_as(@jane, scope: :user)
     visit root_path

--- a/test/system/action_models_test.rb
+++ b/test/system/action_models_test.rb
@@ -5,8 +5,7 @@
 require "application_system_test_case"
 
 class ActionModelsSystemTest < ApplicationSystemTestCase
-  def setup
-    super
+  setup do
     @jane = create :onboarded_user, first_name: "Jane", last_name: "Smith"
   end
 

--- a/test/system/animations_test.rb
+++ b/test/system/animations_test.rb
@@ -1,8 +1,7 @@
 require "application_system_test_case"
 
 class AnimationsTest < ApplicationSystemTestCase
-  def setup
-    super
+  setup do
     @jane = create :onboarded_user, first_name: "Jane", last_name: "Smith"
     @team = @jane.current_team
   end

--- a/test/system/bullet_train_gems/audit_logs/super_scaffolding_test.rb
+++ b/test/system/bullet_train_gems/audit_logs/super_scaffolding_test.rb
@@ -3,10 +3,9 @@ require "application_system_test_case"
 module BulletTrainGems
   module AuditLogs
     class SuperScaffoldingSystemTest < ApplicationSystemTestCase
-      def setup
+      setup do
         skip unless File.readlines("Gemfile").grep(/bullet_train-audit_logs/).any?
         skip unless defined?(Book)
-        super
         @jane = create :onboarded_user, first_name: "Jane", last_name: "Smith"
       end
 

--- a/test/system/dates_helper_test.rb
+++ b/test/system/dates_helper_test.rb
@@ -1,15 +1,13 @@
 require "application_system_test_case"
 
 class DatesHelperTest < ApplicationSystemTestCase
-  def setup
-    super
+  setup do
     @original_hide_things = ENV["HIDE_THINGS"]
     ENV["HIDE_THINGS"] = "false"
     Rails.application.reload_routes!
   end
 
-  def teardown
-    super
+  teardown do
     ENV["HIDE_THINGS"] = @original_hide_things
     Rails.application.reload_routes!
   end

--- a/test/system/fields_test.rb
+++ b/test/system/fields_test.rb
@@ -1,15 +1,13 @@
 require "application_system_test_case"
 
 class FieldsTest < ApplicationSystemTestCase
-  def setup
-    super
+  setup do
     @original_hide_things = ENV["HIDE_THINGS"]
     ENV["HIDE_THINGS"] = "false"
     Rails.application.reload_routes!
   end
 
-  def teardown
-    super
+  teardown do
     ENV["HIDE_THINGS"] = @original_hide_things
     Rails.application.reload_routes!
   end

--- a/test/system/invitation_details_test.rb
+++ b/test/system/invitation_details_test.rb
@@ -1,8 +1,7 @@
 require "application_system_test_case"
 
 class InvitationsTest < ApplicationSystemTestCase
-  def setup
-    super
+  setup do
     @jane = create :onboarded_user, first_name: "Jane", last_name: "Smith"
     @john = create :onboarded_user, first_name: "John", last_name: "Smith", email: "john@bullettrain.co"
 

--- a/test/system/invitation_lists_test.rb
+++ b/test/system/invitation_lists_test.rb
@@ -1,7 +1,7 @@
 require "application_system_test_case"
 
 class InvitationListsTest < ApplicationSystemTestCase
-  def setup
+  setup do
     # TODO: Capybara.current_driver is returning :selenium,
     # when it should be either :selenium_chrome or :selenium_chrome_headless.
     Capybara.current_driver = Capybara.default_driver
@@ -13,7 +13,7 @@ class InvitationListsTest < ApplicationSystemTestCase
     end
   end
 
-  def teardown
+  teardown do
     BulletTrain.configure do |config|
       config.enable_bulk_invitations = @current_bulk_invitations_setting
     end

--- a/test/system/pagination_test.rb
+++ b/test/system/pagination_test.rb
@@ -1,8 +1,7 @@
 require "application_system_test_case"
 
 class PaginationTest < ApplicationSystemTestCase
-  def setup
-    super
+  setup do
     @jane = create :onboarded_user, first_name: "Jane", last_name: "Smith"
     @team = @jane.current_team
 
@@ -11,8 +10,7 @@ class PaginationTest < ApplicationSystemTestCase
     Rails.application.reload_routes!
   end
 
-  def teardown
-    super
+  teardown do
     ENV["HIDE_THINGS"] = @original_hide_things
     Rails.application.reload_routes!
   end

--- a/test/system/reactivity_system_test.rb
+++ b/test/system/reactivity_system_test.rb
@@ -1,15 +1,13 @@
 require "application_system_test_case"
 
 class ReactivitySystemTest < ApplicationSystemTestCase
-  def setup
-    super
+  setup do
     @original_hide_things = ENV["HIDE_THINGS"]
     ENV["HIDE_THINGS"] = "false"
     Rails.application.reload_routes!
   end
 
-  def teardown
-    super
+  teardown do
     ENV["HIDE_THINGS"] = @original_hide_things
     Rails.application.reload_routes!
   end

--- a/test/system/super_scaffolding/partial_test.rb
+++ b/test/system/super_scaffolding/partial_test.rb
@@ -1,8 +1,7 @@
 require "application_system_test_case"
 
 class SuperScaffoldingSystemTest < ApplicationSystemTestCase
-  def setup
-    super
+  setup do
     @jane = create :onboarded_user, first_name: "Jane", last_name: "Smith"
   end
 

--- a/test/system/super_scaffolding/super_scaffolding_test.rb
+++ b/test/system/super_scaffolding/super_scaffolding_test.rb
@@ -1,8 +1,7 @@
 require "application_system_test_case"
 
 class SuperScaffoldingSystemTest < ApplicationSystemTestCase
-  def setup
-    super
+  setup do
     @jane = create :onboarded_user, first_name: "Jane", last_name: "Smith"
   end
 

--- a/test/system/tangible_thing_test.rb
+++ b/test/system/tangible_thing_test.rb
@@ -1,15 +1,13 @@
 require "application_system_test_case"
 
 class TangibleThingTest < ApplicationSystemTestCase
-  def setup
-    super
+  setup do
     @original_hide_things = ENV["HIDE_THINGS"]
     ENV["HIDE_THINGS"] = "false"
     Rails.application.reload_routes!
   end
 
-  def teardown
-    super
+  teardown do
     ENV["HIDE_THINGS"] = @original_hide_things
     Rails.application.reload_routes!
   end

--- a/test/system/teams_test.rb
+++ b/test/system/teams_test.rb
@@ -1,8 +1,7 @@
 require "application_system_test_case"
 
 class TeamsTest < ApplicationSystemTestCase
-  def setup
-    super
+  setup do
     @jane = create :onboarded_user, first_name: "Jane", last_name: "Smith"
     @john = create :onboarded_user, first_name: "John", last_name: "Smith"
     @jack = create :user, first_name: "Jack", last_name: "Smith"

--- a/test/system/two_factor_authentication_test.rb
+++ b/test/system/two_factor_authentication_test.rb
@@ -2,7 +2,7 @@ require "application_system_test_case"
 
 class TwoFactorAuthentication < ApplicationSystemTestCase
   if two_factor_authentication_enabled?
-    def setup
+    setup do
       @jane = FactoryBot.create :two_factor_user, first_name: "Jane", last_name: "Smith"
       @john = FactoryBot.create :user, first_name: "John", last_name: "Smith"
     end

--- a/test/system/webhooks_system_test.rb
+++ b/test/system/webhooks_system_test.rb
@@ -3,8 +3,7 @@ require "application_system_test_case"
 class WebhooksSystemTest < ApplicationSystemTestCase
   include ActiveJob::TestHelper
 
-  def setup
-    super
+  setup do
     @user = create :onboarded_user, first_name: "Andrew", last_name: "Culver"
     @another_user = create :onboarded_user, first_name: "John", last_name: "Smith"
     return unless Rails.configuration.respond_to?(:outgoing_webhooks)
@@ -17,8 +16,7 @@ class WebhooksSystemTest < ApplicationSystemTestCase
     Rails.application.reload_routes!
   end
 
-  def teardown
-    super
+  teardown do
     ENV["HIDE_THINGS"] = @original_hide_things
     Rails.application.reload_routes!
   end


### PR DESCRIPTION
When using `def setup` things can behave unpredictably if developers forget to call `super`. Using the `setup do` hook eliminates that problem.

Fixes: https://github.com/bullet-train-co/bullet_train/issues/1626