### PR TITLE
fix: avo `time_zone` options

### DIFF
--- a/app/avo/resources/team.rb
+++ b/app/avo/resources/team.rb
@@ -15,7 +15,9 @@ class Avo::Resources::Team < Avo::BaseResource
     field :name, as: :text
     field :slug, as: :text
     field :being_destroyed, as: :boolean, hide_on: :forms
-    field :time_zone, as: :select, options: -> { view_context.time_zone_options_for_select(Avo::Current.user.time_zone, nil, ActiveSupport::TimeZone) }
+    field :time_zone, as: :select, options: -> {
+      ActiveSupport::TimeZone.all.map { |tz| ["(GMT#{tz.formatted_offset}) #{tz.name}", tz.name] }.to_h 
+    }
     field :locale, as: :text
     field :users, as: :has_many, through: :memberships
     field :memberships, as: :has_many

--- a/app/avo/resources/user.rb
+++ b/app/avo/resources/user.rb
@@ -15,7 +15,9 @@ class Avo::Resources::User < Avo::BaseResource
     field :email, as: :text
     field :first_name, as: :text
     field :last_name, as: :text
-    field :time_zone, as: :select, options: -> { view_context.time_zone_options_for_select(Avo::Current.user.time_zone, nil, ActiveSupport::TimeZone) }
+    field :time_zone, as: :select, options: -> { 
+      ActiveSupport::TimeZone.all.map { |tz| ["(GMT#{tz.formatted_offset}) #{tz.name}", tz.name] }.to_h
+    }
     field :current_team, as: :belongs_to
 
     field :teams, as: :has_many, through: :teams


### PR DESCRIPTION
Fixes #1371

This PR fixes the `time_zone` select field options on Avo resources.

Previously, the code:

```ruby
view_context.time_zone_options_for_select(Avo::Current.user.time_zone, nil, ActiveSupport::TimeZone)
```

was generating a `ActiveSupport::SafeBuffer`, which is not compatible with the select field `options` that expects a hash.