### PR TITLE
DO NOT MERGE - New sortable controller proof of concept

### DIFF
--- a/app/avo/resources/page.rb
+++ b/app/avo/resources/page.rb
@@ -4,7 +4,7 @@ class Avo::Resources::Page < Avo::BaseResource
   # self.search = {
   #   query: -> { query.ransack(id_eq: q, m: "or").result(distinct: false) }
   # }
-  
+
   def fields
     field :id, as: :id
     field :team, as: :belongs_to

--- a/app/avo/resources/page.rb
+++ b/app/avo/resources/page.rb
@@ -1,0 +1,14 @@
+class Avo::Resources::Page < Avo::BaseResource
+  # self.includes = []
+  # self.attachments = []
+  # self.search = {
+  #   query: -> { query.ransack(id_eq: q, m: "or").result(distinct: false) }
+  # }
+  
+  def fields
+    field :id, as: :id
+    field :team, as: :belongs_to
+    field :name, as: :text
+    field :path, as: :textarea
+  end
+end

--- a/app/controllers/account/pages_controller.rb
+++ b/app/controllers/account/pages_controller.rb
@@ -1,5 +1,6 @@
 class Account::PagesController < Account::ApplicationController
   include SortableActions
+
   account_load_and_authorize_resource :page, through: :team, through_association: :pages
 
   # GET /account/teams/:team_id/pages

