### PR TITLE
Updates for `pagy` 9

### DIFF
--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -4,7 +4,6 @@
 # Customize only what you really need and notice that the core Pagy works also without any of the following lines.
 # Should you just cherry pick part of this file, please maintain the require-order of the extras
 
-
 # Pagy Variables
 # See https://ddnexus.github.io/pagy/docs/api/pagy#variables
 # You can set any pagy variable as a Pagy::DEFAULT. They can also be overridden per instance by just passing them to
@@ -17,17 +16,14 @@
 # Pagy::DEFAULT[:count_args]  = []                    # example for non AR ORMs
 # Pagy::DEFAULT[:max_pages]   = 3000                  # example
 
-
 # Extras
 # See https://ddnexus.github.io/pagy/categories/extra
-
 
 # Legacy Compatibility Extras
 
 # Size extra: Enable the Array type for the `:size` variable (e.g. `size: [1,4,4,1]`)
 # See https://ddnexus.github.io/pagy/docs/extras/size
 # require 'pagy/extras/size'   # must be required before the other extras
-
 
 # Backend Extras
 
@@ -111,7 +107,6 @@
 # uncomment if you are going to use Searchkick.pagy_search
 # Searchkick.extend Pagy::Searchkick
 
-
 # Frontend Extras
 
 # Bootstrap extra: Add nav, nav_js and combo_nav_js helpers and templates for Bootstrap pagination
@@ -130,7 +125,6 @@
 # Multi size var used by the *_nav_js helpers
 # See https://ddnexus.github.io/pagy/docs/extras/pagy#steps
 # Pagy::DEFAULT[:steps] = { 0 => 5, 540 => 7, 720 => 9 }   # example
-
 
 # Feature Extras
 
@@ -209,12 +203,10 @@
 #                   filepath: 'path/to/pagy-xyz.yml',
 #                   pluralize: lambda{ |count| ... } )
 
-
 # I18n extra: uses the standard i18n gem which is ~18x slower using ~10x more memory
 # than the default pagy internal i18n (see above)
 # See https://ddnexus.github.io/pagy/docs/extras/i18n
 # require 'pagy/extras/i18n'
-
 
 # When you are done setting your own default freeze it, so it will not get changed accidentally
 Pagy::DEFAULT.freeze

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -1,58 +1,53 @@
 # frozen_string_literal: true
 
-# Pagy initializer file (5.10.1)
+# Pagy initializer file (9.3.3)
 # Customize only what you really need and notice that the core Pagy works also without any of the following lines.
 # Should you just cherry pick part of this file, please maintain the require-order of the extras
 
-# Pagy DEFAULT Variables
-# See https://ddnexus.github.io/pagy/api/pagy#variables
-# All the Pagy::DEFAULT are set for all the Pagy instances but can be overridden per instance by just passing them to
+
+# Pagy Variables
+# See https://ddnexus.github.io/pagy/docs/api/pagy#variables
+# You can set any pagy variable as a Pagy::DEFAULT. They can also be overridden per instance by just passing them to
 # Pagy.new|Pagy::Countless.new|Pagy::Calendar::*.new or any of the #pagy* controller methods
+# Here are the few that make more sense as DEFAULTs:
+# Pagy::DEFAULT[:limit]       = 20                    # default
+# Pagy::DEFAULT[:size]        = 7                     # default
+# Pagy::DEFAULT[:ends]        = true                  # default
+# Pagy::DEFAULT[:page_param]  = :page                 # default
+# Pagy::DEFAULT[:count_args]  = []                    # example for non AR ORMs
+# Pagy::DEFAULT[:max_pages]   = 3000                  # example
 
