### PR TITLE
Fix missing JS peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "stimulus-reveal": "^1.4.2",
     "stimulus-scroll-reveal": "^3.2.0",
     "tailwindcss": "^3.4.17",
+    "trix": "^2.1.11",
     "yalc": "^1.0.0-pre.53"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@bullet-train/fields": "1.12.2",
     "@esbuild-plugins/node-globals-polyfill": "^0.2.3",
     "@fullhuman/postcss-purgecss": "7.0.2",
+    "@hotwired/stimulus": "^3.2.2",
     "@hotwired/turbo-rails": "^8.0.12",
     "@icon/themify-icons": "^1.0.1-alpha.3",
     "@rails/actioncable": "^7.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2202,6 +2202,7 @@ __metadata:
     "@bullet-train/fields": "npm:1.12.2"
     "@esbuild-plugins/node-globals-polyfill": "npm:^0.2.3"
     "@fullhuman/postcss-purgecss": "npm:7.0.2"
+    "@hotwired/stimulus": "npm:^3.2.2"
     "@hotwired/turbo-rails": "npm:^8.0.12"
     "@icon/themify-icons": "npm:^1.0.1-alpha.3"
     "@rails/actioncable": "npm:^7.1.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2102,6 +2102,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/trusted-types@npm:^2.0.7":
+  version: 2.0.7
+  resolution: "@types/trusted-types@npm:2.0.7"
+  checksum: 10c0/4c4855f10de7c6c135e0d32ce462419d8abbbc33713b31d294596c0cc34ae1fa6112a2f9da729c8f7a20707782b0d69da3b1f8df6645b0366d08825ca1522e0c
+  languageName: node
+  linkType: hard
+
 "abbrev@npm:^2.0.0":
   version: 2.0.0
   resolution: "abbrev@npm:2.0.0"
@@ -2227,6 +2234,7 @@ __metadata:
     stimulus-reveal: "npm:^1.4.2"
     stimulus-scroll-reveal: "npm:^3.2.0"
     tailwindcss: "npm:^3.4.17"
+    trix: "npm:^2.1.11"
     yalc: "npm:^1.0.0-pre.53"
   languageName: unknown
   linkType: soft
@@ -2843,6 +2851,18 @@ __metadata:
   version: 3.1.5
   resolution: "dompurify@npm:3.1.5"
   checksum: 10c0/8227fb1328c02d94f823de8cd499fca5ee07051e03e6b52bce06b592348aeb6e56ea8e2a4b0a9cfaeac7d623e4b5a52e4326aedf72596a6c2510b88dfcf2a2b6
+  languageName: node
+  linkType: hard
+
+"dompurify@npm:^3.2.3":
+  version: 3.2.3
+  resolution: "dompurify@npm:3.2.3"
+  dependencies:
+    "@types/trusted-types": "npm:^2.0.7"
+  dependenciesMeta:
+    "@types/trusted-types":
+      optional: true
+  checksum: 10c0/0ce5cb89b76f396d800751bcb48e0d137792891d350ccc049f1bc9a5eca7332cc69030c25007ff4962e0824a5696904d4d74264df9277b5ad955642dfb6f313f
   languageName: node
   linkType: hard
 
@@ -5937,6 +5957,15 @@ __metadata:
   version: 2.0.8
   resolution: "trix@npm:2.0.8"
   checksum: 10c0/b95f6e4c466863c656e4d64e757c53132dbfc07a2b19ce0aa84ac725211e0137aa8ae055298f248df461885122228c8b195082aa792ea85c9f79dfc068eb41db
+  languageName: node
+  linkType: hard
+
+"trix@npm:^2.1.11":
+  version: 2.1.11
+  resolution: "trix@npm:2.1.11"
+  dependencies:
+    dompurify: "npm:^3.2.3"
+  checksum: 10c0/ec52229a92e6d30f6cff1423578290215ea5e4219871a14963e23db9da45134b9b5b9ee6bebac4d0e1b038aae4af1ccd6add365b775582430bd61bdba5bcf086
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Before (notice the "Post-resolution validation" section):

```
$ yarn
➤ YN0000: · Yarn 4.2.2
➤ YN0000: ┌ Resolution step
➤ YN0000: └ Completed
➤ YN0000: ┌ Post-resolution validation
➤ YN0002: │ app@workspace:. doesn't provide @hotwired/stimulus (pf1eaf), requested by stimulus-scroll-reveal.
➤ YN0002: │ app@workspace:. doesn't provide trix (pf188a), requested by @rails/actiontext.
➤ YN0086: │ Some peer dependencies are incorrectly met; run yarn explain peer-requirements <hash> for details, where <hash> is the six-letter p-prefixed code.
➤ YN0000: └ Completed
➤ YN0000: ┌ Fetch step
➤ YN0000: └ Completed
➤ YN0000: ┌ Link step
➤ YN0000: └ Completed
➤ YN0000: · Done with warnings in 0s 314ms
```

To generate this PR I did:

```
yarn add @hotwired/stimulus
yarn add trix
```

After

```
$ yarn
➤ YN0000: · Yarn 4.2.2
➤ YN0000: ┌ Resolution step
➤ YN0000: └ Completed
➤ YN0000: ┌ Fetch step
➤ YN0000: └ Completed
➤ YN0000: ┌ Link step
➤ YN0000: └ Completed
➤ YN0000: · Done in 0s 285ms
```

Fixes https://github.com/bullet-train-co/bullet_train/issues/1550