### PR TITLE
Add `arm64-darwin-24` to `Gemfile.lock`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -673,6 +673,7 @@ PLATFORMS
   arm64-darwin-21
   arm64-darwin-22
   arm64-darwin-23
+  arm64-darwin-24
   x86_64-darwin-21
   x86_64-linux
 


### PR DESCRIPTION
After pulling down the latest starter repo and running `bundle install` this line was automatically added to `Gemfile.lock`. I think this has to do with the latest updates to MacOS.