### PR TITLE
Add `awesome_print` as an optional gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -234,6 +234,10 @@ gem "pry"
 # https://github.com/sferik/openai-ruby
 # gem "ruby-openai"
 
+# awesome_print allows us to `ap` our objects for a clean presentation of them.
+# https://github.com/awesome-print/awesome_print
+# gem "awesome_print"
+
 # YOUR GEMS
 # You can add any Ruby gems you need below. By keeping them separate from our gems above, you'll avoid the likelihood
 # that you run into a merge conflict in the future.

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -26,6 +26,7 @@ if ENV["KNAPSACK_PRO_CI_NODE_INDEX"].present?
   knapsack_pro_adapter = KnapsackPro::Adapters::MinitestAdapter.bind
   knapsack_pro_adapter.set_test_helper_path(__FILE__)
 else
+  require "colorize"
   puts "Not requiring Knapsack Pro.".yellow
   puts "If you'd like to use Knapsack Pro make sure that you've set the environment variable KNAPSACK_PRO_CI_NODE_INDEX".yellow
 end


### PR DESCRIPTION
We used to list `awesome_print` as a hard dependency in the main `bullet_train` gem. In an effort to reduce memory use in a new BT app we're now adding it as an optional dependency that developers can opt-in to using if they want to.

Joint PR: https://github.com/bullet-train-co/bullet_train-core/pull/1042