### PR TITLE
Remove `dragula` as an application dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "@tailwindcss/typography": "^0.5.19",
     "autoprefixer": "^10.4.21",
     "cable_ready": "^5.0.6",
-    "dragula": "^3.7.3",
     "esbuild": "^0.25.10",
     "glob": "^10.3.12",
     "jstz": "^2.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2541,7 +2541,6 @@ __metadata:
     "@tailwindcss/typography": "npm:^0.5.19"
     autoprefixer: "npm:^10.4.21"
     cable_ready: "npm:^5.0.6"
-    dragula: "npm:^3.7.3"
     esbuild: "npm:^0.25.10"
     glob: "npm:^10.3.12"
     jstz: "npm:^2.1.1"


### PR DESCRIPTION
The new sortable controller in `core` doesn't need it anymore. And we probably shouldn't have had it as a dependency in the app to begin with.

Joint PR: https://github.com/bullet-train-co/bullet_train-core/pull/1222