--- a/app/controllers/account/pages_controller.rb
+++ b/app/controllers/account/pages_controller.rb
@@ -1,0 +1,72 @@
+class Account::PagesController < Account::ApplicationController
+  include SortableActions
+  account_load_and_authorize_resource :page, through: :team, through_association: :pages
+
+  # GET /account/teams/:team_id/pages
+  # GET /account/teams/:team_id/pages.json
+  def index
+    delegate_json_to_api
+  end
+
+  # GET /account/pages/:id
+  # GET /account/pages/:id.json
+  def show
+    delegate_json_to_api
+  end
+
+  # GET /account/teams/:team_id/pages/new
+  def new
+  end
+
+  # GET /account/pages/:id/edit
+  def edit
+  end
+
+  # POST /account/teams/:team_id/pages
+  # POST /account/teams/:team_id/pages.json
+  def create
+    respond_to do |format|
+      if @page.save
+        format.html { redirect_to [:account, @page], notice: I18n.t("pages.notifications.created") }
+        format.json { render :show, status: :created, location: [:account, @page] }
+      else
+        format.html { render :new, status: :unprocessable_entity }
+        format.json { render json: @page.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # PATCH/PUT /account/pages/:id
+  # PATCH/PUT /account/pages/:id.json
+  def update
+    respond_to do |format|
+      if @page.update(page_params)
+        format.html { redirect_to [:account, @page], notice: I18n.t("pages.notifications.updated") }
+        format.json { render :show, status: :ok, location: [:account, @page] }
+      else
+        format.html { render :edit, status: :unprocessable_entity }
+        format.json { render json: @page.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # DELETE /account/pages/:id
+  # DELETE /account/pages/:id.json
+  def destroy
+    @page.destroy
+    respond_to do |format|
+      format.html { redirect_to [:account, @team, :pages], notice: I18n.t("pages.notifications.destroyed") }
+      format.json { head :no_content }
+    end
+  end
+
+  private
+
+  if defined?(Api::V1::ApplicationController)
+    include strong_parameters_from_api
+  end
+
+  def process_params(strong_params)
+    # 🚅 super scaffolding will insert processing for new fields above this line.
+  end
+end

--- a/app/controllers/api/v1/pages_controller.rb
+++ b/app/controllers/api/v1/pages_controller.rb
@@ -1,0 +1,65 @@
+# Api::V1::ApplicationController is in the starter repository and isn't
+# needed for this package's unit tests, but our CI tests will try to load this
+# class because eager loading is set to `true` when CI=true.
+# We wrap this class in an `if` statement to circumvent this issue.
+if defined?(Api::V1::ApplicationController)
+  class Api::V1::PagesController < Api::V1::ApplicationController
+    account_load_and_authorize_resource :page, through: :team, through_association: :pages
+
+    # GET /api/v1/teams/:team_id/pages
+    def index
+    end
+
+    # GET /api/v1/pages/:id
+    def show
+    end
+
+    # POST /api/v1/teams/:team_id/pages
+    def create
+      if @page.save
+        render :show, status: :created, location: [:api, :v1, @page]
+      else
+        render json: @page.errors, status: :unprocessable_entity
+      end
+    end
+
+    # PATCH/PUT /api/v1/pages/:id
+    def update
+      if @page.update(page_params)
+        render :show
+      else
+        render json: @page.errors, status: :unprocessable_entity
+      end
+    end
+
+    # DELETE /api/v1/pages/:id
+    def destroy
+      @page.destroy
+    end
+
+    private
+
+    module StrongParameters
+      # Only allow a list of trusted parameters through.
+      def page_params
+        strong_params = params.require(:page).permit(
+          *permitted_fields,
+          :name,
+          :path,
+          # 🚅 super scaffolding will insert new fields above this line.
+          *permitted_arrays,
+          # 🚅 super scaffolding will insert new arrays above this line.
+        )
+
+        process_params(strong_params)
+
+        strong_params
+      end
+    end
+
+    include StrongParameters
+  end
+else
+  class Api::V1::PagesController
+  end
+end

--- a/app/controllers/avo/pages_controller.rb
+++ b/app/controllers/avo/pages_controller.rb
@@ -1,0 +1,4 @@
+# This controller has been generated to enable Rails' resource routes.
+# More information on https://docs.avohq.io/3.0/controllers.html
+class Avo::PagesController < Avo::ResourcesController
+end

--- a/app/javascript/controllers/confirm-reorder_controller.js
+++ b/app/javascript/controllers/confirm-reorder_controller.js
@@ -1,0 +1,38 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = [ "sortable" ]
+
+  connect() {
+    console.log('confirm-reorder connect!')
+  }
+
+  requestConfirmation(event) {
+    console.log('requestConfirmation!!!!!', event);
+    //return;
+
+    const [el, target, source, sibling] = event.detail?.args
+
+    // sibling will be undefined if dropped in last position, taking a shortcut here
+    const areYouSure = `Are you sure you want to place ${el.dataset.name} before ${sibling.dataset.name}?`
+    //const areYouSure = `Are you sure you want to move ${el.dataset.name}?`
+
+    // let's suppose each <tr> in sortable has a data-name attribute
+    if (confirm(areYouSure)) {
+      this.sortableTarget.dispatchEvent(new CustomEvent('save-sort-order'))
+    } else {
+      this.revertToOriginalOrder()
+    }
+  }
+
+  prepareForRevertOnCancel(event) {
+    // we're assuming we can swap out the HTML safely
+    this.originalSortableHTML = this.sortableTarget.innerHTML
+  }
+
+  revertToOriginalOrder() {
+    if (this.originalSortableHTML === undefined) { return }
+    this.sortableTarget.innerHTML = this.originalSortableHTML
+    this.originalSortableHTML = undefined
+  }
+}

--- a/app/javascript/controllers/new_sortable_controller.js
+++ b/app/javascript/controllers/new_sortable_controller.js
@@ -1,0 +1,210 @@
+import { Controller } from "@hotwired/stimulus"
+import { post } from '@rails/request.js'
+
+// These are defaults so that we don't have to require people to update their templates.
+// If the template does contain values for any of these the template values will be used instead.
+const defaultClasses = {
+  "activeDropzoneClasses": "border-dashed bg-gray-50 border-slate-400",
+  "activeItemClasses": "shadow bg-white cursor-grabbing bg-white *:bg-white opacity-100 *:opacity-100",
+  "dropTargetClasses": "shadow-inner shadow-gray-500 hover:shadow-inner bg-gray-100 *:opacity-0 *:bg-gray-100"
+};
+
+// Connects to data-controller="new-sortable"
+export default class extends Controller {
+  static values = {
+    reorderPath: String,
+    saveOnReorder: { type: Boolean, default: true }
+  }
+  static classes = ["activeDropzone", "activeItem", "dropTarget"];
+
+  dragHandleMouseDown(event){
+    const draggableItem = getDataNode(event.target);
+    draggableItem.setAttribute('draggable', true);
+  }
+
+  dragHandleMouseUp(event){
+    const draggableItem = getDataNode(event.target);
+    draggableItem.setAttribute('draggable', false);
+  }
+
+  dragstart(event) {
+    event.stopPropagation();
+    this.element.classList.add(...this.activeDropzoneClassesWithDefaults);
+    const draggableItem = getDataNode(event.target);
+    draggableItem.classList.add(...this.activeItemClassesWithDefaults);
+    event.dataTransfer.setData(
+      "application/drag-key",
+      draggableItem.dataset.id
+    );
+    event.dataTransfer.effectAllowed = "move";
+    // For most browsers we could rely on the dataTransfer.setData call above,
+    // but Safari doesn't seem to allow us access to that data at any time other
+    // than during a drop. But we need it during dragenter to reorder the list
+    // as the drag happens. So, we just stash the value here and then use it later.
+    this.draggingDataId = draggableItem.dataset.id;
+  }
+
+  drag(event){ }
+
+  dragover(event) {
+    event.stopPropagation();
+    event.preventDefault();
+    return true;
+  }
+
+  dragenter(event) {
+    event.stopPropagation();
+    let parent = getDataNode(event.target);
+
+    // We keep a count of the `dragenter` events for the row being dragged to fix jank. When dragging between cells
+    // (or cell content) within a row a dragenter event is fired before the dragleave event from the previous cell.
+    // If we removed the activeItemClasses when the dragleave happens then the UI doesn't match expectations.
+    if(parent.dataset.dragEnterCount){
+      parent.dataset.dragEnterCount = parseInt(parent.dataset.dragEnterCount) + 1;
+    }else{
+      parent.dataset.dragEnterCount = 1;
+    }
+
+    if (parent != null && parent.dataset.id != null) {
+      parent.classList.add(...this.dropTargetClassesWithDefaults);
+      var data = this.draggingDataId;
+      const draggedItem = this.element.querySelector(
+        `[data-id='${data}']`
+      );
+
+      if (draggedItem) {
+        draggedItem.classList.remove(...this.activeItemClassesWithDefaults);
+
+        if (
+          parent.compareDocumentPosition(draggedItem) &
+          Node.DOCUMENT_POSITION_FOLLOWING
+        ) {
+          let result = parent.insertAdjacentElement(
+            "beforebegin",
+            draggedItem
+          );
+        } else if (
+          parent.compareDocumentPosition(draggedItem) &
+          Node.DOCUMENT_POSITION_PRECEDING
+        ) {
+          let result = parent.insertAdjacentElement("afterend", draggedItem);
+        }
+
+      }
+      event.preventDefault();
+    }
+  }
+
+  dragleave(event) {
+    event.stopPropagation();
+    let parent = getDataNode(event.target);
+
+    if(parent.dataset.dragEnterCount > 0){
+      parent.dataset.dragEnterCount = parseInt(parent.dataset.dragEnterCount) - 1;
+    }
+
+    if (parent != null && parent.dataset.id != null && parent.dataset.dragEnterCount == 0) {
+      parent.classList.remove(...this.dropTargetClassesWithDefaults);
+      event.preventDefault();
+    }
+  }
+
+  drop(event) {
+    event.stopPropagation();
+    this.element.classList.remove(...this.activeDropzoneClassesWithDefaults);
+
+    const dropTarget = getDataNode(event.target);
+    dropTarget.classList.remove(...this.dropTargetClassesWithDefaults);
+
+    var data = this.draggingDataId;
+    const draggedItem = this.element.querySelector(
+      `[data-id='${data}']`
+    );
+
+    if (draggedItem) {
+      draggedItem.classList.remove(...this.activeItemClassesWithDefaults);
+
+      if (
+        dropTarget.compareDocumentPosition(draggedItem) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+      ) {
+        let result = dropTarget.insertAdjacentElement(
+          "beforebegin",
+          draggedItem
+        );
+      } else if (
+        dropTarget.compareDocumentPosition(draggedItem) &
+        Node.DOCUMENT_POSITION_PRECEDING
+      ) {
+        let result = dropTarget.insertAdjacentElement("afterend", draggedItem);
+      }
+
+      if (this.saveOnReorderValue) {
+        this.saveSortOrder()
+      }
+    }
+    event.preventDefault();
+  }
+
+  saveSortOrder() {
+    var idsInOrder = Array.from(this.element.childNodes).map((el) => { return parseInt(el.dataset?.id) });
+    post(this.reorderPathValue, { body: JSON.stringify({ids_in_order: idsInOrder}) })
+  }
+
+  dragend(event) {
+    event.stopPropagation();
+    this.element.classList.remove(...this.activeDropzoneClassesWithDefaults);
+
+    const draggableItem = getDataNode(event.target);
+    draggableItem.setAttribute('draggable', false);
+    draggableItem.dataset.dragEnterCount = 0;
+  }
+
+  connect() {
+    // We do this to ease the upgrade path so that people aren't required to udpate their templates.
+    this.activeDropzoneClassesWithDefaults = this.activeDropzoneClasses.length == 0 ? defaultClasses["activeDropzoneClasses"].split(" ") : this.activeDropzoneClasses;
+    this.activeItemClassesWithDefaults = this.activeItemClasses.length == 0 ? defaultClasses["activeItemClasses"].split(" ") : this.activeItemClasses;
+    this.dropTargetClassesWithDefaults = this.dropTargetClasses.length == 0 ? defaultClasses["dropTargetClasses"].split(" ") : this.dropTargetClasses;
+
+    // Normally with Stimulus we'd wire these up via the data-action attribute. We're doing it this way to make
+    // the transition to this new controller easier.
+    this.element.addEventListener('dragstart', this.dragstart.bind(this));
+    this.element.addEventListener('drag', this.drag.bind(this));
+    this.element.addEventListener('dragover', this.dragover.bind(this));
+    this.element.addEventListener('dragenter', this.dragenter.bind(this));
+    this.element.addEventListener('dragleave', this.dragleave.bind(this));
+    this.element.addEventListener('dragend', this.dragend.bind(this));
+    this.element.addEventListener('drop', this.drop.bind(this));
+
+    let handles = this.element.querySelectorAll('.dragHandle')
+    for (const handle of handles) {
+      handle.addEventListener('mousedown', this.dragHandleMouseDown.bind(this));
+      handle.addEventListener('mouseup', this.dragHandleMouseUp.bind(this));
+    }
+  }
+
+  disconnect() {
+    this.element.removeEventListener('dragstart', this.dragstart.bind(this));
+    this.element.removeEventListener('drag', this.drag.bind(this));
+    this.element.removeEventListener('dragover', this.dragover.bind(this));
+    this.element.removeEventListener('dragenter', this.dragenter.bind(this));
+    this.element.removeEventListener('dragleave', this.dragleave.bind(this));
+    this.element.removeEventListener('dragend', this.dragend.bind(this));
+    this.element.removeEventListener('drop', this.drop.bind(this));
+
+    let handles = this.element.querySelectorAll('.dragHangle')
+    for (const handle of handles) {
+      handle.removeEventListener('mousedown', this.dragHandleMouseDown.bind(this));
+      handle.removeEventListener('mouseup', this.dragHandleMouseUp.bind(this));
+    }
+  }
+}
+
+function getDataNode(node) {
+  return node.closest("[data-id]");
+}
+
+function getMetaValue(name) {
+  const element = document.head.querySelector(`meta[name="${name}"]`);
+  return element.getAttribute("content");
+}

--- a/app/javascript/controllers/new_sortable_controller.js
+++ b/app/javascript/controllers/new_sortable_controller.js
@@ -5,9 +5,7 @@ import { post } from '@rails/request.js'
 export default class extends Controller {
   static values = {
     reorderPath: String,
-    saveOnReorder: { type: Boolean, default: true },
-    // This is used to get a hold of the draggable elements (tr by default) inside of the draggable container (tbody by default).
-    draggableSelector: { type: String, default: "tr" }
+    saveOnReorder: { type: Boolean, default: true }
   }
   static classes = ["activeDropzone", "activeItem", "dropTarget"];
 
@@ -131,8 +129,6 @@ class SortableTable{
     this.draggingDataId = draggableItem.dataset.id;
   }
 
-  drag(event){ }
-
   dragover(event) {
     event.stopPropagation();
     event.preventDefault();
@@ -246,7 +242,6 @@ class SortableTable{
   }
 
   addDragHandles(){
-
     // Here we assume that this controller is connected to a tbody element
     const table = this.element.parentNode;
     const thead = table.querySelector('thead');
@@ -263,13 +258,12 @@ class SortableTable{
 
       const iconSpan = document.createElement('span');
       iconSpan.classList.add(...'h-6 w-6 text-center'.split(' '));
-      newCell.append(iconSpan);
 
       const icon = document.createElement('i');
       icon.classList.add(...'ti ti-line-double'.split(' '));
 
       iconSpan.append(icon);
-
+      newCell.append(iconSpan);
       draggable.prepend(newCell);
     }
   }

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -1,24 +1,28 @@
-class Team < ApplicationRecord
-  include Teams::Base
-  include Webhooks::Outgoing::TeamSupport
+class Page < ApplicationRecord
+  include Sortable
   # 🚅 add concerns above.
 
+  # 🚅 add attribute accessors above.
+
+  belongs_to :team
   # 🚅 add belongs_to associations above.
 
-  has_many :pages, dependent: :destroy
   # 🚅 add has_many associations above.
-
-  # 🚅 add oauth providers above.
 
   # 🚅 add has_one associations above.
 
   # 🚅 add scopes above.
 
+  validates :name, presence: true
   # 🚅 add validations above.
 
   # 🚅 add callbacks above.
 
   # 🚅 add delegations above.
+
+  def collection
+    team.pages
+  end
 
   # 🚅 add methods above.
 end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -1,5 +1,6 @@
 class Page < ApplicationRecord
   include Sortable
+
   # 🚅 add concerns above.
 
   # 🚅 add attribute accessors above.

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -1,6 +1,7 @@
 class Team < ApplicationRecord
   include Teams::Base
   include Webhooks::Outgoing::TeamSupport
+
   # 🚅 add concerns above.
 
   # 🚅 add belongs_to associations above.

--- a/app/views/account/pages/_breadcrumbs.html.erb
+++ b/app/views/account/pages/_breadcrumbs.html.erb
@@ -1,0 +1,8 @@
+<% page ||= @page %>
+<% team ||= @team || page&.team %>
+<%= render 'account/teams/breadcrumbs', team: team %>
+<%= render 'account/shared/breadcrumb', label: t('.label'), url: [:account, team, :pages] %>
+<% if page&.persisted? %>
+  <%= render 'account/shared/breadcrumb', label: page.label_string, url: [:account, page] %>
+<% end %>
+<%= render 'account/shared/breadcrumbs/actions', only_for: 'pages' %>

--- a/app/views/account/pages/_form.html.erb
+++ b/app/views/account/pages/_form.html.erb
@@ -1,0 +1,18 @@
+<% cancel_path ||= page.persisted? ? [:account, page] : [:account, @team, :pages] %>
+
+<%= form_with model: page, url: (page.persisted? ? [:account, page] : [:account, @team, :pages]), class: 'form' do |form| %>
+  <%= render "shared/limits/form", form: form, cancel_path: cancel_path do %>
+    <%= render 'account/shared/forms/errors', form: form %>
+
+    <% with_field_settings form: form do %>
+      <%= render 'shared/fields/text_field', method: :name, options: {autofocus: true} %>
+      <%= render 'shared/fields/text_area', method: :path %>
+      <%# 🚅 super scaffolding will insert new fields above this line. %>
+    <% end %>
+
+    <div class="buttons">
+      <%= form.submit (form.object.persisted? ? t('.buttons.update') : t('.buttons.create')), class: "button" %>
+      <%= link_to t('global.buttons.cancel'), cancel_path, class: "button-secondary" %>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/account/pages/_index.html.erb
+++ b/app/views/account/pages/_index.html.erb
@@ -22,6 +22,7 @@
           <table class="table">
             <thead>
               <tr>
+                <th class="w-6"></th>
                 <%= render "shared/tables/select_all" %>
                 <th><%= t('.fields.name.heading') %></th>
                 <%# 🚅 super scaffolding will insert new field headers above this line. %>
@@ -29,7 +30,7 @@
                 <th class="text-right"></th>
               </tr>
             </thead>
-            <tbody data-controller="sortable" data-sortable-reorder-path-value="<%= url_for [:reorder, :account, context, collection] %>">
+            <tbody data-controller="new-sortable" data-new-sortable-reorder-path-value="<%= url_for [:reorder, :account, context, collection] %>">
               <%= render partial: 'account/pages/page', collection: pages %>
             </tbody>
           </table>

--- a/app/views/account/pages/_index.html.erb
+++ b/app/views/account/pages/_index.html.erb
@@ -1,0 +1,62 @@
+<% pages = pages.accessible_by(current_ability) %>
+<% team = @team %>
+<% context ||= team %>
+<% collection ||= :pages %>
+<% hide_actions ||= false %>
+<% hide_back ||= false %>
+
+<% pagy ||= nil %>
+<% pagy, pages = pagy(pages, page_param: :pages_page) unless pagy %>
+
+<%= action_model_select_controller do %>
+  <% cable_ready_updates_for context, collection do %>
+    <%= render 'account/shared/box', pagy: pagy do |box| %>
+      <% box.title t(".contexts.#{context.class.name.underscore}.header") %>
+      <% box.description do %>
+        <%= t(".contexts.#{context.class.name.underscore}.description#{"_empty" unless pages.any?}") %>
+        <%= render "shared/limits/index", model: pages.model %>
+      <% end %>
+
+      <% box.table do %>
+        <% if pages.any? %>
+          <table class="table">
+            <thead>
+              <tr>
+                <%= render "shared/tables/select_all" %>
+                <th><%= t('.fields.name.heading') %></th>
+                <%# 🚅 super scaffolding will insert new field headers above this line. %>
+                <th><%= t('.fields.created_at.heading') %></th>
+                <th class="text-right"></th>
+              </tr>
+            </thead>
+            <tbody data-controller="sortable" data-sortable-reorder-path-value="<%= url_for [:reorder, :account, context, collection] %>">
+              <%= render partial: 'account/pages/page', collection: pages %>
+            </tbody>
+          </table>
+        <% end %>
+      <% end %>
+
+      <% box.actions do %>
+        <% unless hide_actions %>
+          <% if context == team %>
+            <% if can? :create, Page.new(team: team) %>
+              <%= link_to t('.buttons.new'), [:new, :account, team, :page], class: "#{first_button_primary(:page)} new" %>
+            <% end %>
+          <% end %>
+
+          <%# 🚅 super scaffolding will insert new targets one parent action model buttons above this line. %>
+          <%# 🚅 super scaffolding will insert new bulk action model buttons above this line. %>
+          <%= render "shared/bulk_action_select" if pages.any? %>
+
+          <% unless hide_back %>
+            <%= link_to t('global.buttons.back'), [:account, context], class: "#{first_button_primary(:page)} back" %>
+          <% end %>
+        <% end %>
+      <% end %>
+
+      <% box.raw_footer do %>
+        <%# 🚅 super scaffolding will insert new action model index views above this line. %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/account/pages/_index.html.erb
+++ b/app/views/account/pages/_index.html.erb
@@ -19,10 +19,10 @@
 
       <% box.table do %>
         <% if pages.any? %>
-          <table class="table">
+          <table class="table" data-controller="confirm-reorder">
             <thead>
               <tr>
-                <th class="w-6"></th>
+                <!--<th class="w-6"></th>-->
                 <%= render "shared/tables/select_all" %>
                 <th><%= t('.fields.name.heading') %></th>
                 <%# 🚅 super scaffolding will insert new field headers above this line. %>
@@ -30,7 +30,9 @@
                 <th class="text-right"></th>
               </tr>
             </thead>
-            <tbody data-controller="new-sortable" data-new-sortable-reorder-path-value="<%= url_for [:reorder, :account, context, collection] %>">
+            <tbody data-controller="new-sortable" data-new-sortable-reorder-path-value="<%= url_for [:reorder, :account, context, collection] %>"
+              data-action="new-sortable:drop->confirm-reorder#requestConfirmation"
+              >
               <%= render partial: 'account/pages/page', collection: pages %>
             </tbody>
           </table>

--- a/app/views/account/pages/_menu_item.html.erb
+++ b/app/views/account/pages/_menu_item.html.erb
@@ -1,0 +1,10 @@
+<% if can? :read, Page.new(team: current_team) %>
+  <%= render 'account/shared/menu/item', {
+    url: main_app.polymorphic_path([:account, current_team, :pages]),
+    label: t('pages.navigation.label'),
+  } do |p| %>
+    <% p.icon do %>
+      <i class="<%= t('pages.navigation.icon') %>"></i>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/account/pages/_page.html.erb
+++ b/app/views/account/pages/_page.html.erb
@@ -1,0 +1,25 @@
+<% team = @team || @team %>
+<% context ||= team %>
+<% collection ||= :pages %>
+<% hide_actions ||= false %>
+<% hide_back ||= false %>
+
+<% with_attribute_settings object: page do %>
+  <tr data-id="<%= page.id %>">
+    <%= render "shared/tables/checkbox", object: page %>
+    <td><%= render 'shared/attributes/text', attribute: :name, url: [:account, page] %></td>
+    <%# 🚅 super scaffolding will insert new fields above this line. %>
+    <td><%= render 'shared/attributes/date_and_time', attribute: :created_at %></td>
+    <td class="buttons">
+      <% unless hide_actions %>
+        <% if can? :edit, page %>
+          <%= link_to t('.buttons.shorthand.edit'), [:edit, :account, page], class: 'button-secondary button-smaller' %>
+        <% end %>
+        <% if can? :destroy, page %>
+          <%= button_to t('.buttons.shorthand.destroy'), [:account, page], method: :delete, data: { turbo_confirm: t('.buttons.confirmations.destroy', model_locales(page)) }, class: 'button-secondary button-smaller' %>
+        <% end %>
+        <%# 🚅 super scaffolding will insert new action model buttons above this line. %>
+      <% end %>
+    </td>
+  </tr>
+<% end %>

--- a/app/views/account/pages/_page.html.erb
+++ b/app/views/account/pages/_page.html.erb
@@ -6,11 +6,13 @@
 
 <% with_attribute_settings object: page do %>
   <tr data-id="<%= page.id %>">
+    <!--
     <td class="dragHandle cursor-grab">
       <span class="h-6 w-6 text-center">
         <i class="ti ti-line-double"></i>
       </span>
     </td>
+    -->
     <%= render "shared/tables/checkbox", object: page %>
     <td><%= render 'shared/attributes/text', attribute: :name, url: [:account, page] %></td>
     <%# 🚅 super scaffolding will insert new fields above this line. %>

--- a/app/views/account/pages/_page.html.erb
+++ b/app/views/account/pages/_page.html.erb
@@ -6,6 +6,11 @@
 
 <% with_attribute_settings object: page do %>
   <tr data-id="<%= page.id %>">
+    <td class="dragHandle cursor-grab">
+      <span class="h-6 w-6 text-center">
+        <i class="ti ti-arrows-vertical"></i>
+      </span>
+    </td>
     <%= render "shared/tables/checkbox", object: page %>
     <td><%= render 'shared/attributes/text', attribute: :name, url: [:account, page] %></td>
     <%# 🚅 super scaffolding will insert new fields above this line. %>

--- a/app/views/account/pages/_page.html.erb
+++ b/app/views/account/pages/_page.html.erb
@@ -8,7 +8,7 @@
   <tr data-id="<%= page.id %>">
     <td class="dragHandle cursor-grab">
       <span class="h-6 w-6 text-center">
-        <i class="ti ti-arrows-vertical"></i>
+        <i class="ti ti-line-double"></i>
       </span>
     </td>
     <%= render "shared/tables/checkbox", object: page %>

--- a/app/views/account/pages/edit.html.erb
+++ b/app/views/account/pages/edit.html.erb
@@ -1,0 +1,7 @@
+<%= render 'account/shared/page' do |page| %>
+  <% page.title t('.section') %>
+  <% page.body.render 'account/shared/box', divider: true do |box| %>
+    <% box.t :description, title: '.header' %>
+    <% box.body.render 'form', page: @page %>
+  <% end %>
+<% end %>

--- a/app/views/account/pages/index.html.erb
+++ b/app/views/account/pages/index.html.erb
@@ -1,0 +1,4 @@
+<%= render 'account/shared/page' do |page| %>
+  <% page.title t('.section') %>
+  <% page.body.render 'index', pages: @pages %>
+<% end %>

--- a/app/views/account/pages/new.html.erb
+++ b/app/views/account/pages/new.html.erb
@@ -1,0 +1,7 @@
+<%= render 'account/shared/page' do |page| %>
+  <% page.title t('.section') %>
+  <% page.body.render 'account/shared/box', divider: true do |box| %>
+    <% box.t :description, title: '.header' %>
+    <% box.body.render 'form', page: @page %>
+  <% end %>
+<% end %>

--- a/app/views/account/pages/show.html.erb
+++ b/app/views/account/pages/show.html.erb
@@ -1,0 +1,35 @@
+<%= render 'account/shared/page' do |page| %>
+  <% page.title t('.section') %>
+  <% page.body do %>
+    <%= cable_ready_updates_for @page do %>
+      <%= render 'account/shared/box', divider: true do |box| %>
+        <% box.title t('.header') %>
+        <% box.description do %>
+          <%= t('.description') %>
+          <%= t('.manage_description') if can? :manage, @page %>
+        <% end %>
+
+        <% box.body do %>
+          <% with_attribute_settings object: @page, strategy: :label do %>
+            <%= render 'shared/attributes/text', attribute: :name %>
+            <%= render 'shared/attributes/text', attribute: :path %>
+            <%# 🚅 super scaffolding will insert new fields above this line. %>
+          <% end %>
+        <% end %>
+
+        <% box.actions do %>
+          <%= link_to t('.buttons.edit'), [:edit, :account, @page], class: first_button_primary if can? :edit, @page %>
+          <%# 🚅 super scaffolding will insert new action model buttons above this line. %>
+          <%= button_to t('.buttons.destroy'), [:account, @page], method: :delete, class: first_button_primary, data: { turbo_confirm: t('.buttons.confirmations.destroy', model_locales(@page)) } if can? :destroy, @page %>
+          <%= link_to t('global.buttons.back'), [:account, @team, :pages], class: first_button_primary %>
+        <% end %>
+
+        <% box.raw_footer do %>
+          <%# 🚅 super scaffolding will insert new action model index views above this line. %>
+        <% end %>
+      <% end %>
+    <% end %>
+
+    <%# 🚅 super scaffolding will insert new children above this line. %>
+  <% end %>
+<% end %>

--- a/app/views/account/teams/show.html.erb
+++ b/app/views/account/teams/show.html.erb
@@ -2,6 +2,7 @@
   <% p.content_for :title, t('.header', teams_possessive: possessive_string(@team.name)) %>
 
   <% p.content_for :body do %>
+    <%= render 'account/pages/index', pages: @team.pages, hide_back: true %>
     <%# 🚅 super scaffolding will insert new children above this line. %>
     
     <%= render 'account/scaffolding/absolutely_abstract/creative_concepts/index', creative_concepts: @team.scaffolding_absolutely_abstract_creative_concepts, hide_back: true unless scaffolding_things_disabled? %>

--- a/app/views/api/v1/open_api/index.yaml.erb
+++ b/app/views/api/v1/open_api/index.yaml.erb
@@ -22,6 +22,7 @@ components:
     <%= automatic_components_for Webhooks::Outgoing::Endpoint %>
     <%= automatic_components_for Webhooks::Outgoing::Event %>
     <%= automatic_components_for Scaffolding::CompletelyConcrete::TangibleThing unless scaffolding_things_disabled? %>
+    <%= automatic_components_for Page %>
     <%# 🚅 super scaffolding will insert new components above this line. %>
   parameters:
     id:
@@ -56,4 +57,5 @@ paths:
   <%= automatic_paths_for Webhooks::Outgoing::Endpoint, Team %>
   <%= automatic_paths_for Webhooks::Outgoing::Event, Team, except: %i[create update delete] %>
   <%= automatic_paths_for Scaffolding::CompletelyConcrete::TangibleThing, Scaffolding::AbsolutelyAbstract::CreativeConcept unless scaffolding_things_disabled? %>
+  <%= automatic_paths_for Page, Team %>
   <%# 🚅 super scaffolding will insert new paths above this line. %>

--- a/app/views/api/v1/pages/_page.json.jbuilder
+++ b/app/views/api/v1/pages/_page.json.jbuilder
@@ -1,0 +1,10 @@
+json.extract! page,
+  :id,
+  :team_id,
+  :name,
+  :path,
+  # 🚅 super scaffolding will insert new fields above this line.
+  :created_at,
+  :updated_at
+
+# 🚅 super scaffolding will insert file-related logic above this line.

--- a/app/views/api/v1/pages/index.json.jbuilder
+++ b/app/views/api/v1/pages/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @pages, partial: "api/v1/pages/page", as: :page

--- a/app/views/api/v1/pages/show.json.jbuilder
+++ b/app/views/api/v1/pages/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! "api/v1/pages/page", page: @page

--- a/config/locales/en/pages.en.yml
+++ b/config/locales/en/pages.en.yml
@@ -1,0 +1,100 @@
+en:
+  pages: &pages
+    label: &label Pages
+    breadcrumbs:
+      label: *label
+    navigation:
+      label: *label
+      icon: fal fa-puzzle-piece
+    buttons: &buttons
+      new: Add New Page
+      create: Create Page
+      edit: Edit Page
+      update: Update Page
+      destroy: Remove Page
+      shorthand:
+        edit: Edit
+        destroy: Delete
+      confirmations:
+        # TODO customize for your use-case.
+        destroy: Are you sure you want to remove %{page_name}? This will also remove any child resources and can't be undone.
+    page:
+      buttons: *buttons
+    fields: &fields
+      id:
+        heading: Page ID
+      team_id:
+        heading: Team ID
+      name:
+        _: &name Name
+        label: *name
+        heading: *name
+        api_title: *name
+        api_description: *name
+      path:
+        _: &path Path
+        label: *path
+        heading: *path
+        api_title: *path
+        api_description: *path
+      # 🚅 super scaffolding will insert new fields above this line.
+      created_at:
+        _: &created_at Added
+        label: *created_at
+        heading: *created_at
+      updated_at:
+        _: &updated_at Updated
+        label: *updated_at
+        heading: *updated_at
+    api:
+      collection_actions: "Collection Actions for Pages"
+      index: "List Pages"
+      create: "Add a New Page"
+      member_actions: "Actions for an Individual Page"
+      show: "Retrieve a Page"
+      update: "Update a Page"
+      destroy: "Delete a Page"
+      fields: *fields
+    index:
+      section: "%{teams_possessive} Pages"
+      contexts:
+        team:
+          header: Pages
+          description: Below is a list of Pages that have been added for %{team_name}.
+          description_empty: No Pages have been added for %{team_name}.
+      fields: *fields
+      buttons: *buttons
+    show:
+      section: "%{page_name}"
+      header: Page Details
+      description: Below are the details we have for %{page_name}.
+      manage_description: You'll also find options for updating these details or removing %{page_name} from %{team_name} entirely.
+      fields: *fields
+      buttons: *buttons
+    form: &form
+      buttons: *buttons
+      fields: *fields
+    new:
+      section: "New Page for %{team_name}"
+      header: New Page Details
+      description: Please provide the details of the new Page you'd like to add to %{team_name}.
+      form: *form
+    edit:
+      section: "%{page_name}"
+      header: Edit Page Details
+      description: You can update the details or settings for %{page_name} below.
+      form: *form
+    notifications:
+      created: Page was successfully created.
+      updated: Page was successfully updated.
+      destroyed: Page was successfully destroyed.
+  account:
+    pages: *pages
+  activerecord:
+    attributes:
+      page:
+        name: *name
+        path: *path
+        # 🚅 super scaffolding will insert new activerecord attributes above this line.
+        created_at: *created_at
+        updated_at: *updated_at

--- a/config/models/roles.yml
+++ b/config/models/roles.yml
@@ -1,5 +1,6 @@
 default:
   models:
+    Page: read
     Team: read
     Membership:
       - read
@@ -28,6 +29,7 @@ admin:
     - admin
     - editor
   models:
+    Page: manage
     Team: manage
     Membership: manage
     Scaffolding::AbsolutelyAbstract::CreativeConcept: manage

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -72,6 +72,8 @@ Rails.application.routes.draw do
         namespace :integrations do
           # 🚅 super scaffolding will insert new integration installations above this line.
         end
+
+        resources :pages, concerns: [:sortable]
       end
     end
   end

--- a/config/routes/api/v1.rb
+++ b/config/routes/api/v1.rb
@@ -30,6 +30,8 @@ shallow do
       namespace :integrations do
         # 🚅 super scaffolding will insert new integration installations above this line.
       end
+
+      resources :pages, concerns: [:sortable]
     end
   end
 end

--- a/db/migrate/20250919173554_create_pages.rb
+++ b/db/migrate/20250919173554_create_pages.rb
@@ -1,0 +1,12 @@
+class CreatePages < ActiveRecord::Migration[8.0]
+  def change
+    create_table :pages do |t|
+      t.references :team, null: false, foreign_key: true
+      t.integer :sort_order
+      t.string :name
+      t.text :path
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_05_28_141219) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_19_173554) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -182,6 +182,16 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_28_141219) do
     t.datetime "updated_at", precision: nil, null: false
     t.index ["uid"], name: "index_oauth_stripe_accounts_on_uid", unique: true
     t.index ["user_id"], name: "index_oauth_stripe_accounts_on_user_id"
