### PR TITLE
Remove `bullet_train-scope_questions` gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -132,7 +132,6 @@ gem "bullet_train-integrations-stripe", BULLET_TRAIN_VERSION
 
 # Optional support packages.
 gem "bullet_train-sortable", BULLET_TRAIN_VERSION
-gem "bullet_train-scope_questions", BULLET_TRAIN_VERSION
 gem "bullet_train-obfuscates_id", BULLET_TRAIN_VERSION
 
 # Core gems that are dependencies of gems listed above. Technically they

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -198,8 +198,6 @@ GEM
       active_hash
       activesupport
       cancancan
-    bullet_train-scope_questions (1.15.0)
-      rails (>= 6.0.0)
     bullet_train-scope_validator (1.15.0)
       rails
     bullet_train-sortable (1.15.0)
@@ -741,7 +739,6 @@ DEPENDENCIES
   bullet_train-obfuscates_id (= 1.15.0)
   bullet_train-outgoing_webhooks (= 1.15.0)
   bullet_train-roles (= 1.15.0)
-  bullet_train-scope_questions (= 1.15.0)
   bullet_train-scope_validator (= 1.15.0)
   bullet_train-sortable (= 1.15.0)
   bullet_train-super_load_and_authorize_resource (= 1.15.0)


### PR DESCRIPTION
This was an empty gem that didn't provide any real code.

Joint PR: https://github.com/bullet-train-co/bullet_train-core/pull/1031