### PR TITLE
Make a bunch of production gems optional

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -200,22 +200,23 @@ end
 
 group :production do
   # We suggest using Postmark for email deliverability.
-  gem "postmark-rails"
+  # gem "postmark-rails"
 
   # If you're hosting on Heroku, this service is highly recommended for autoscaling of dynos.
-  gem "rails_autoscale_agent"
+  # gem "rails_autoscale_agent"
 
   # Exception tracking, uptime monitoring, and status page service with a generous free tier.
-  gem "honeybadger"
+  # gem "honeybadger"
 
   # Another exception tracking service.
-  gem "sentry-ruby"
-  gem "sentry-rails"
-  gem "sentry-sidekiq"
+  # gem "sentry-ruby"
+  # gem "sentry-rails"
+  # gem "sentry-sidekiq"
 
   # Use S3 for Active Storage by default.
-  gem "aws-sdk-s3", require: false
+  # gem "aws-sdk-s3", require: false
 
+  # terser is used to compress assets during precompilation
   gem "terser"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,23 +97,6 @@ GEM
       view_component (>= 3.7.0)
       zeitwerk (>= 2.6.12)
     awesome_print (1.9.2)
-    aws-eventstream (1.3.0)
-    aws-partitions (1.1050.0)
-    aws-sdk-core (3.218.1)
-      aws-eventstream (~> 1, >= 1.3.0)
-      aws-partitions (~> 1, >= 1.992.0)
-      aws-sigv4 (~> 1.9)
-      base64
-      jmespath (~> 1, >= 1.6.1)
-    aws-sdk-kms (1.98.0)
-      aws-sdk-core (~> 3, >= 3.216.0)
-      aws-sigv4 (~> 1.5)
-    aws-sdk-s3 (1.180.0)
-      aws-sdk-core (~> 3, >= 3.216.0)
-      aws-sdk-kms (~> 1)
-      aws-sigv4 (~> 1.5)
-    aws-sigv4 (1.11.0)
-      aws-eventstream (~> 1, >= 1.0.2)
     base64 (0.2.0)
     bcrypt (3.1.20)
     benchmark (0.4.0)
@@ -348,9 +331,6 @@ GEM
     heapy (0.2.0)
       thor
     hiredis (0.6.3)
-    honeybadger (5.26.3)
-      logger
-      ostruct
     htmlentities (4.3.4)
     http_accept_language (2.1.1)
     i18n (1.14.7)
@@ -375,7 +355,6 @@ GEM
       jbuilder
       method_source
       rails (>= 5.0.0)
-    jmespath (1.6.2)
     jsbundling-rails (1.3.1)
       railties (>= 6.0.0)
     json (2.10.1)
@@ -491,11 +470,6 @@ GEM
     pg (1.5.9)
     phonelib (0.10.4)
     possessive (1.0.1)
-    postmark (1.25.1)
-      json
-    postmark-rails (0.22.1)
-      actionmailer (>= 3.0.0)
-      postmark (>= 1.21.3, < 2.0)
     pp (0.6.2)
       prettyprint
     premailer (1.27.0)
@@ -566,7 +540,6 @@ GEM
     rails-html-sanitizer (1.6.2)
       loofah (~> 2.21)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
-    rails_autoscale_agent (0.12.0)
     rails_best_practices (1.23.2)
       activesupport
       code_analyzer (~> 0.5.5)
@@ -639,15 +612,6 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
-    sentry-rails (5.22.4)
-      railties (>= 5.0)
-      sentry-ruby (~> 5.22.4)
-    sentry-ruby (5.22.4)
-      bigdecimal
-      concurrent-ruby (~> 1.0, >= 1.0.2)
-    sentry-sidekiq (5.22.4)
-      sentry-ruby (~> 5.22.4)
-      sidekiq (>= 3.0)
     sexp_processor (4.17.3)
     showcase-rails (0.4.6)
       rails (>= 6.1.0)
@@ -746,7 +710,6 @@ PLATFORMS
 DEPENDENCIES
   active_hash
   avo (>= 3.1.7)
-  aws-sdk-s3
   bootsnap
   bullet_train (= 1.16.0)
   bullet_train-api (= 1.16.0)
@@ -777,7 +740,6 @@ DEPENDENCIES
   devise-two-factor
   factory_bot_rails (~> 6.2, != 6.4.2, != 6.4.1, != 6.4.0, != 6.3.0)
   foreman
-  honeybadger
   jbuilder
   jsbundling-rails
   knapsack_pro
@@ -787,21 +749,16 @@ DEPENDENCIES
   minitest-retry
   parallel_tests
   pg (>= 0.18, < 2.0)
-  postmark-rails
   pry
   puma (~> 6.0)
   rack-mini-profiler
   rails (~> 8.0.0)
   rails-erd
-  rails_autoscale_agent
   rails_best_practices
   redis (~> 5.3.0)
   rqrcode
   ruby-vips
   selenium-webdriver
-  sentry-rails
-  sentry-ruby
-  sentry-sidekiq
   simplecov
   simplecov-json
   sprockets-rails

--- a/lib/tasks/aws.rake
+++ b/lib/tasks/aws.rake
@@ -1,8 +1,15 @@
-require "aws-sdk-s3"
-
 namespace :aws do
   desc "Set default CORS permissions on your S3 bucket"
   task set_cors: :environment do
+    begin
+      require "aws-sdk-s3"
+    rescue LoadError
+      require "colorize"
+      puts "We were unable to require the `aws-sdk-s3` gem.".yellow
+      puts "If you want to use S3 you should uncomment the line in the `Gemfile` for `aws-sdk-s3`.".yellow
+      abort "Aborting this task because we were unable to require `aws-sdk-s3`.".red
+    end
+
     # Fetch the settings defined in `config/storage.yml`.
     Rails.application.eager_load!
     s3_config = Rails.configuration.active_storage.service_configurations.with_indifferent_access[:amazon]


### PR DESCRIPTION
We used to include several gems in the `:production` group of the `Gemfile` that may not be used in downstream apps. This PR comments them out in the `Gemfile` with the idea that people who need to use them can uncomment them to opt-in. This will make the default deployment image smaller than it was previously.

The new `:production` block of gems looks like this:

```ruby
group :production do
  # We suggest using Postmark for email deliverability.
  # gem "postmark-rails"

  # If you're hosting on Heroku, this service is highly recommended for autoscaling of dynos.
  # gem "rails_autoscale_agent"

  # Exception tracking, uptime monitoring, and status page service with a generous free tier.
  # gem "honeybadger"

  # Another exception tracking service.
  # gem "sentry-ruby"
  # gem "sentry-rails"
  # gem "sentry-sidekiq"

  # Use S3 for Active Storage by default.
  # gem "aws-sdk-s3", require: false

  # terser is used to compress assets during precompilation
  gem "terser"
end
```

You should evaluate whether you are using any of the gems that are commented out, and if so, you should un-comment them in your `Gemfile`.