+  end
+
+  create_table "pages", force: :cascade do |t|
+    t.bigint "team_id", null: false
+    t.integer "sort_order"
+    t.string "name"
+    t.text "path"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["team_id"], name: "index_pages_on_team_id"
   end
 
   create_table "scaffolding_absolutely_abstract_creative_concepts", force: :cascade do |t|
@@ -365,6 +375,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_28_141219) do
   add_foreign_key "oauth_access_tokens", "oauth_applications", column: "application_id"
   add_foreign_key "oauth_applications", "teams"
   add_foreign_key "oauth_stripe_accounts", "users"
+  add_foreign_key "pages", "teams"
   add_foreign_key "scaffolding_absolutely_abstract_creative_concepts", "teams"
   add_foreign_key "scaffolding_completely_concrete_tangible_things", "scaffolding_absolutely_abstract_creative_concepts", column: "absolutely_abstract_creative_concept_id"
   add_foreign_key "scaffolding_completely_concrete_tangible_things_assignments", "memberships"

--- a/test/controllers/api/v1/pages_controller_test.rb
+++ b/test/controllers/api/v1/pages_controller_test.rb
@@ -1,0 +1,125 @@
+require "controllers/api/v1/test"
+
+class Api::V1::PagesControllerTest < Api::Test
+  setup do
+    # See `test/controllers/api/test.rb` for common set up for API tests.
+
+    @page = build(:page, team: @team)
+    @other_pages = create_list(:page, 3)
+
+    @another_page = create(:page, team: @team)
+
+    # 🚅 super scaffolding will insert file-related logic above this line.
+    @page.save
+    @another_page.save
+
+    @original_hide_things = ENV["HIDE_THINGS"]
+    ENV["HIDE_THINGS"] = "false"
+    Rails.application.reload_routes!
+  end
+
+  teardown do
+    ENV["HIDE_THINGS"] = @original_hide_things
+    Rails.application.reload_routes!
+  end
+
+  # This assertion is written in such a way that new attributes won't cause the tests to start failing, but removing
+  # data we were previously providing to users _will_ break the test suite.
+  def assert_proper_object_serialization(page_data)
+    # Fetch the page in question and prepare to compare it's attributes.
+    page = Page.find(page_data["id"])
+
+    assert_equal_or_nil page_data['name'], page.name
+    assert_equal_or_nil page_data['path'], page.path
+    # 🚅 super scaffolding will insert new fields above this line.
+
+    assert_equal page_data["team_id"], page.team_id
+  end
+
+  test "index" do
+    # Fetch and ensure nothing is seriously broken.
+    get "/api/v1/teams/#{@team.id}/pages", params: {access_token: access_token}
+    assert_response :success
+
+    # Make sure it's returning our resources.
+    page_ids_returned = response.parsed_body.map { |page| page["id"] }
+    assert_includes(page_ids_returned, @page.id)
+
+    # But not returning other people's resources.
+    assert_not_includes(page_ids_returned, @other_pages[0].id)
+
+    # And that the object structure is correct.
+    assert_proper_object_serialization response.parsed_body.first
+  end
+
+  test "show" do
+    # Fetch and ensure nothing is seriously broken.
+    get "/api/v1/pages/#{@page.id}", params: {access_token: access_token}
+    assert_response :success
+
+    # Ensure all the required data is returned properly.
+    assert_proper_object_serialization response.parsed_body
+
+    # Also ensure we can't do that same action as another user.
+    get "/api/v1/pages/#{@page.id}", params: {access_token: another_access_token}
+    assert_response :not_found
+  end
+
+  test "create" do
+    # Use the serializer to generate a payload, but strip some attributes out.
+    params = {access_token: access_token}
+    page_data = JSON.parse(build(:page, team: nil).api_attributes.to_json)
+    page_data.except!("id", "team_id", "created_at", "updated_at")
+    params[:page] = page_data
+
+    post "/api/v1/teams/#{@team.id}/pages", params: params
+    assert_response :success
+
+    # # Ensure all the required data is returned properly.
+    assert_proper_object_serialization response.parsed_body
+
+    # Also ensure we can't do that same action as another user.
+    post "/api/v1/teams/#{@team.id}/pages",
+      params: params.merge({access_token: another_access_token})
+    assert_response :not_found
+  end
+
+  test "update" do
+    # Post an attribute update ensure nothing is seriously broken.
+    put "/api/v1/pages/#{@page.id}", params: {
+      access_token: access_token,
+      page: {
+        name: 'Alternative String Value',
+        path: 'Alternative String Value',
+        # 🚅 super scaffolding will also insert new fields above this line.
+      }
+    }
+
+    assert_response :success
+
+    # Ensure all the required data is returned properly.
+    assert_proper_object_serialization response.parsed_body
+
+    # But we have to manually assert the value was properly updated.
+    @page.reload
+    assert_equal @page.name, 'Alternative String Value'
+    assert_equal @page.path, 'Alternative String Value'
+    # 🚅 super scaffolding will additionally insert new fields above this line.
+
+    # Also ensure we can't do that same action as another user.
+    put "/api/v1/pages/#{@page.id}", params: {access_token: another_access_token}
+    assert_response :not_found
+  end
+
+  test "destroy" do
+    # Delete and ensure it actually went away.
+    assert_difference("Page.count", -1) do
+      delete "/api/v1/pages/#{@page.id}", params: {access_token: access_token}
+      assert_response :success
+    end
+
+    # Also ensure we can't do that same action as another user.
+    delete "/api/v1/pages/#{@another_page.id}", params: {access_token: another_access_token}
+    assert_response :not_found
+  end
+end

