### PR TITLE
Remove a couple of the riskier Doorkeeper grant flows

### DIFF
--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -368,7 +368,7 @@ Doorkeeper.configure do
   # The user doesn't have control over the authorization process, so clients
   # aren't limited by scope, and could potentially have the same capabilities
   # as the user themselves. See the second link above for countermeasures.
-  grant_flows %w[authorization_code password implicit client_credentials]
+  grant_flows %w[authorization_code client_credentials]
 
   # Allows to customize OAuth grant flows that +each+ application support.
   # You can configure a custom block (or use a class respond to `#call`) that must

--- a/test/controllers/api/test.rb
+++ b/test/controllers/api/test.rb
@@ -1,28 +1,18 @@
 class Api::Test < ActionDispatch::IntegrationTest
   def access_token
-    params = {
-      client_id: @platform_application.uid,
-      client_secret: @platform_application.secret,
-      grant_type: "password",
-      scope: "read write delete"
-    }
-
-    post "/oauth/token", params: params
-    assert_response :success
-    response.parsed_body["access_token"]
+    access_token = Doorkeeper::AccessToken.create!(resource_owner_id: @user.id,
+                                             token: SecureRandom.hex,
+                                             application: @platform_application,
+                                             scopes: "read write delete")
+    access_token.token
   end
 
   def another_access_token
-    params = {
-      client_id: @another_platform_application.uid,
-      client_secret: @another_platform_application.secret,
-      grant_type: "password",
-      scope: "read write delete"
-    }
-
-    post "/oauth/token", params: params
-    assert_response :success
-    response.parsed_body["access_token"]
+    access_token = Doorkeeper::AccessToken.create!(resource_owner_id: @another_user.id,
+                                             token: SecureRandom.hex,
+                                             application: @another_platform_application,
+                                             scopes: "read write delete")
+    access_token.token
   end
 
   setup do

--- a/test/controllers/api/test.rb
+++ b/test/controllers/api/test.rb
@@ -1,17 +1,21 @@
 class Api::Test < ActionDispatch::IntegrationTest
   def access_token
-    access_token = Doorkeeper::AccessToken.create!(resource_owner_id: @user.id,
-                                             token: SecureRandom.hex,
-                                             application: @platform_application,
-                                             scopes: "read write delete")
+    access_token = Doorkeeper::AccessToken.create!(
+      resource_owner_id: @user.id,
+      token: SecureRandom.hex,
+      application: @platform_application,
+      scopes: "read write delete"
+    )
     access_token.token
   end
 
   def another_access_token
-    access_token = Doorkeeper::AccessToken.create!(resource_owner_id: @another_user.id,
-                                             token: SecureRandom.hex,
-                                             application: @another_platform_application,
-                                             scopes: "read write delete")
+    access_token = Doorkeeper::AccessToken.create!(
+      resource_owner_id: @another_user.id,
+      token: SecureRandom.hex,
+      application: @another_platform_application,
+      scopes: "read write delete"
+    )
     access_token.token
   end
 


### PR DESCRIPTION
The `password` and `implicit` grant flows are a little riskier from a security standpoint. We're removing them so that we ship a more secure default. It's easy enough for a developer add them to the Doorkeeper config if they're needed.

If you need to bring back one or both of these you can add them back to `config/initializers/doorkeeper.rb` here:

https://github.com/bullet-train-co/bullet_train/pull/1772/files#diff-c7fc4e057f18c41db72e3ab775f9871e6bee4d7e2b0aba1fdbfb2ea209dd2141L371-R371

Fixes https://github.com/bullet-train-co/bullet_train/issues/820