### PR TITLE
Make turned off redis/pg non-breaking during setup

### DIFF
--- a/bin/setup-scripts/check_postgres.rb
+++ b/bin/setup-scripts/check_postgres.rb
@@ -21,6 +21,20 @@ if /postgres/.match?(postgres_version_info.downcase)
 
   if postgres_version.match?(/^14/)
     puts "You have PostgreSQL 14 installed.".green
+
+    postgres_running = system("pg_isready > /dev/null 2>&1")
+    if postgres_running
+      puts "PostgreSQL is running.".green
+    else
+      puts "PostgreSQL is installed but not running. You will need it in the DB setup steps.".red
+      stop_now = ask_boolean "Would you like to stop here and start PostgreSQL first?", "n"
+      if stop_now
+        puts "PostgreSQL is not running and you've chosen to start it first. Run bin/setup again after.".red
+        exit
+      else
+        puts "Continuing without PostgreSQL running. You will need it in the next setup steps.".yellow
+      end
+    end
   else
     puts "You have PostgreSQL installed, but you're using v#{postgres_version} and not v14.".red
     continue_anyway = ask_boolean "Try proceeding without PostgreSQL 14?", "y"
@@ -36,6 +50,20 @@ elsif /postgres/.match?(psql_version_info.downcase)
 
   if psql_version.match?(/^14/)
     puts "You have PostgreSQL 14 installed.".green
+
+    postgres_running = system("pg_isready > /dev/null 2>&1")
+    if postgres_running
+      puts "PostgreSQL is running.".green
+    else
+      puts "PostgreSQL is installed but not running. You will need it in the DB setup steps.".red
+      stop_now = ask_boolean "Would you like to stop here and start PostgreSQL first?", "n"
+      if stop_now
+        puts "PostgreSQL is not running and you've chosen to start it first. Run bin/setup again after.".red
+        exit
+      else
+        puts "Continuing without PostgreSQL running. You will need it in the next setup steps.".yellow
+      end
+    end
   else
     puts "You have PostgreSQL installed, but you're using v#{psql_version} and not v14.".red
     continue_anyway = ask_boolean "Try proceeding without PostgreSQL 14?", "y"

--- a/bin/setup-scripts/check_redis.rb
+++ b/bin/setup-scripts/check_redis.rb
@@ -14,6 +14,20 @@ puts ""
 if /redis/.match?(redis_version_info.downcase)
   redis_version = redis_version_info.split("\s")[1]
   puts "You have redis #{redis_version} installed.".green
+
+  redis_running = system("redis-cli ping > /dev/null 2>&1")
+  if redis_running
+    puts "Redis is running.".green
+  else
+    puts "Redis is installed but not running. You will need it when starting your development app.".red
+    stop_now = ask_boolean "Would you like to stop here and start Redis first?", "n"
+    if stop_now
+      puts "Redis is not running and you've chosen to start it first. Run bin/setup again after.".red
+      exit
+    else
+      puts "Continuing without Redis running. You will need it when starting your development app.".yellow
+    end
+  end
 else
   puts "You don't seem to have redis installed.".red
   continue_anyway = ask_boolean "Would you like to try to continue without redis?", "n"


### PR DESCRIPTION
It's possible that a dev installs Postgres and Redis as prompted which will pass the installed check. However, if the dev has those services still turned off, they will fail later during the install, which can lead to confusion, frustration and less activations on BT.