### PR TITLE
Hoist `rack-cors` into the `Gemfile` of the starter repo

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -154,6 +154,9 @@ gem "avo", ">= 3.1.7"
 # Background processing
 gem "sidekiq"
 
+# Protect the API routes via CORS
+gem "rack-cors"
+
 group :development do
   # Open any sent emails in your browser instead of having to setup an SMTP trap.
   gem "letter_opener"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -732,6 +732,7 @@ DEPENDENCIES
   pg (>= 0.18, < 2.0)
   pry
   puma (~> 6.0)
+  rack-cors
   rack-mini-profiler
   rails (~> 8.0.0)
   rails-erd


### PR DESCRIPTION
Previously we listed `rack-cors` as a hard dependency in the `core` gems, which meant that application developers were forced to include the gem even if they're not using the api. This makes it possible to remove `rack-cors` from the application completely.