### PR TITLE
Improve Heroku Detection

### DIFF
--- a/app.json
+++ b/app.json
@@ -33,6 +33,10 @@
       "description": "Supply the fully-qualified URL for this Heroku app, e.g. `https://your-app.herokuapp.com`. You'll update this later after configuring a custom domain.",
       "value": "https://ENTER_YOUR_APP_NAME_HERE.herokuapp.com"
     },
+    "BT_IS_IN_HEROKU": {
+      "description": "We use this to tweak some run-time settings when we know we're running the app in Heroku. Don't change it!",
+      "value": "true"
+    },
     "FONTAWESOME_NPM_AUTH_TOKEN": {
       "description": "We recommend using Font Awesome Pro for icons. To use it, fetch your token from `https://fontawesome.com/how-to-use/on-the-web/setup/using-package-managers` and enter it here.",
       "required": false


### PR DESCRIPTION
We can use app.json to set an environment variable for apps deployed in Heroku. This is kind of the "first line of defense" for detecting that we're in Heroku. We'll also fallback to some other methods.

When the `BT_IS_IN_HEROKU` ENV var is set to `true` we'll assume that we're running in Heroku, and we'll sidestep any other detection methods.

We'll still fallback to our previous detection methods if that ENV var does not exist.

This also allows apps _not_ in Heroku to negate a false positive detection by our fallback methods by setting the `BT_IS_IN_HEROKU` ENV var to `false`.

Joint PR: https://github.com/bullet-train-co/bullet_train-core/pull/985