### PR TITLE
Set Avo default_url_options

### DIFF
--- a/config/initializers/avo.rb
+++ b/config/initializers/avo.rb
@@ -106,4 +106,6 @@ Avo.configure do |config|
   # config.profile_menu = -> {
   #   link "Profile", path: "/avo/profile", icon: "user-circle"
   # }
+  config.default_url_options = Rails.application.routes.default_url_options
+  Avo::Engine.routes.default_url_options = Rails.application.routes.default_url_options
 end


### PR DESCRIPTION
Fixes host exceptions when attempting to use avo paths directly as well as via the engine calls. this tries to use the bullettrain concepts of the default option population handled in [development](https://github.com/bullet-train-co/bullet_train/blob/main/config/environments/development.rb#L84) & [production.rb](https://github.com/bullet-train-co/bullet_train/blob/main/config/environments/production.rb#L117) env initializers.

before:
`Avo::Engine.routes.url_helpers.resources_user_url(Team.first)` -> `Missing host to link to! Please provide the :host parameter, set default_url_options[:host], or set :only_path to true (ArgumentError)`

after: `"http://mylocalhost:3000/admin/avo/resources/teams/bJYLew"`
