### PR TITLE
Upgrade pagy to version 8 (via `core`)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -110,9 +110,6 @@ end
 # BULLET TRAIN GEMS
 # This section is the list of Ruby gems included by default for Bullet Train.
 
-# TODO: Remove this after updating the core gems to 1.7.21
-gem "pagy", "< 7"
-
 # We use a constant here so that we can ensure that all of the bullet_train-*
 # packages are on the same version.
 BULLET_TRAIN_VERSION = "1.8.5"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -752,7 +752,6 @@ DEPENDENCIES
   magic_test
   minitest-reporters
   minitest-retry
-  pagy (< 7)
   pg (>= 0.18, < 2.0)
   postmark-rails
   pry

--- a/test/system/pagination_test.rb
+++ b/test/system/pagination_test.rb
@@ -38,7 +38,7 @@ class PaginationTest < ApplicationSystemTestCase
     assert_text("Test 1")
     refute_text("Test #{Pagy::DEFAULT[:items] + 1}")
 
-    click_on ">"
+    click_on "2"
     assert_text("Test #{Pagy::DEFAULT[:items] + 1}")
   end
 end

--- a/test/system/pagination_test.rb
+++ b/test/system/pagination_test.rb
@@ -38,7 +38,7 @@ class PaginationTest < ApplicationSystemTestCase
     assert_text("Test 1")
     refute_text("Test #{Pagy::DEFAULT[:items] + 1}")
 
-    click_on "Next"
+    click_on ">"
     assert_text("Test #{Pagy::DEFAULT[:items] + 1}")
   end
 end


### PR DESCRIPTION
This makes it so that we don't declare a direct dependency on `pagy`, but instead rely on the version specified by the `core` gems.

Joint PR in `core` that updates `pagy` from version 6 to version 8: https://github.com/bullet-train-co/bullet_train-core/pull/955

In `pagy` version 7 they [changed the default text](https://github.com/ddnexus/pagy/blob/master/CHANGELOG_LEGACY.md#visual-changes-possibly-breaking-testviews) for the "next page" and "previous page" buttons. For simplicity, and to reduce the amount of code that we need to support, we're sticking with the `pagy` defaults. Previously those buttons read `< Prev` and `Next >` and now they've dropped the text and just use the symbols `<` and `>`.

If you want to maintain the previous behavior you can [copy the pagy translation file](https://github.com/ddnexus/pagy/blob/master/gem/locales/en.yml) into your app, customize it, and then [configure pagy to use it](https://ddnexus.github.io/pagy/docs/how-to/#customize-the-dictionary).

If you stick with the new defaults you may need to [update some system tests to alter how they move from page to page](https://github.com/bullet-train-co/bullet_train/pull/1767/files#diff-6ebc1d555ac83492c25fe74eb07272332f9c47aceada8081f63350d0be3d5a1b) (if you have any of your own tests around pagination).

Before upgrading `pagy`:

![CleanShot 2024-11-19 at 09 54 28](https://github.com/user-attachments/assets/91a7d5e4-3193-4625-83c0-a1cf32e0e247)

After upgrading `pagy`:

![CleanShot 2024-11-19 at 09 54 40](https://github.com/user-attachments/assets/66ca07b4-a916-4766-bc7d-766d6f0bb323)

Fixes: https://github.com/bullet-train-co/bullet_train/issues/1582
Fixes: https://github.com/bullet-train-co/bullet_train/issues/1450