-# Instance variables
-# See https://ddnexus.github.io/pagy/api/pagy#instance-variables
-# Pagy::DEFAULT[:page]   = 1                                  # default
-# Pagy::DEFAULT[:items]  = 20                                 # default
-# Pagy::DEFAULT[:outset] = 0                                  # default
-
-# Other Variables
-# See https://ddnexus.github.io/pagy/api/pagy#other-variables
-# Pagy::DEFAULT[:size]       = [1,4,4,1]                       # default
-# Pagy::DEFAULT[:page_param] = :page                           # default
-# The :params can be also set as a lambda e.g ->(params){ params.exclude('useless').merge!('custom' => 'useful') }
-# Pagy::DEFAULT[:params]     = {}                              # default
-# Pagy::DEFAULT[:fragment]   = '#fragment'                     # example
-# Pagy::DEFAULT[:link_extra] = 'data-remote="true"'            # example
-# Pagy::DEFAULT[:i18n_key]   = 'pagy.item_name'                # default
-# Pagy::DEFAULT[:cycle]      = true                            # example
 
 # Extras
-# See https://ddnexus.github.io/pagy/extras
+# See https://ddnexus.github.io/pagy/categories/extra
+
+
+# Legacy Compatibility Extras
+
+# Size extra: Enable the Array type for the `:size` variable (e.g. `size: [1,4,4,1]`)
+# See https://ddnexus.github.io/pagy/docs/extras/size
+# require 'pagy/extras/size'   # must be required before the other extras
+
 
 # Backend Extras
 
+# Arel extra: For better performance utilizing grouped ActiveRecord collections:
+# See: https://ddnexus.github.io/pagy/docs/extras/arel
+# require 'pagy/extras/arel'
+
 # Array extra: Paginate arrays efficiently, avoiding expensive array-wrapping and without overriding
-# See https://ddnexus.github.io/pagy/extras/array
+# See https://ddnexus.github.io/pagy/docs/extras/array
 # require 'pagy/extras/array'
 
 # Calendar extra: Add pagination filtering by calendar time unit (year, quarter, month, week, day)
-# See https://ddnexus.github.io/pagy/extras/calendar
+# See https://ddnexus.github.io/pagy/docs/extras/calendar
 # require 'pagy/extras/calendar'
-# Default for each unit
-# Pagy::Calendar::Year::DEFAULT[:order]     = :asc        # Time direction of pagination
-# Pagy::Calendar::Year::DEFAULT[:format]    = '%Y'        # strftime format
-#
-# Pagy::Calendar::Quarter::DEFAULT[:order]  = :asc        # Time direction of pagination
-# Pagy::Calendar::Quarter::DEFAULT[:format] = '%Y-Q%q'    # strftime format
-#
-# Pagy::Calendar::Month::DEFAULT[:order]    = :asc        # Time direction of pagination
-# Pagy::Calendar::Month::DEFAULT[:format]   = '%Y-%m'     # strftime format
-#
-# Pagy::Calendar::Week::DEFAULT[:order]     = :asc        # Time direction of pagination
-# Pagy::Calendar::Week::DEFAULT[:format]    = '%Y-%W'     # strftime format
-#
-# Pagy::Calendar::Day::DEFAULT[:order]      = :asc        # Time direction of pagination
-# Pagy::Calendar::Day::DEFAULT[:format]     = '%Y-%m-%d'  # strftime format
+# Default for each calendar unit class in IRB:
+# >> Pagy::Calendar::Year::DEFAULT
+# >> Pagy::Calendar::Quarter::DEFAULT
+# >> Pagy::Calendar::Month::DEFAULT
+# >> Pagy::Calendar::Week::DEFAULT
+# >> Pagy::Calendar::Day::DEFAULT
 #
 # Uncomment the following lines, if you need calendar localization without using the I18n extra
 # module LocalizePagyCalendar
@@ -63,12 +58,12 @@
 # Pagy::Calendar.prepend LocalizePagyCalendar
 
 # Countless extra: Paginate without any count, saving one query per rendering
-# See https://ddnexus.github.io/pagy/extras/countless
+# See https://ddnexus.github.io/pagy/docs/extras/countless
 # require 'pagy/extras/countless'
 # Pagy::DEFAULT[:countless_minimal] = false   # default (eager loading)
 
 # Elasticsearch Rails extra: Paginate `ElasticsearchRails::Results` objects
