### PR TITLE
Avoid clobbering our Stimulus manifest file when generating a new controller

### DIFF
--- a/lib/tasks/stimulus_manifest_update_override.rake
+++ b/lib/tasks/stimulus_manifest_update_override.rake
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-#
+
 # We clear and override the stimulus:manifest:update task to avoid having it clobber
 # our custom and non-standard stimulus manifest file.
 # For details about why, see this issue:

--- a/lib/tasks/stimulus_manifest_update_override.rake
+++ b/lib/tasks/stimulus_manifest_update_override.rake
@@ -5,7 +5,7 @@
 # For details about why, see this issue:
 # https://github.com/bullet-train-co/bullet_train/issues/2011
 
-override_default_stimulus_manifest_update_task = true
+override_default_stimulus_manifest_update_task = ARGV[1] != "--clobber"
 
 if override_default_stimulus_manifest_update_task
   Rake::Task["stimulus:manifest:update"].clear
@@ -15,7 +15,8 @@ if override_default_stimulus_manifest_update_task
         require "colorize"
         puts "-----------------------------------------------------------------------------------".yellow
         puts "We are skipping the stimulus:manifest:update task to avoid clobbering our manifest.".yellow
-        puts "If you need to run this task see lib/tasks/stimulus_manifest_update_override.rake".yellow
+        puts "If you need to run this task pass it the `--clobber` option like this:".yellow
+        puts "    bin/rails stimulus:manifest:update -- --clobber".yellow
         puts "-----------------------------------------------------------------------------------".yellow
       end
     end

--- a/lib/tasks/stimulus_manifest_update_override.rake
+++ b/lib/tasks/stimulus_manifest_update_override.rake
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+#
+# We clear and override the stimulus:manifest:update task to avoid having it clobber
+# our custom and non-standard stimulus manifest file.
+# For details about why, see this issue:
+# https://github.com/bullet-train-co/bullet_train/issues/2011
+
+override_default_stimulus_manifest_update_task = true
+
+if override_default_stimulus_manifest_update_task
+  Rake::Task["stimulus:manifest:update"].clear
+  namespace :stimulus do
+    namespace :manifest do
+      task :update do
+        require "colorize"
+        puts "-----------------------------------------------------------------------------------".yellow
+        puts "We are skipping the stimulus:manifest:update task to avoid clobbering our manifest.".yellow
+        puts "If you need to run this task see lib/tasks/stimulus_manifest_update_override.rake".yellow
+        puts "-----------------------------------------------------------------------------------".yellow
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes https://github.com/bullet-train-co/bullet_train/issues/2011

With this task override active you'll see this when generating a new stimulus controller:

```
$ rails g stimulus MyNewController
      create  app/javascript/controllers/my_new_controller.js
       rails  stimulus:manifest:update
-----------------------------------------------------------------------------------
We are skipping the stimulus:manifest:update task to avoid clobbering our manifest.
If you need to run this task pass it the `--clobber` option like this:
    bin/rails stimulus:manifest:update -- --clobber
-----------------------------------------------------------------------------------
```

If you do `bin/rails stimulus:manifest:update -- --clobber` then we avoid overriding the task, and we run the original task, which will clobber the file we're trying to protect.