### PR TITLE
Use `bundle exec` in `bin/dev`

### DIFF
--- a/bin/dev
+++ b/bin/dev
@@ -4,7 +4,7 @@ bin/link
 
 if [ -x "$(command -v overmind)" ]
 then
-  overmind start -f Procfile.dev "$@"
+  bundle exec overmind start -f Procfile.dev "$@"
 else
-  foreman start -f Procfile.dev "$@"
+  bundle exec foreman start -f Procfile.dev "$@"
 fi


### PR DESCRIPTION
Depending on your local configuration you may _need_ `bundle exec` to be included in these commands. In either case adding it won't hurt anything.