### PR TITLE
two_factor_authentication_test: remove unneeded " a #{device_name}"

### DIFF
--- a/test/system/two_factor_authentication_test.rb
+++ b/test/system/two_factor_authentication_test.rb
@@ -21,7 +21,7 @@ class TwoFactorAuthentication < ApplicationSystemTestCase
       assert_text("Dashboard")
     end
 
-    device_test "a user cannot log in with an invalid OTP a #{device_name}" do
+    device_test "a user cannot log in with an invalid OTP" do
       visit new_user_session_path
       assert_text("Sign In")
 


### PR DESCRIPTION
Fixed #2308 