### PR TITLE
Remove rails-ujs

### DIFF
--- a/.github/workflows/_run_super_scaffolding_tests.yml
+++ b/.github/workflows/_run_super_scaffolding_tests.yml
@@ -171,5 +171,5 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: error_screenshots_${{ matrix.parallel_test_groups }}.log
+          name: error_screenshots_${{ matrix.parallel_test_groups }}.zip
           path: tmp/starter/tmp/screenshots/*.png

--- a/.github/workflows/_run_super_scaffolding_tests.yml
+++ b/.github/workflows/_run_super_scaffolding_tests.yml
@@ -166,3 +166,10 @@ jobs:
           name: test_coverage_${{ strategy.job-index }}_${{ inputs.use-core-repo }}.log
           path: tmp/starter/coverage/.resultset.json
           include-hidden-files: true
+
+      - name: Upload Error Screenshots
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: error_screenshots_${{ matrix.parallel_test_groups }}.log
+          path: tmp/starter/tmp/screenshots/*.png

--- a/.github/workflows/_run_super_scaffolding_tests.yml
+++ b/.github/workflows/_run_super_scaffolding_tests.yml
@@ -171,5 +171,5 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: error_screenshots_${{ matrix.parallel_test_groups }}.zip
+          name: error_screenshots_${{ strategy.job-index }}.zip
           path: tmp/starter/tmp/screenshots/*.png

--- a/.github/workflows/_run_tests.yml
+++ b/.github/workflows/_run_tests.yml
@@ -200,3 +200,10 @@ jobs:
         with:
           name: test_summary_${{ matrix.parallel_test_groups }}.log
           path: tmp/starter/test/reports*/**/TEST-*.xml
