### PR TITLE
Refactor check_image_dependencies.rb to not require both vips and ImageMagick

### DIFF
--- a/bin/setup-scripts/check_image_dependencies.rb
+++ b/bin/setup-scripts/check_image_dependencies.rb
@@ -11,10 +11,10 @@ def check_dependency(name, version_command)
   if $?.success?
     version = version_info.split("\n").first
     puts "#{name} is installed: #{version}".green
-    return true
+    true
   else
     puts "#{name} is not installed or not found in PATH.".red
-    return false
+    false
   end
 end
 

--- a/bin/setup-scripts/check_image_dependencies.rb
+++ b/bin/setup-scripts/check_image_dependencies.rb
@@ -11,27 +11,37 @@ def check_dependency(name, version_command)
   if $?.success?
     version = version_info.split("\n").first
     puts "#{name} is installed: #{version}".green
+    return true
   else
     puts "#{name} is not installed or not found in PATH.".red
-    install_msg = case name
-    when "vips"
-      "Try `brew install vips` on macOS or `sudo apt-get install libvips` on Ubuntu."
-    when "ImageMagick"
-      "Try `brew install imagemagick` on macOS or `sudo apt-get install imagemagick` on Ubuntu."
-    end
-    puts install_msg
-
-    continue_anyway = ask_boolean "Would you like to continue without #{name}?", "n"
-    if continue_anyway
-      puts "Continuing without #{name}. This can prevent Rails scripts from running and cause problems with image processing.".yellow
-    else
-      puts "You've chosen not to continue without #{name}. Goodbye.".red
-      exit
-    end
+    return false
   end
 end
 
-check_dependency("vips", "vips --version")
-check_dependency("ImageMagick", "magick -version")
+vips_installed = check_dependency("vips", "vips --version")
+magick_installed = check_dependency("ImageMagick", "magick -version")
+
+if vips_installed || magick_installed
+  # do nothing
+else
+  puts " "
+  puts "--------------------------------------------".red
+  puts "We couldn't find either vips or ImageMagick.".red
+  puts " "
+  puts "To install vips:"
+  puts "Try `brew install vips` on macOS or `sudo apt-get install libvips` on Ubuntu."
+  puts " "
+  puts "To install ImageMagick:"
+  puts "Try `brew install imagemagick` on macOS or `sudo apt-get install imagemagick` on Ubuntu."
+  puts " "
+
+  continue_anyway = ask_boolean "Would you like to continue without any image processing dependencies?", "n"
+  if continue_anyway
+    puts "Continuing without image processing dependencies. This can prevent Rails scripts from running and cause problems with image processing.".yellow
+  else
+    puts "You've chosen not to continue without image processing dependencies. Goodbye.".red
+    exit
+  end
+end
 
 puts "\nImage processing dependency check completed.".green


### PR DESCRIPTION
This makes it so that if you have either `vips` or `magick` available on your `PATH` that we count that as being good enough for image processing dependencies and we move on. Previously we'd check for both and prompt you to install both even though we only need one or the other. This should make it less confusing for people who don't realize that they're alternatives that do the same thing.