### PR TITLE
Move `pry` into the `:development, :test` gem group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -193,6 +193,11 @@ group :test do
   gem "knapsack_pro"
 end
 
+group :development, :test do
+  # A great debugger.
+  gem "pry"
+end
+
 group :production do
   # We suggest using Postmark for email deliverability.
   gem "postmark-rails"
@@ -216,9 +221,6 @@ end
 
 # Use Ruby hashes as readonly datasources for ActiveRecord-like models.
 gem "active_hash"
-
-# A great debugger.
-gem "pry"
 
 # OPTIONAL BULLET TRAIN GEMS
 # This section lists Ruby gems that we used to include by default. In an effort to


### PR DESCRIPTION
Previously we had `pry` in all groups, which meant that we were shipping it to production, but really you shouldn't need a debugger in production unless you really know what you're doing. Moving it to the `:development, :test` group makes it available in the places that you're most likely to need it while slimming down the production footprint.

If you need to use it in production for your app you can move it out of the `:development, :test` group in your `Gemfile`.