### PR TITLE
Add `microscope` as an optional gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -214,6 +214,12 @@ gem "active_hash"
 # A great debugger.
 gem "pry"
 
+# OPTIONAL BULLET TRAIN GEMS
+# This section lists Ruby gems that we used to include by default. In an effort to
+# reduce memory use we're not including these as hard dependencies anymore, but if
+# you want to use them you can uncoment them.
+# gem "microscope"
+
 # YOUR GEMS
 # You can add any Ruby gems you need below. By keeping them separate from our gems above, you'll avoid the likelihood
 # that you run into a merge conflict in the future.


### PR DESCRIPTION
We used to list `microscope` in the `.gemspec` for the `bullet_train` gem, which forced it to be present in _all_ Bullet Train apps. To try to reduce memory use we're now including it as a "recommended bu optional" gem that people can opt-in to using.

Joint PR: https://github.com/bullet-train-co/bullet_train-core/pull/1035