### PR TITLE
Fix for standardrb in GitHub Actions

### DIFF
--- a/.github/workflows/ci-cd-pipeline-main.yml
+++ b/.github/workflows/ci-cd-pipeline-main.yml
@@ -20,6 +20,9 @@ jobs:
     name: 🔬 Standardrb
     uses: ./.github/workflows/_standardrb.yml
     secrets: inherit
+    permissions:
+      checks: write
+      contents: read
   db_schema:
     name: 🔎 DB Schema
     uses: ./.github/workflows/_database_schema_check.yml

--- a/.github/workflows/ci-cd-pipeline.yml
+++ b/.github/workflows/ci-cd-pipeline.yml
@@ -20,6 +20,9 @@ jobs:
     name: 🔬 Standardrb
     uses: ./.github/workflows/_standardrb.yml
     secrets: inherit
+    permissions:
+      checks: write
+      contents: read
   db_schema:
     name: 🔎 DB Schema
     uses: ./.github/workflows/_database_schema_check.yml


### PR DESCRIPTION
The official workflow for starndard rb requires that permissions be passed down through workflows. For some reason this is unneccessary in the starter repo itself, but for downstream apps GHA sometimes complains about standard rb missing required permissions. This should make it more stable across apps.

Fixes: https://github.com/bullet-train-co/bullet_train/issues/1812