### PR TITLE
Replace `sprockets-rails` with `propshaft`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,8 +11,8 @@ ruby(File.read(File.expand_path(".ruby-version", __dir__)))
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 8.0.0"
 
-# The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
-gem "sprockets-rails"
+# The modern asset pipeline for Rails [https://github.com/rails/propshaft]
+gem "propshaft"
 
 # Use postgresql as the database for Active Record
 gem "pg", ">= 0.18", "< 2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -488,6 +488,11 @@ GEM
     prism (1.3.0)
     prop_initializer (0.2.0)
       zeitwerk (>= 2.6.18)
+    propshaft (1.1.0)
+      actionpack (>= 7.0.0)
+      activesupport (>= 7.0.0)
+      rack
+      railties (>= 7.0.0)
     pry (0.15.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -647,13 +652,6 @@ GEM
     snaky_hash (2.0.1)
       hashie
       version_gem (~> 1.1, >= 1.1.1)
-    sprockets (4.2.1)
-      concurrent-ruby (~> 1.0)
-      rack (>= 2.2.4, < 4)
-    sprockets-rails (3.5.2)
-      actionpack (>= 6.1)
-      activesupport (>= 6.1)
-      sprockets (>= 3.0.0)
     standard (1.44.0)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.0)
@@ -771,6 +769,7 @@ DEPENDENCIES
   parallel_tests
   pg (>= 0.18, < 2.0)
   postmark-rails
+  propshaft
   pry
   puma (~> 6.0)
   rack-mini-profiler
@@ -787,7 +786,6 @@ DEPENDENCIES
   sentry-sidekiq
   simplecov
   simplecov-json
-  sprockets-rails
   standard
   stimulus-rails
   terser

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,2 +1,0 @@
-//= link_tree ../images
-//= link_tree ../builds

--- a/config/application.rb
+++ b/config/application.rb
@@ -32,7 +32,6 @@ module UntitledApplication
     config.i18n.available_locales = YAML.safe_load_file("config/locales/locales.yml", aliases: true).with_indifferent_access.dig(:locales).keys.map(&:to_sym)
     config.i18n.default_locale = config.i18n.available_locales.first
     config.i18n.fallbacks = [:en]
-    config.assets.paths << Rails.root.join("app", "assets", "fonts")
 
     BulletTrain::Api.set_configuration(self)
   end


