### PR TITLE
Don't run `yarn build` twice during asset prcompilation

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "scripts": {
     "heroku-postbuild": "echo 'This step prevents Heroku from trying to run `yarn build` before ruby and bundler are available. The asset pipeline will call it as part of asset precompilation.'",
     "build": "THEME=\"light\" node esbuild.config.js",
-    "build:css": "bin/link; THEME=\"light\" yarn build; yarn light:build:css; yarn light:build:mailer:css",
+    "build:css": "bin/link; yarn light:build:css; yarn light:build:mailer:css",
     "light:build:css": "THEME=\"light\" NODE_PATH=./node_modules tailwindcss -c tailwind.config.js -i ./app/assets/stylesheets/application.css -o ./app/assets/builds/application.light.css --postcss ./postcss.config.js",
     "light:build:mailer:css": "THEME=\"light\" NODE_PATH=./node_modules tailwindcss -c $(bundle exec bin/theme tailwind-mailer-config light) -i $(bundle exec bin/theme tailwind-stylesheet light) -o ./app/assets/builds/application.mailer.light.css --postcss ./postcss.mailer.config.js"
   },


### PR DESCRIPTION
Running `rails assets:precompile` will automatically run `yarn build` and `yarn build:css` so we don't need to call `yarn build` as a part of `yarn build:css`.

Fixes https://github.com/bullet-train-co/bullet_train/issues/2108