-# See https://ddnexus.github.io/pagy/extras/elasticsearch_rails
+# See https://ddnexus.github.io/pagy/docs/extras/elasticsearch_rails
 # Default :pagy_search method: change only if you use also
 # the searchkick or meilisearch extra that defines the same
 # Pagy::DEFAULT[:elasticsearch_rails_pagy_search] = :pagy_search
@@ -77,15 +72,19 @@
 # require 'pagy/extras/elasticsearch_rails'
 
 # Headers extra: http response headers (and other helpers) useful for API pagination
-# See http://ddnexus.github.io/pagy/extras/headers
+# See https://ddnexus.github.io/pagy/docs/extras/headers
 # require 'pagy/extras/headers'
 # Pagy::DEFAULT[:headers] = { page: 'Current-Page',
-#                            items: 'Page-Items',
+#                            limit: 'Page-Items',
 #                            count: 'Total-Count',
 #                            pages: 'Total-Pages' }     # default
 
+# Keyset extra: Paginate with the Pagy keyset pagination technique
+# See https://ddnexus.github.io/pagy/docs/extras/keyset
+# require 'pagy/extras/keyset'
+
 # Meilisearch extra: Paginate `Meilisearch` result objects
-# See https://ddnexus.github.io/pagy/extras/meilisearch
+# See https://ddnexus.github.io/pagy/docs/extras/meilisearch
 # Default :pagy_search method: change only if you use also
 # the elasticsearch_rails or searchkick extra that define the same method
 # Pagy::DEFAULT[:meilisearch_pagy_search] = :pagy_search
@@ -94,101 +93,88 @@
 # require 'pagy/extras/meilisearch'
 
 # Metadata extra: Provides the pagination metadata to Javascript frameworks like Vue.js, react.js, etc.
-# See https://ddnexus.github.io/pagy/extras/metadata
-# you must require the shared internal extra (BEFORE the metadata extra) ONLY if you need also the :sequels
-# require 'pagy/extras/shared'
+# See https://ddnexus.github.io/pagy/docs/extras/metadata
+# you must require the JS Tools internal extra (BEFORE the metadata extra) ONLY if you need also the :sequels
+# require 'pagy/extras/js_tools'
 # require 'pagy/extras/metadata'
 # For performance reasons, you should explicitly set ONLY the metadata you use in the frontend
 # Pagy::DEFAULT[:metadata] = %i[scaffold_url page prev next last]   # example
 
 # Searchkick extra: Paginate `Searchkick::Results` objects
-# See https://ddnexus.github.io/pagy/extras/searchkick
+# See https://ddnexus.github.io/pagy/docs/extras/searchkick
 # Default :pagy_search method: change only if you use also
 # the elasticsearch_rails or meilisearch extra that defines the same
-# DEFAULT[:searchkick_pagy_search] = :pagy_search
+# Pagy::DEFAULT[:searchkick_pagy_search] = :pagy_search
 # Default original :search method called internally to do the actual search
 # Pagy::DEFAULT[:searchkick_search] = :search
 # require 'pagy/extras/searchkick'
 # uncomment if you are going to use Searchkick.pagy_search
 # Searchkick.extend Pagy::Searchkick
 
+
 # Frontend Extras
 
 # Bootstrap extra: Add nav, nav_js and combo_nav_js helpers and templates for Bootstrap pagination
-# See https://ddnexus.github.io/pagy/extras/bootstrap
+# See https://ddnexus.github.io/pagy/docs/extras/bootstrap
 # require 'pagy/extras/bootstrap'
 
 # Bulma extra: Add nav, nav_js and combo_nav_js helpers and templates for Bulma pagination
-# See https://ddnexus.github.io/pagy/extras/bulma
+# See https://ddnexus.github.io/pagy/docs/extras/bulma
 # require 'pagy/extras/bulma'
 
