### PR TITLE
Add `ruby-openai` as an optional gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -224,7 +224,15 @@ gem "pry"
 # This section lists Ruby gems that we used to include by default. In an effort to
 # reduce memory use we're not including these as hard dependencies anymore, but if
 # you want to use them you can uncoment them.
+
+# Microscope adds useful scopes targeting ActiveRecord `boolean`, `date` and `datetime` attributes.
+# https://github.com/mirego/microscope
 # gem "microscope"
+
+# The bullet_train-action_models gem can use OpenAI during the CSV import process to
+# automatically match column names to database attributes.
+# https://github.com/sferik/openai-ruby
+# gem "ruby-openai"
 
 # YOUR GEMS
 # You can add any Ruby gems you need below. By keeping them separate from our gems above, you'll avoid the likelihood


### PR DESCRIPTION
We used to include `ruby-openai` as a dependency in the `.gemspec` of the main `bullet_train` gem. But we don't actually use it in any of the `core` gems or in the starter repo directly. The only place that we use it is in the `bullet_train-action_models` gem, and even there it's an optional dependency.

If you want to continue to use it you can uncomment the `ruby-openai` line in the `Gemfile`.

Joint PR: https://github.com/bullet-train-co/bullet_train-core/pull/1037