### PR TITLE
Track main on origin after configure

### DIFF
--- a/bin/configure-scripts/push_to_origin.rb
+++ b/bin/configure-scripts/push_to_origin.rb
@@ -9,14 +9,7 @@ if has_origin_remote
   push_to_origin = ask_boolean "Should we push this repo to `origin`?", "y"
   if push_to_origin
     puts "Pushing repository to `origin`.".green
-    # TODO: We used to do this to push whatever the current branch is to `main`:
-    # local_branch = `git branch | grep "*"`.split.last
-    # stream "git push origin #{local_branch}:main 2>&1"
-    #
-    # I'm not sure that's a great thing to do, so for now I'm just doing a bare
-    # push. Are there reasons that would be inadequate?
-
-    stream "git push origin 2>&1"
+    stream "git push --set-upstream origin main:main 2>&1"
   else
     puts "Skipping pushing to origin.".yellow
   end


### PR DESCRIPTION
## What changed

`bin/configure` now pushes local `main` with `--set-upstream` when publishing to the newly configured `origin` remote.

## Why

The configure flow renames the template remote from `origin` to `bullet-train`, but the previous bare push left local `main` tracking `bullet-train/main`. Explicitly pushing `main:main` with `--set-upstream` changes its tracking branch to `origin/main`.

Closes #2327

## Validation

- `ruby -c bin/configure-scripts/push_to_origin.rb`
- Reproduced the remote rename state with temporary bare repositories, ran the new push command, and verified `main@{upstream}` resolves to `origin/main`.
