### PR TITLE
Fix openai documentation url

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -243,7 +243,7 @@ gem "active_hash"
 
 # The bullet_train-action_models gem can use OpenAI during the CSV import process to
 # automatically match column names to database attributes.
-# https://github.com/sferik/openai-ruby
+# https://github.com/alexrudall/ruby-openai
 # gem "ruby-openai"
 
 # awesome_print allows us to `ap` our objects for a clean presentation of them.


### PR DESCRIPTION
We were pointing to the wrong gem documentation page (openai-ruby vs ruby-openai). Took me a minute to realize it wasn't correct.