### PR TITLE
Don't `require "pry"` in `config/application.rb`

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -1,7 +1,6 @@
 require_relative "boot"
 
 require "rails/all"
-require "pry"
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.


### PR DESCRIPTION
For some reason we were explicitly requiring `pry` in `config/application.rb`. Doing so isn't necessary because it will automatically be required in the approriate environments because of it being in the `Gemfile`. This PR removes the uneccessary line.