### PR TITLE
Make it easier to use Cloudinary as a storage option for ActiveStorage

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -114,12 +114,11 @@ Rails.application.configure do
   # configuration right now, i'm making them the default here as well.
   config.action_mailbox.ingress = :mailgun
 
+  # Rails defaults to :local in development. Set any of these ENV vars to use non-local options.
   if (ENV["AWS_ACCESS_KEY_ID"] || ENV["BUCKETEER_AWS_ACCESS_KEY_ID"]).present?
     config.active_storage.service = :amazon
   elsif ENV["CLOUDINARY_URL"].present?
     config.active_storage.service = :cloudinary
-  else
-    config.active_storage.service = :local
   end
 
   # ✅ YOUR APPLICATION'S CONFIGURATION

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -114,6 +114,14 @@ Rails.application.configure do
   # configuration right now, i'm making them the default here as well.
   config.action_mailbox.ingress = :mailgun
 
+  if (ENV["AWS_ACCESS_KEY_ID"] || ENV["BUCKETEER_AWS_ACCESS_KEY_ID"]).present?
+    config.active_storage.service = :amazon
+  elsif ENV["CLOUDINARY_URL"].present?
+    config.active_storage.service = :cloudinary
+  else
+    config.active_storage.service = :local
+  end
+
   # ✅ YOUR APPLICATION'S CONFIGURATION
   # If you need to customize your application's configuration, this is the place to do it. This helps avoid merge
   # conflicts in the future when Rails or Bullet Train update their own default settings.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -115,6 +115,8 @@ Rails.application.configure do
 
   if (ENV["AWS_ACCESS_KEY_ID"] || ENV["BUCKETEER_AWS_ACCESS_KEY_ID"]).present?
     config.active_storage.service = :amazon
+  elsif ENV["CLOUDINARY_URL"].present?
+    config.active_storage.service = :cloudinary
   else
     puts "WARNING! : We didn't find an active_storage.service configured so we're falling back to the local store, but it's A VERY BAD IDEA to rely on it in production unless you know what you're doing."
     config.active_storage.service = :local

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -13,3 +13,6 @@ amazon:
   secret_access_key: <%= ENV['AWS_SECRET_ACCESS_KEY'] || ENV['BUCKETEER_AWS_SECRET_ACCESS_KEY'] %>
   bucket: <%= ENV['AWS_S3_BUCKET'] || ENV['BUCKETEER_BUCKET_NAME'] %>
   region: <%= ENV['AWS_S3_REGION'] || ENV['BUCKETEER_AWS_REGION'] %>
+
+cloudinary:
+  service: Cloudinary


### PR DESCRIPTION
This makes it easier to use Cloudindary as the backend service for ActiveStorage. From a functional perspective this works very much like the S3 service option. ActiveStorage is still in control of files, but it sends them through to Cloudinary for storage and delivery.

**NOTE:** If, in production, you use Cloudinary for anything and have a `CLOUDINARY_URL` ENV var set but you want to use the `:local` option for ActiveStorage then you'll want to make an adjustment to `config/environments/production.rb`.

Partial fix for : https://github.com/bullet-train-co/bullet_train/issues/1617