### PR DESCRIPTION
[propshaft](https://github.com/rails/propshaft) is the new gem for the asset pipeline that replaces [sprockets](https://github.com/rails/sprockets). Moving to `propshaft` from `sprockets` should make it easier to transition to using `importmaps`.

`propshaft` takes a more simplified approach and doesn't provide as many features as `sprockets`, but I don't think that we were really _depending_ any of those features. We already use `jsbuilding-rails` and `cssbundling-rails` to handle bundling and transpiling `.js` and `.css` files.

After making these changes I ran `rails assets:clobber` to make sure that I wasn't seeing old assets, and then I ran `bin/dev` to launch the dev server. Everything seems to work as expected. I confirmed that the color picker, date picker, super selects, dependent fields, and mobile slide out menu are all working.

I ran `rails assets:precompile` to make sure that precompilation works.

## Details about differences between output under `propshaft` and `sprockets`

I ran the following to compare precompilation output from sprockets with the output from propshaft both in production mode and in development mode. (The `main` branch is using sprockets, and the `jeremy/propshaft` branch is using propshaft.)

```
git checkout main
RAILS_ENV=production SECRET_KEY_BASE_DUMMY=1 rails assets:precompile
mv public/assets public/assets_sprockets_production

RAILS_ENV=development SECRET_KEY_BASE_DUMMY=1 rails assets:precompile
mv public/assets public/assets_sprockets_development

git checkout jeremy/propshaft
RAILS_ENV=production SECRET_KEY_BASE_DUMMY=1 rails assets:precompile
mv public/assets public/assets_propshaft_production

RAILS_ENV=development SECRET_KEY_BASE_DUMMY=1 rails assets:precompile
mv public/assets public/assets_propshaft_development
```

The biggest differences that I can see are:
* `propshaft` picks up many more files for precompilation than `sprockets`
* `propshaft` does not produce gzipped/compressed versions of the files
* `propshaft` does not obfuscate `.js` code in production mode

### `propshaft` picks up many more files for precompilation than `sprockets`

There's a considerable difference in the size of the generated directories.

```
du -sh assets_*
 37M    assets_propshaft_development
 37M    assets_propshaft_production
 14M    assets_sprockets_development
 12M    assets_sprockets_production
```

That size difference is because sprockets only precompiles assets that are explicitly requested via `config.assets_paths` but propshaft grabs everything in an `app/assets` directory, both from the application itself and from any gems.

`sprockets` produces 4 directories containing 86 files.
`propshaft` produces 21 directories containing 1787 files

If we need to prevent compiliation of some of these additional files with `propshaft` we can use the `config.assets.excluded_paths` [configuration option](https://guides.rubyonrails.org/asset_pipeline.html#excluding-directories-from-digestion).

See [this gist](https://gist.github.com/jagthedrummer/f38a0c00879fe34c795e0ff3fd152734) for a comparison between [`tree assets_propshaft_production/`](https://gist.github.com/jagthedrummer/f38a0c00879fe34c795e0ff3fd152734#file-propshaft_tree-txt) and [`tree assets_sprockets_production/`](https://gist.github.com/jagthedrummer/f38a0c00879fe34c795e0ff3fd152734#file-sprockets_tree-txt). (Including that info here makes the PR description too long for GitHub validations. 😢)

### `propshaft` does not produce gzipped/compressed versions of the files

Using sprockets the precompiliation process will produce gzipped versions of assets, but propshaft does not.

```
ls assets_sprockets/application*
assets_sprockets/application-56aa2d6ac0411d27a31d2d772b59c17737048554938a85578260ee30cc4e2810.css
assets_sprockets/application-56aa2d6ac0411d27a31d2d772b59c17737048554938a85578260ee30cc4e2810.css.gz
assets_sprockets/application-a181fae3aa80f6a405086698e4f326c831e56bc5e2fdf819e8c744824e7fe567.js
assets_sprockets/application-a181fae3aa80f6a405086698e4f326c831e56bc5e2fdf819e8c744824e7fe567.js.gz
assets_sprockets/application.css-14cf1b41f7b6abfad8bc1ac76212b160d04fe20361c6205ddf2a747fb5fc3cf0.map
assets_sprockets/application.css-14cf1b41f7b6abfad8bc1ac76212b160d04fe20361c6205ddf2a747fb5fc3cf0.map.gz
assets_sprockets/application.js-29150f03941c8fdc7a88d1ed0a863e42b64978b8cdf00f49c2704d7e259febf1.map
assets_sprockets/application.js-29150f03941c8fdc7a88d1ed0a863e42b64978b8cdf00f49c2704d7e259febf1.map.gz
assets_sprockets/application.light-04024382391bb910584145d8113cf35ef376b55d125bb4516cebeb14ce788597.js
assets_sprockets/application.light-04024382391bb910584145d8113cf35ef376b55d125bb4516cebeb14ce788597.js.gz
assets_sprockets/application.light-7f8e2dd7acbcc6e25b2647ecddd41a9e78f11fffac285dd61c34ae40ae4728cb.css
assets_sprockets/application.light-7f8e2dd7acbcc6e25b2647ecddd41a9e78f11fffac285dd61c34ae40ae4728cb.css.gz
assets_sprockets/application.light.js-8126603a99003c29abd335aedc35194359cf35d0798939e63481a47cc7b7c1ad.map
assets_sprockets/application.light.js-8126603a99003c29abd335aedc35194359cf35d0798939e63481a47cc7b7c1ad.map.gz
assets_sprockets/application.mailer.light-bba9838096d4f808809a91d57d903959ace1bcedddd6b495f9bca246cc3fd6be.css
assets_sprockets/application.mailer.light-bba9838096d4f808809a91d57d903959ace1bcedddd6b495f9bca246cc3fd6be.css.gz
```

```
ls assets_propshaft/application*
assets_propshaft/application-3b1dadb9.css.map
assets_propshaft/application-3bbac6f0.js
assets_propshaft/application-cf8df722.css
assets_propshaft/application-fd45fee3.js.map
assets_propshaft/application.light-6d57f58c.css
assets_propshaft/application.light-b0df6176.js.map
assets_propshaft/application.light-d9ebbb44.js
assets_propshaft/application.mailer.light-97f9db98.css
```

Many webservers/CDNs can dynamically compress assets as they're being served, so this may not be an issue. If we (or a downstream app) need to produce gzipped versions we could handle that in a separate post-precompilation step.

```
find public/assets -type f -exec gzip -k {} \;
```

### Precompiled File Content Differences

The output of the generated `.css` files is almost identical, with the only differences being related to fingerprinting and sourcemap locations.

```
$ diff assets_sprockets_production/application-56aa2d6ac0411d27a31d2d772b59c17737048554938a85578260ee30cc4e2810.css assets_propshaft_production/application-cf8df722.css
1c1
<
---
> @charset "UTF-8";
1980c1980
<   background-image: url(/assets/flags-645KQKNA-959070a9f002abd28383322dd455a851d1fd445974edb3f720d54ff79894e28b.png);
---
>   background-image: url("/assets/flags-645KQKNA-939e7450.png");
1987c1987
<     background-image: url(/assets/flags@2x-E4CMA2OR-d00ec77cf49d0c3fbd725dbcdcca661b5db35a02d12f8f4fcf8a3ce6065391bc.png);
---
>     background-image: url("/assets/flags@2x-E4CMA2OR-b5f3734e.png");
3034c3034
<   src: url(/assets/themify-icons-AUCIARCF-f1ba2ff6b8910c974fe48b17a80843b8b19ac6e6ae08d68bd27df2259ce6c658.eot);
---
>   src: url("/assets/themify-icons-AUCIARCF-fcb0a881.eot");
3036,3039c3036,3039
<     url(/assets/themify-icons-AUCIARCF-f1ba2ff6b8910c974fe48b17a80843b8b19ac6e6ae08d68bd27df2259ce6c658.eot?#iefix) format("eot"),
<     url(/assets/themify-icons-LDWN3OQG-efcb3c913adebf3e17d241a55cab2c25f0ff6fbd217d1ae4c29e7c84952a404b.woff) format("woff"),
<     url(/assets/themify-icons-NS22GCUV-67c745cef69ad6303b7cf19bd616a48401e7bb8e1e1d9de050c7d6622c56fcb5.ttf) format("truetype"),
<     url(/assets/themify-icons-KIKGDMUW-65e509ce3dede84abcba9340e383d7188b5fd05d30a7558ad4b7bc2c8d8d1118.svg#themify-icons) format("svg");
---
>     url("/assets/themify-icons-AUCIARCF-fcb0a881.eot?#iefix") format("eot"),
>     url("/assets/themify-icons-LDWN3OQG-10a0179e.woff") format("woff"),
>     url("/assets/themify-icons-NS22GCUV-74860cfe.ttf") format("truetype"),
>     url("/assets/themify-icons-KIKGDMUW-8828ac07.svg#themify-icons") format("svg");
4110c4110
< /*# sourceMappingURL=application.css.map */
---
> /*# sourceMappingURL=/assets/application-3b1dadb9.css.map */
```

For `.js` files, in production mode they are uglified/obfuscated with `sprockets` but not with `propshaft`. But in `development` mode the output is almost identical. The only difference is related to the sourcemap location.

```
$ diff assets_sprockets_development/application-b19fa5cf2669081d1f12e5fa25740a3727183a87095a665dbd9639edb7424553.js assets_propshaft_development/application-3bbac6f0.js
46591,46593c46591
< //# sourceMappingURL=/assets/application.js-29150f03941c8fdc7a88d1ed0a863e42b64978b8cdf00f49c2704d7e259febf1.map
< //!
< ;
---
> //# sourceMappingURL=/assets/application-fd45fee3.js.map
```

There is a decent difference in size of the compiled js file in production mode. This is due to the obfuscation step also removing line breaks and using shorter obfuscated variable names.

```
ls -al assets_sprockets_production/application-a181fae3aa80f6a405086698e4f326c831e56bc5e2fdf819e8c744824e7fe567.js assets_propshaft_production/application-3bbac6f0.js
-rw-r--r--  1 jgreen  staff   3.4M Feb  6 10:43 assets_propshaft_production/application-3bbac6f0.js
-rw-r--r--  1 jgreen  staff   2.5M Feb  6 10:43 assets_sprockets_production/application-a181fae3aa80f6a405086698e4f326c831e56bc5e2fdf819e8c744824e7fe567.js
```

We could potentially use something like `esbuild-plugin-obfuscator` to obfuscate the code during the `esbuild` process. But ideally we'll be able to move away from using `esbuild` at all once we've migrated to `importmaps`, so it may not be worth it to complicate things with that plugin.

After manually gzipping the production assets that `propshaft` produces they're not _that_ much larger than the gzipped version that `sprockets` produces.

```
ls -al assets_sprockets_production/application-a181fae3aa80f6a405086698e4f326c831e56bc5e2fdf819e8c744824e7fe567.js.gz assets_propshaft_production/application-3bbac6f0.js.gz
-rw-r--r--  1 jgreen  staff   814K Feb  6 10:43 assets_propshaft_production/application-3bbac6f0.js.gz
-rw-r--r--  1 jgreen  staff   701K Feb  6 10:43 assets_sprockets_production/application-a181fae3aa80f6a405086698e4f326c831e56bc5e2fdf819e8c744824e7fe567.js.gz
```