+
+      - name: Upload Error Screenshots
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: error_screenshots_${{ matrix.parallel_test_groups }}.log
+          path: tmp/starter/tmp/screenshots/*.png

--- a/.github/workflows/_run_tests.yml
+++ b/.github/workflows/_run_tests.yml
@@ -205,5 +205,5 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: error_screenshots_${{ matrix.parallel_test_groups }}.log
+          name: error_screenshots_${{ matrix.parallel_test_groups }}.zip
           path: tmp/starter/tmp/screenshots/*.png

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -586,7 +586,7 @@ GEM
     ruby2_keywords (0.0.5)
     rubyzip (2.4.1)
     securerandom (0.4.1)
-    selenium-webdriver (4.32.0)
+    selenium-webdriver (4.33.0)
       base64 (~> 0.2)
       logger (~> 1.4)
       rexml (~> 3.2, >= 3.2.5)

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -3,13 +3,11 @@
 // includes should be specified at the end of the file, not in this section. This helps avoid merge conflicts in the
 // future should the framework defaults change.
 
-import Rails from "@rails/ujs"
 import * as ActiveStorage from "@rails/activestorage"
 import "@hotwired/turbo-rails"
 import "./controllers"
 import "./channels"
 
-Rails.start()
 ActiveStorage.start()
 
 // 🚫 DEFAULT BULLET TRAIN INCLUDES

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "@rails/actiontext": "^8.0.200",
     "@rails/activestorage": "^8.0.100",
     "@rails/request.js": "^0.0.12",
-    "@rails/ujs": "^7.1.501",
     "@redocly/cli": "^1.0.0-beta.111",
     "@tailwindcss/forms": "^0.5.10",
     "@tailwindcss/typography": "^0.5.16",

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -3,7 +3,7 @@ require "capybara/email"
 require "support/waiting"
 require "minitest/retry"
 
-Minitest::Retry.use!(retry_count: 3, verbose: true, exceptions_to_retry: [Net::ReadTimeout])
+Minitest::Retry.use!(retry_count: 3, verbose: true, exceptions_to_retry: [Net::ReadTimeout, Capybara::ModalNotFound])
 OmniAuth.config.test_mode = true
 
 # Configure Capybara with either cuprite or selenium based on what gems are installed

--- a/test/system/invitations_test.rb
+++ b/test/system/invitations_test.rb
@@ -138,6 +138,7 @@ class InvitationDetailsTest < ApplicationSystemTestCase
         end
       end
 
+      assert_text("Re-Invite to Team")
       accept_alert { click_on "Re-Invite to Team" }
       assert_text("The user has been successfully re-invited. They will receive an email to rejoin the team.")
     end

--- a/test/system/super_scaffolding/project/project_test.rb
+++ b/test/system/super_scaffolding/project/project_test.rb
@@ -46,7 +46,7 @@ class BulletTrain::SuperScaffolding::ProjectTest < ApplicationSystemTestCase
       assert_text("Your Team’s Projects")
 
       # this is ensuring cascading deletes generate properly.
-      accept_alert do
+      accept_confirm do
         click_on "Delete"
       end
 

--- a/test/system/super_scaffolding/project/project_test.rb
+++ b/test/system/super_scaffolding/project/project_test.rb
@@ -45,8 +45,6 @@ class BulletTrain::SuperScaffolding::ProjectTest < ApplicationSystemTestCase
 
       assert_text("Your Team’s Projects")
 
-      # will this help?
-      sleep 1
       # this is ensuring cascading deletes generate properly.
       accept_confirm do
         click_on "Delete"

--- a/test/system/super_scaffolding/project/project_test.rb
+++ b/test/system/super_scaffolding/project/project_test.rb
@@ -48,9 +48,9 @@ class BulletTrain::SuperScaffolding::ProjectTest < ApplicationSystemTestCase
       # will this help?
       sleep 1
       # this is ensuring cascading deletes generate properly.
-      #accept_confirm do
+      accept_confirm do
         click_on "Delete"
-      #end
+      end
 
       assert_text("Project was successfully destroyed.")
 

--- a/test/system/super_scaffolding/project/project_test.rb
+++ b/test/system/super_scaffolding/project/project_test.rb
@@ -48,9 +48,9 @@ class BulletTrain::SuperScaffolding::ProjectTest < ApplicationSystemTestCase
       # will this help?
       sleep 1
       # this is ensuring cascading deletes generate properly.
-      accept_confirm do
+      #accept_confirm do
         click_on "Delete"
-      end
+      #end
 
       assert_text("Project was successfully destroyed.")
 

--- a/test/system/super_scaffolding/project/project_test.rb
+++ b/test/system/super_scaffolding/project/project_test.rb
@@ -45,6 +45,8 @@ class BulletTrain::SuperScaffolding::ProjectTest < ApplicationSystemTestCase
 
       assert_text("Your Team’s Projects")
 
+      # will this help?
+      sleep 1
       # this is ensuring cascading deletes generate properly.
       accept_confirm do
         click_on "Delete"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2254,13 +2254,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rails/ujs@npm:^7.1.501":
-  version: 7.1.501
-  resolution: "@rails/ujs@npm:7.1.501"
-  checksum: 10c0/b75a30f36ff219264e0926da1ffcd14c2a5d6aee5be29da4dc81f9a45843875da79ac19cf7ed9a3f11a39084398d0ae4a75a8edb28ba94907db3081572af62b0
-  languageName: node
-  linkType: hard
-
 "@redocly/ajv@npm:8.11.2, @redocly/ajv@npm:^8.11.2":
   version: 8.11.2
   resolution: "@redocly/ajv@npm:8.11.2"
@@ -2536,7 +2529,6 @@ __metadata:
     "@rails/actiontext": "npm:^8.0.200"
     "@rails/activestorage": "npm:^8.0.100"
     "@rails/request.js": "npm:^0.0.12"
-    "@rails/ujs": "npm:^7.1.501"
     "@redocly/cli": "npm:^1.0.0-beta.111"
     "@tailwindcss/forms": "npm:^0.5.10"
     "@tailwindcss/typography": "npm:^0.5.16"


### PR DESCRIPTION
Joint PR: https://github.com/bullet-train-co/bullet_train-core/pull/1134

**NOTE** The failing tests here are expected. They're the ones that are testing against the currently published gems. Those gems depend on `rails-ujs` so they fail when it's not there. All of the tests against `core` are passing because it's running on the `jeremy/turbo-delete` branch which uses turbo instead of rails-ujs.