### PR TITLE
Hoist `sidekiq` into the `Gemfile` of the starter repo

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -151,6 +151,9 @@ gem "rqrcode"
 # Admin panel
 gem "avo", ">= 3.1.7"
 
+# Background processing
+gem "sidekiq"
+
 group :development do
   # Open any sent emails in your browser instead of having to setup an SMTP trap.
   gem "letter_opener"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -740,6 +740,7 @@ DEPENDENCIES
   rqrcode
   ruby-vips
   selenium-webdriver
+  sidekiq
   simplecov
   simplecov-json
   sprockets-rails


### PR DESCRIPTION
Previously we had listed `sidekiq` as a hard dependency of the `core` gems. This (and the joint PR) make it so that we list `sidekiq` directly in the `Gemfile` of the starter repo instead of as a gem dependency of the `core` gems. That will allow people to remove sidekiq if they want to use something else for background processing.

Joint PR: https://github.com/bullet-train-co/bullet_train-core/pull/1059