-# Foundation extra: Add nav, nav_js and combo_nav_js helpers and templates for Foundation pagination
-# See https://ddnexus.github.io/pagy/extras/foundation
-# require 'pagy/extras/foundation'
-
-# Materialize extra: Add nav, nav_js and combo_nav_js helpers for Materialize pagination
-# See https://ddnexus.github.io/pagy/extras/materialize
-# require 'pagy/extras/materialize'
-
-# Navs extra: Add nav_js and combo_nav_js javascript helpers
-# Notice: the other frontend extras add their own framework-styled versions,
-# so require this extra only if you need the unstyled version
-# See https://ddnexus.github.io/pagy/extras/navs
-# require 'pagy/extras/navs'
-
-# Semantic extra: Add nav, nav_js and combo_nav_js helpers for Semantic UI pagination
-# See https://ddnexus.github.io/pagy/extras/semantic
-# require 'pagy/extras/semantic'
-
-# UIkit extra: Add nav helper and templates for UIkit pagination
-# See https://ddnexus.github.io/pagy/extras/uikit
-# require 'pagy/extras/uikit'
+# Pagy extra: Add the pagy styled versions of the javascript-powered navs
+# and a few other components to the Pagy::Frontend module.
+# See https://ddnexus.github.io/pagy/docs/extras/pagy
+# require 'pagy/extras/pagy'
 
 # Multi size var used by the *_nav_js helpers
-# See https://ddnexus.github.io/pagy/extras/navs#steps
-# Pagy::DEFAULT[:steps] = { 0 => [2,3,3,2], 540 => [3,5,5,3], 720 => [5,7,7,5] }   # example
+# See https://ddnexus.github.io/pagy/docs/extras/pagy#steps
+# Pagy::DEFAULT[:steps] = { 0 => 5, 540 => 7, 720 => 9 }   # example
+
 
 # Feature Extras
 
-# Gearbox extra: Automatically change the number of items per page depending on the page number
-# See https://ddnexus.github.io/pagy/extras/gearbox
+# Gearbox extra: Automatically change the limit per page depending on the page number
+# See https://ddnexus.github.io/pagy/docs/extras/gearbox
 # require 'pagy/extras/gearbox'
 # set to false only if you want to make :gearbox_extra an opt-in variable
 # Pagy::DEFAULT[:gearbox_extra] = false               # default true
-# Pagy::DEFAULT[:gearbox_items] = [15, 30, 60, 100]   # default
+# Pagy::DEFAULT[:gearbox_limit] = [15, 30, 60, 100]   # default
 
-# Items extra: Allow the client to request a custom number of items per page with an optional selector UI
-# See https://ddnexus.github.io/pagy/extras/items
-# require 'pagy/extras/items'
-# set to false only if you want to make :items_extra an opt-in variable
-# Pagy::DEFAULT[:items_extra] = false    # default true
-# Pagy::DEFAULT[:items_param] = :items   # default
-# Pagy::DEFAULT[:max_items]   = 100      # default
+# Limit extra: Allow the client to request a custom limit per page with an optional selector UI
+# See https://ddnexus.github.io/pagy/docs/extras/limit
+# require 'pagy/extras/limit'
+# set to false only if you want to make :limit_extra an opt-in variable
+# Pagy::DEFAULT[:limit_extra] = false    # default true
+# Pagy::DEFAULT[:limit_param] = :limit   # default
+# Pagy::DEFAULT[:limit_max]   = 100      # default
 
 # Overflow extra: Allow for easy handling of overflowing pages
-# See https://ddnexus.github.io/pagy/extras/overflow
+# See https://ddnexus.github.io/pagy/docs/extras/overflow
 # require 'pagy/extras/overflow'
 # Pagy::DEFAULT[:overflow] = :empty_page    # default  (other options: :last_page and :exception)
 
-# Support extra: Extra support for features like: incremental, infinite, auto-scroll pagination
-# See https://ddnexus.github.io/pagy/extras/support
-# require 'pagy/extras/support'
-
 # Trim extra: Remove the page=1 param from links
