### PR TITLE
Unpin minitest

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -184,9 +184,7 @@ group :development do
 end
 
 group :test do
-  # We're pinning this beause minitest-reporters 1.7.1 doesn't work with minitest 6.
-  # When a new version of minitest-reporters is released we should be able to unpin this.
-  gem "minitest", "~> 6.0.3"
+  gem "minitest"
 
   # Helps smooth over flakiness in system tests.
   gem "minitest-retry"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -730,7 +730,7 @@ DEPENDENCIES
   knapsack_pro
   letter_opener
   magic_test
-  minitest (~> 6.0.3)
+  minitest
   minitest-reporters
   minitest-retry
   parallel_tests


### PR DESCRIPTION
We had previously pinned it due to an incompatibility with `minitest-reporters` which has been fixed in version `1.8.0`.