### PR TITLE
Hoist `premailer-rails` into the `Gemfile` in the starter repo

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -157,6 +157,9 @@ gem "sidekiq"
 # Protect the API routes via CORS
 gem "rack-cors"
 
+# Easy and automatic inline CSS for mailers
+gem "premailer-rails"
+
 group :development do
   # Open any sent emails in your browser instead of having to setup an SMTP trap.
   gem "letter_opener"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -730,6 +730,7 @@ DEPENDENCIES
   minitest-retry
   parallel_tests
   pg (>= 0.18, < 2.0)
+  premailer-rails
   pry
   puma (~> 6.0)
   rack-cors


### PR DESCRIPTION
Previously we listed `premailer-rails` as a hard dependency in the core gems, which meant that application developers were forced to include the gem even if they don't want to. This makes it possible to remove `premailer-rails` from the application completely.