### PR TITLE
Remove `bundle exec` when calling `overmind`

### DIFF
--- a/bin/dev
+++ b/bin/dev
@@ -4,7 +4,7 @@ bin/link
 
 if [ -x "$(command -v overmind)" ]
 then
-  exec bundle exec overmind start -f Procfile.dev "$@"
+  exec overmind start -f Procfile.dev "$@"
 else
   exec bundle exec foreman start -f Procfile.dev "$@"
 fi


### PR DESCRIPTION
We dont' include `overmind` in the `Gemfile` because we want it to be optional for people. So we shouldn't try to call it vai `bundle exec` because some versions of bundler blow up if it's not in the bundle.