-# See https://ddnexus.github.io/pagy/extras/trim
+# See https://ddnexus.github.io/pagy/docs/extras/trim
 # require 'pagy/extras/trim'
 # set to false only if you want to make :trim_extra an opt-in variable
 # Pagy::DEFAULT[:trim_extra] = false # default true
 
 # Standalone extra: Use pagy in non Rack environment/gem
-# See https://ddnexus.github.io/pagy/extras/standalone
+# See https://ddnexus.github.io/pagy/docs/extras/standalone
 # require 'pagy/extras/standalone'
 # Pagy::DEFAULT[:url] = 'http://www.example.com/subdir'  # optional default
 
+# Jsonapi extra: Implements JSON:API specifications
+# See https://ddnexus.github.io/pagy/docs/extras/jsonapi
+# require 'pagy/extras/jsonapi'   # must be required after the other extras
+# set to false only if you want to make :jsonapi an opt-in variable
+# Pagy::DEFAULT[:jsonapi] = false  # default true
+
 # Rails
 # Enable the .js file required by the helpers that use javascript
-# (pagy*_nav_js, pagy*_combo_nav_js, and pagy_items_selector_js)
-# See https://ddnexus.github.io/pagy/extras#javascript
+# (pagy*_nav_js, pagy*_combo_nav_js, and pagy_limit_selector_js)
+# See https://ddnexus.github.io/pagy/docs/api/javascript
 
 # With the asset pipeline
 # Sprockets need to look into the pagy javascripts dir, so add it to the assets paths
@@ -197,7 +183,7 @@
 # I18n
 
 # Pagy internal I18n: ~18x faster using ~10x less memory than the i18n gem
-# See https://ddnexus.github.io/pagy/api/frontend#i18n
+# See https://ddnexus.github.io/pagy/docs/api/i18n
 # Notice: No need to configure anything in this section if your app uses only "en"
 # or if you use the i18n extra below
 #
@@ -223,13 +209,12 @@
 #                   filepath: 'path/to/pagy-xyz.yml',
 #                   pluralize: lambda{ |count| ... } )
 
+
 # I18n extra: uses the standard i18n gem which is ~18x slower using ~10x more memory
 # than the default pagy internal i18n (see above)
-# See https://ddnexus.github.io/pagy/extras/i18n
+# See https://ddnexus.github.io/pagy/docs/extras/i18n
 # require 'pagy/extras/i18n'
 
-# Default i18n key
-# Pagy::DEFAULT[:i18n_key] = 'pagy.item_name'   # default
 
 # When you are done setting your own default freeze it, so it will not get changed accidentally
 Pagy::DEFAULT.freeze

--- a/test/system/pagination_test.rb
+++ b/test/system/pagination_test.rb
@@ -20,8 +20,8 @@ class PaginationTest < ApplicationSystemTestCase
 
     creative_concept = @team.scaffolding_absolutely_abstract_creative_concepts.create(name: "Test Name")
 
-    # Pagy::DEFAULT[:items] denotes the max of records that exist on one page.
-    (Pagy::DEFAULT[:items] + 1).times do |n|
+    # Pagy::DEFAULT[:limit] denotes the max of records that exist on one page.
+    (Pagy::DEFAULT[:limit] + 1).times do |n|
       creative_concept.completely_concrete_tangible_things.create(text_field_value: "Test #{n + 1}")
     end
 
@@ -36,9 +36,9 @@ class PaginationTest < ApplicationSystemTestCase
     visit account_scaffolding_absolutely_abstract_creative_concept_path(creative_concept)
 
     assert_text("Test 1")
-    refute_text("Test #{Pagy::DEFAULT[:items] + 1}")
+    refute_text("Test #{Pagy::DEFAULT[:limit] + 1}")
 
     click_on "2"
-    assert_text("Test #{Pagy::DEFAULT[:items] + 1}")
+    assert_text("Test #{Pagy::DEFAULT[:limit] + 1}")
   end
 end


### PR DESCRIPTION
Joint PR: https://github.com/bullet-train-co/bullet_train-core/pull/1150

The test failures here are in the part of the test suite that's testing against the published gems, which expect `pagy` version 8, so they're to be expected.