### PR TITLE
fix small SETUP_GITHUB issue

### DIFF
--- a/bin/configure-scripts/deploy_button_heroku.rb
+++ b/bin/configure-scripts/deploy_button_heroku.rb
@@ -9,7 +9,7 @@ button_file = "#{__dir__}/deploy-buttons/heroku.md"
 add_button = ask_boolean "Would you like to add a 'Deploy to Heroku' button to your project.", "y"
 if add_button
   puts "Adding a 'Deploy to Heroku' button.".green
-  new_repo_link = if defined?(SETUP_GITHUB)
+  new_repo_link = if defined?(SETUP_GITHUB) && SETUP_GITHUB
     HTTP_PATH
   else
     ask "What is the https variant of your repo URL? (Something like: https://github.com/your-org/your-repo)"


### PR DESCRIPTION
Reproduction:

The user runs `bin/configure` and responds `n` to "Continue setting up with Github". (NB: this sets the global `SETUP_GITHUB` to `false`)

The user later responds 'y' to "Would you like to add a 'Deploy to Heroku' button to your project. [Y/n]". This results in the following error:

```text
Adding a 'Deploy to Heroku' button.
/path_to_project/bin/configure-scripts/deploy_button_heroku.rb:13:in '<top (required)>': uninitialized constant HTTP_PATH (NameError)

    HTTP_PATH
    ^^^^^^^^^
	from /Users/grymoire/rbenv/versions/3.4.5/lib/ruby/3.4.0/bundled_gems.rb:82:in 'Kernel.require'
	from /Users/grymoire/.rbenv/versions/3.4.5/lib/ruby/3.4.0/bundled_gems.rb:82:in 'block (2 levels) in Kernel#replace_require'
	from bin/configure:22:in '<main>'
```

The line of code in question is
https://github.com/bullet-train-co/bullet_train/blob/main/bin/configure-scripts/deploy_button_heroku.rb#L13 :

```ruby
add_button = ask_boolean "Would you like to add a 'Deploy to Heroku' button to your project.", "y"
if add_button
  puts "Adding a 'Deploy to Heroku' button.".green
  new_repo_link = if defined?(SETUP_GITHUB)
    HTTP_PATH   # <-- This is line 13
  else
    ask "What is the https variant of your repo URL? (Something like: https://github.com/your-org/your-repo)"
  end
```

The problem is that `SETUP_GITHUB` is defined, and defined to be `false` because the user answered 'n' to the first question, the Github setup code was never run, and HTTP_PATH was never set.

Proposed solution:

The proposed solution is to change `if defined?(SETUP_GITHUB)` to `if defined?(SETUP_GITHUB) && SETUP_GITHUB`.