### PR TITLE
Allow gifs to animate when embedded in ActionText

### DIFF
--- a/app/views/active_storage/blobs/_blob.html.erb
+++ b/app/views/active_storage/blobs/_blob.html.erb
@@ -1,6 +1,6 @@
 <figure class="attachment attachment--<%= blob.representable? ? "preview" : "file" %> attachment--<%= blob.filename.extension %>">
   <% if blob.representable? %>
-    <%= image_tag blob.representation(resize_to_limit: local_assigns[:in_gallery] ? [ 800, 600 ] : [ 1024, 768 ]) %>
+    <%= image_tag blob.representation(loader: { n: -1 }, resize_to_limit: local_assigns[:in_gallery] ? [ 800, 600 ] : [ 1024, 768 ]) %>
   <% end %>
 
   <figcaption class="attachment__caption">


### PR DESCRIPTION
By default the `vips` library will read only the first frame of a `.gif` when creating a "representation" of it. Passing `-1` to `loader -> n` tells it to read all of the frames.

https://www.libvips.org/API/current/ctor.Image.gifload.html

This allows us to show the whole gif animation, but to also scale it down if needed.

Fixes: https://github.com/bullet-train-co/bullet_train/issues/2303

NOTE: We probably won't merge this PR here. I think we should hoist this file into the `core` repo and remove it from the starter repo. I'm just opening this PR to document something that I found that works.