### PR TITLE
image and video partial + making attachments in action text actually render

### DIFF
--- a/app/views/active_storage/blobs/_blob.html.erb
+++ b/app/views/active_storage/blobs/_blob.html.erb
@@ -1,14 +1,35 @@
-<figure class="attachment attachment--<%= blob.representable? ? "preview" : "file" %> attachment--<%= blob.filename.extension %>">
-  <% if blob.representable? %>
-    <%= image_tag blob.representation(resize_to_limit: local_assigns[:in_gallery] ? [ 800, 600 ] : [ 1024, 768 ]) %>
+<% options ||= {} %>
+
+<% if blob.representable? %>
+  <%
+    image_source = nil
+    if blob.content_type == "application/pdf"
+      # If it's a PDF, increase the DPI to make the preview image actually readable.
+      options[:width] ||= 400
+      options[:height] ||= 400
+      preview_options = { resize_to_limit: [options[:width], options[:height]] }
+      preview_options[:saver] = { dpi: 300 }
+      image_source = blob.representation(preview_options)
+    else
+      image_source = blob
+    end
+  %>
+
+  <%= link_to url_for(blob), target: "_blank", title: "View original: #{blob.filename}", style: "display: inline-block" do %>
+    <%= image_tag image_source, options %>
   <% end %>
 
-  <figcaption class="attachment__caption">
-    <% if caption = blob.try(:caption) %>
-      <%= caption %>
-    <% else %>
-      <span class="attachment__name"><%= blob.filename %></span>
-      <span class="attachment__size"><%= number_to_human_size blob.byte_size %></span>
+<% elsif blob.video? %>
+  <video controls="true", width="<%= options[:width] %>", preload="metadata", style="max-width: 100%; height: auto; border-radius: 5px;" >
+    <source src="<%= rails_blob_url(blob) %>" type="<%= blob.content_type %>">
+  </video>
+
+<% else %>
+  <%# Fallback for files that can't be represented as images, like zip files %>
+  <div class="file-fallback" style="padding: 10px; border: 1px solid #ccc; border-radius: 5px;">
+    <%= link_to url_for(blob), target: "_blank", style: "text-decoration: none; color: #007bff;" do %>
+      <span style="font-size: 1.5em; margin-right: 10px;">📄</span>
+      <span><%= blob.filename %></span>
     <% end %>
-  </figcaption>
-</figure>
+  </div>
+<% end %>

--- a/app/views/themes/base/attributes/_html.html.erb
+++ b/app/views/themes/base/attributes/_html.html.erb
@@ -1,0 +1,13 @@
+<% object ||= current_attributes_object %>
+<% strategy ||= current_attributes_strategy || :none %>
+<% url ||= nil %>
+
+<% if object.public_send(attribute).present? %>
+  <%= render 'shared/attributes/attribute', object: object, attribute: attribute, strategy: strategy, url: url do %>
+    <% if object.send(attribute).is_a?(ActionText::RichText) %>
+      <%= tag.div(class: "trix-content") do %>
+        <%= object.public_send(attribute) %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/themes/base/attributes/_image.html.erb
+++ b/app/views/themes/base/attributes/_image.html.erb
@@ -1,0 +1,8 @@
+<% object ||= current_attributes_object %>
+<% attribute ||= :image %>
+<% options ||= {} %>
+
+<% attachment = object.public_send(attribute) %>
+<% if attachment && attachment.attached? %>
+  <%= render 'active_storage/blobs/blob', blob: attachment, options: options %>
+<% end %>

--- a/config/initializers/action_text_video_support.rb
+++ b/config/initializers/action_text_video_support.rb
@@ -1,0 +1,11 @@
+# I got this from here: https://mileswoodroffe.com/articles/action-text-video-support
+# The point of it is to render previews for video attachments in Action Text
+Rails.application.config.after_initialize do
+  default_allowed_attributes = Rails::HTML5::Sanitizer.safe_list_sanitizer.allowed_attributes + ActionText::Attachment::ATTRIBUTES.to_set
+  custom_allowed_attributes = Set.new(%w[controls])
+  ActionText::ContentHelper.allowed_attributes = (default_allowed_attributes + custom_allowed_attributes).freeze
+
+  default_allowed_tags = Rails::HTML5::Sanitizer.safe_list_sanitizer.allowed_tags + Set.new([ ActionText::Attachment.tag_name, "figure", "figcaption" ])
+  custom_allowed_tags = Set.new(%w[audio video source])
+  ActionText::ContentHelper.allowed_tags = (default_allowed_tags + custom_allowed_tags).freeze
+end


### PR DESCRIPTION
added a partial for rendering images and videos
added _html.html.erb and changed _blob.html.erb so that they render attachments that are in ActionText
