### PR TITLE
For superscaffolding tests name artifacts differently

### DIFF
--- a/.github/workflows/_run_super_scaffolding_tests.yml
+++ b/.github/workflows/_run_super_scaffolding_tests.yml
@@ -156,14 +156,14 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: test_summary_super_scaffolding_${{ strategy.job-index }}_${{ inputs.use-core-repo }}.log
+          name: test_summary_super_scaffolding_${{ matrix.test }}_${{ inputs.use-core-repo }}.log
           path: tmp/starter/test/reports/**/TEST-*.xml
 
       - name: Upload Test Coverage Data
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: test_coverage_${{ strategy.job-index }}_${{ inputs.use-core-repo }}.log
+          name: test_coverage_${{ matrix.test }}_${{ inputs.use-core-repo }}.log
           path: tmp/starter/coverage/.resultset.json
           include-hidden-files: true
 
@@ -171,5 +171,5 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: error_screenshots_${{ strategy.job-index }}.zip
+          name: error_screenshots_${{ matrix.test }}.zip
           path: tmp/starter/tmp/screenshots/*.png


### PR DESCRIPTION
This prevents possible collisions