### PR TITLE
Add zapier/.yarn/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,13 @@ yalc.lock
 !.yarn/sdks
 !.yarn/versions
 
+zapier/.yarn/*
+!zapier/.yarn/patches
+!zapier/.yarn/plugins
+!zapier/.yarn/releases
+!zapier/.yarn/sdks
+!zapier/.yarn/versions
+
 # 🚅 this is bullet train's list of files to ignore.
 # please add yours at the end of the file.
 


### PR DESCRIPTION
The zapier integration has its own `package.json` and `yarn.lock` files and new versions of yarn create `.yarn` directory when you install.

This adds the same patterns for `zapier/.yarn/` that we already have for `.yarn/`.