--- a/test/controllers/api/v1/pages_controller_test.rb
+++ b/test/controllers/api/v1/pages_controller_test.rb
@@ -29,8 +29,8 @@ class Api::V1::PagesControllerTest < Api::Test
     # Fetch the page in question and prepare to compare it's attributes.
     page = Page.find(page_data["id"])
 
-    assert_equal_or_nil page_data['name'], page.name
-    assert_equal_or_nil page_data['path'], page.path
+    assert_equal_or_nil page_data["name"], page.name
+    assert_equal_or_nil page_data["path"], page.path
     # 🚅 super scaffolding will insert new fields above this line.
 
     assert_equal page_data["team_id"], page.team_id
@@ -89,8 +89,8 @@ class Api::V1::PagesControllerTest < Api::Test
     put "/api/v1/pages/#{@page.id}", params: {
       access_token: access_token,
       page: {
-        name: 'Alternative String Value',
-        path: 'Alternative String Value',
+        name: "Alternative String Value",
+        path: "Alternative String Value",
         # 🚅 super scaffolding will also insert new fields above this line.
       }
     }
@@ -102,8 +102,8 @@ class Api::V1::PagesControllerTest < Api::Test
 
     # But we have to manually assert the value was properly updated.
     @page.reload
-    assert_equal @page.name, 'Alternative String Value'
-    assert_equal @page.path, 'Alternative String Value'
+    assert_equal @page.name, "Alternative String Value"
+    assert_equal @page.path, "Alternative String Value"
     # 🚅 super scaffolding will additionally insert new fields above this line.
 
     # Also ensure we can't do that same action as another user.

