### PR TITLE
Exit after showing error message if bin/theme is missing arguments

### DIFF
--- a/bin/theme
+++ b/bin/theme
@@ -15,6 +15,7 @@ if ARGV.size < 2
   puts "\t\"tailwind-mailer-config\""
   puts "\t\"tailwind-stylesheet\""
   puts "\t\"javascript\""
+  exit
 end
 
 file_type = ARGV.shift


### PR DESCRIPTION
Previously we'd show an error about missing argument, but then try to continue running the script, which would then throw a different less descriptive error, which makes it easy to miss the descriptive one that's shown earlier.