### PR TITLE
Add `derailed_benchmarks` to the `:development` group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -166,6 +166,12 @@ group :development do
 
   # For colorizing text in command line scripts.
   gem "colorize"
+
+  # derailed_benchmarks and stackprof are used to find opportunities for performance/memory improvements
+  # See the derailed_benchmarks docs for details: https://github.com/zombocom/derailed_benchmarks
+  gem 'derailed_benchmarks'
+  # stackprof has some native components and it may be harder to compile locally, so we leave it as optional
+  # gem 'stackprof'
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -169,9 +169,9 @@ group :development do
 
   # derailed_benchmarks and stackprof are used to find opportunities for performance/memory improvements
   # See the derailed_benchmarks docs for details: https://github.com/zombocom/derailed_benchmarks
-  gem 'derailed_benchmarks'
+  gem "derailed_benchmarks"
   # stackprof has some native components and it may be harder to compile locally, so we leave it as optional
-  # gem 'stackprof'
+  # gem "stackprof"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,6 +117,7 @@ GEM
     base64 (0.2.0)
     bcrypt (3.1.20)
     benchmark (0.4.0)
+    benchmark-ips (2.14.0)
     bigdecimal (3.1.9)
     bindex (0.8.1)
     binding_of_caller (1.0.1)
@@ -275,6 +276,24 @@ GEM
       irb (~> 1.10)
       reline (>= 0.3.8)
     debug_inspector (1.2.0)
+    derailed_benchmarks (2.2.1)
+      base64
+      benchmark-ips (~> 2)
+      bigdecimal
+      drb
+      get_process_mem
+      heapy (~> 0)
+      logger
+      memory_profiler (>= 0, < 2)
+      mini_histogram (>= 0.3.0)
+      mutex_m
+      ostruct
+      rack (>= 1)
+      rack-test
+      rake (> 10, < 14)
+      ruby-statistics (>= 4.0.1)
+      ruby2_keywords
+      thor (>= 0.19, < 2)
     devise (4.9.4)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -319,10 +338,15 @@ GEM
     figaro (1.2.0)
       thor (>= 0.14.0, < 2)
     foreman (0.88.1)
+    get_process_mem (1.0.0)
+      bigdecimal (>= 2.0)
+      ffi (~> 1.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
     hashids (1.0.6)
     hashie (5.0.0)
+    heapy (0.2.0)
+      thor
     hiredis (0.6.3)
     honeybadger (5.26.3)
       logger
@@ -386,12 +410,14 @@ GEM
       activesupport
       prism (>= 0.14.0)
     matrix (0.4.2)
+    memory_profiler (1.1.0)
     meta-tags (2.22.1)
       actionpack (>= 6.0.0, < 8.1)
     method_source (1.1.0)
     microscope (1.1.1)
       activerecord (>= 4.1.0)
       activesupport (>= 4.1.0)
+    mini_histogram (0.3.1)
     mini_magick (5.1.2)
       benchmark
       logger
@@ -408,6 +434,7 @@ GEM
     multi_xml (0.7.1)
       bigdecimal (~> 3.1)
     multipart-post (2.4.1)
+    mutex_m (0.3.0)
     net-http (0.6.0)
       uri
     net-imap (0.5.6)
@@ -599,6 +626,7 @@ GEM
       faraday (>= 1)
       faraday-multipart (>= 1)
     ruby-progressbar (1.13.0)
+    ruby-statistics (4.1.0)
     ruby-vips (2.2.3)
       ffi (~> 1.12)
       logger
@@ -744,6 +772,7 @@ DEPENDENCIES
   colorize
   cssbundling-rails
   debug
+  derailed_benchmarks
   devise
   devise-two-factor
   factory_bot_rails (~> 6.2, != 6.4.2, != 6.4.1, != 6.4.0, != 6.3.0)


### PR DESCRIPTION
`derailed_benchmarks` is useful for figuring out which gems require the most memory and for finding memory leaks.

See the derailed_benchmarks docs for details: https://github.com/zombocom/derailed_benchmarks