### PR TITLE
Use `Gem::Specification` instead of relying on shelling out to `bundle show`

### DIFF
--- a/bin/theme
+++ b/bin/theme
@@ -19,7 +19,7 @@ end
 
 file_type = ARGV.shift
 theme = ARGV.shift
-gem_path = `bundle show bullet_train-themes-#{theme} 2> /dev/null`.chomp
+gem_path = Gem::Specification.find_by_name("bullet_train-themes-#{theme}").gem_dir
 
 file_path, fallback_file_path = case file_type
 when "tailwind-config"

--- a/test/system/resolver_system_test.rb
+++ b/test/system/resolver_system_test.rb
@@ -15,7 +15,7 @@ class ResolverSystemTest < ApplicationSystemTestCase
     if local_view_path
       assert `bin/resolve shared/attributes/text`.include?(local_view_path)
     else
-      themes_gem = `bundle show bullet_train-themes`.chomp
+      themes_gem = Gem::Specification.find_by_name("bullet_train-themes").gem_dir
       absolute_path = themes_gem + "/" + relative_view_path
       assert `bin/resolve shared/attributes/text`.include?(absolute_path)
     end


### PR DESCRIPTION
Apparently some systems/configurations can end up in a state where doing something like `bundle show bullet_train-themes-light` will result in bundler showing the location of the gem twice, which then messes up code that expects the output to be a single line.

So instead we'll use `Gem::Specification` direclty to find the info we need.