### PR TITLE
Allow local overrides of Bullet Train's Stimulus controllers

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -21,17 +21,30 @@ window.Stimulus = application
 // Controller files must be named *_controller.js.
 import { context as controllersContext } from './**/*_controller.js';
 
-application.load(bulletTrainControllers)
-application.load(bulletTrainFieldControllers)
-application.load(bulletTrainSortableControllers)
-
 application.register('reveal', RevealController)
 application.register('scroll-reveal', ScrollReveal)
 
-const controllers = Object.keys(controllersContext).map((filename) => ({
+let controllers = Object.keys(controllersContext).map((filename) => ({
   identifier: identifierForContextKey(filename),
   controllerConstructor: controllersContext[filename] }))
+
+controllers = overrideByIdentifier([
+  ...bulletTrainControllers,
+  ...bulletTrainFieldControllers,
+  ...bulletTrainSortableControllers,
+  ...controllers,
+])
 
 application.load(controllers)
 
 CableReady.initialize({ consumer })
+
+function overrideByIdentifier(controllers) {
+  const byIdentifier = {}
+
+  controllers.forEach(item => {
+    byIdentifier[item.identifier] = item
+  })
+
+  return Object.values(byIdentifier)
+}


### PR DESCRIPTION
Updates the way `controllers/index.js` loads local controllers, allowing them to take precedence over controllers of the same name from Bullet Train's packages.

To reproduce:

* Create a new project using this branch
* Create a local `controllers/fields/super_select_controller.js` empty file
* Add the following to that new file, which will inject a `console.log` in the `connect()`

```js
import { SuperSelectController } from '@bullet-train/fields'

export default class extends SuperSelectController {
  connect() {
    console.log('super_select_controller connected')
    super.connect()
  }
}
```