--- a/test/factories/pages.rb
+++ b/test/factories/pages.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :page do
+    association :team
+    name { "MyString" }
+    path { "MyText" }
+  end
+end

--- a/test/models/page_test.rb
+++ b/test/models/page_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class PageTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
This is a first pass at a sortable controller that doesn't rely on `dragula`, which is pretty much abandoned, and forces us to include several other dependencies. Related issue: https://github.com/bullet-train-co/bullet_train-core/issues/1215

It also addresses https://github.com/bullet-train-co/bullet_train-core/issues/826 by adding a drag handle, adding some better styling for in-process drags, and disabling dragging on other parts of the row so that text in the row is still selectable.

Dragging and dropping is working reasonably well in Firefox, Safari and Chrome, but it does look slightly different in each browser.

### Firefox:

![CleanShot 2025-09-26 at 14 55 28](https://github.com/user-attachments/assets/7a24dc9c-a74d-429d-92b8-c9b972fdbcca)

### Safari:

![CleanShot 2025-09-26 at 14 57 17](https://github.com/user-attachments/assets/efd24c66-a8a2-400a-8448-99456a5a78fe)

### Chrome:

![CleanShot 2025-09-26 at 14 59 34](https://github.com/user-attachments/assets/752f9225-7e98-43c5-932b-b87b45f398aa)

This demo PR consists of two commits, one to generate the old sortable super scaffolding and [this commit](https://github.com/bullet-train-co/bullet_train/pull/2222/commits/340ebe9f70c338b6b1f88af1cac93349c788a365) which contains a `new-sortable` stimulus controller and some updates to the templates for the super scaffolded demo model.

In order to get this into Bullet Train we'd need to do the following:

* move the Stimulus controller into `core`
* update super scaffolding in `core` to add the new `th` and `td` columns that we need for drag handles
* document any changes that people would need to make to upgrade to the new controller
* remove `dragula` as a dependency in all the appropriate spots in `core`
* document how people could continue to use the old `dragula` based controller
* update the controller to emit `sortable:*` events [as described here](https://bullettrain.co/docs/super-scaffolding/sortable#events)
