### PR TITLE
Replace deprecated tag `apple-mobile-web-app-capable` with `mobile-web-app-capable`

### DIFF
--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -12,7 +12,7 @@
 <meta content="<%= t('application.description') %>" name="description" />
 <meta content="width=device-width, initial-scale=1" name="viewport" />
 
-<meta name="apple-mobile-web-app-capable" content="yes" />
+<meta name="mobile-web-app-capable" content="yes" />
 
 <%= csrf_meta_tags %>
 


### PR DESCRIPTION
With new tag `mobile-web-app-capable`

<img width="470" alt="Screenshot 2025-03-27 at 23 48 24" src="https://github.com/user-attachments/assets/d96e6feb-2181-4fa6-9f14-6d3edb937a40" />


Example https://github.com/vercel/next.js/issues/70272