### PR TITLE
Override the `action_text:install` task

### DIFF
--- a/lib/tasks/action_text_install_override.rake
+++ b/lib/tasks/action_text_install_override.rake
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# We clear and override the action_text:install task to avoid confusion and duplication.
+# We already have all of the ActionText stuff in the `core` repo, so including it in the
+# starter repo is redundant and and possible source of confusion.
+
+override_default_action_text_install_task = ARGV[1] != "--clobber"
+
+if override_default_action_text_install_task
+  Rake::Task["action_text:install"].clear
+  namespace :action_text do
+    task :install do
+      require "colorize"
+      puts "-------------------------------------------------------------------------------------------------".yellow
+      puts "We are skipping the action_text:install task because we configure ActionText via the `core` repo.".yellow
+      puts "If you need to run this task pass it the `--clobber` option like this:".yellow
+      puts "    bin/rails action_text:install -- --clobber".yellow
+      puts "-------------------------------------------------------------------------------------------------".yellow
+    end
+  end
+end


### PR DESCRIPTION
We already have most of the `ActionText` stuff in the `core` repo, and are considering moving the remaining bits there as well. We're overriding this task to prevent confusion if someone tries to run the installation process. We're including a `--clobber` option so that people can still run the original task if they really want to.